### PR TITLE
Move changelog to documentations and improve it

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,6 @@ All the results are stored either in a SQLite database or directly as files and 
 
 - https://zdb.metagenlab.ch/
 
-## Changelog
-v1.2.1 (October 2023)
- - use mamba to build conda environments
- 
-v1.1.1 (april 2023):
- - several fixes with conda environments
-
-v1.0.8 (february 2023):
-- added support for dockers and conda
-- several bugfixes
-
-v1.0.5 (december 2022): 
-- added a ```--resume``` option to ```zdb run```
-- added a name field in the input csv file
-- genbank files with other extensions are now accepted by the pipeline
 
 ## Installation
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,15 +1,83 @@
 # Changelog
-v1.2.1 (October 2023)
- - use mamba to build conda environments
 
-v1.1.1 (april 2023):
- - several fixes with conda environments
 
-v1.0.8 (february 2023):
-- added support for dockers and conda
-- several bugfixes
+Versions are of the form MAJOR.MINOR.PATCH and this changelog tries to conform
+to [Common Changelog](https://common-changelog.org)
 
-v1.0.5 (december 2022):
-- added a ```--resume``` option to ```zdb run```
-- added a name field in the input csv file
-- genbank files with other extensions are now accepted by the pipeline
+
+## 1.2.1 - 2023-10-16
+
+### Changed
+- Bump checkm-genome version to 1.2.2. (Trestan Pillonel)
+
+
+## 1.2.0 - 2023-10-13
+
+### Changed
+
+- Use mamba to build conda envs ([30bbb7530d75c3adf986aaf4c5052ad83ea301b8](https://github.com/metagenlab/zDB/commit/30bbb7530d75c3adf986aaf4c5052ad83ea301b8)) (Trestan Pillonel)
+
+### Fixed
+
+- Fix issue for genome file download ([#16](https://github.com/metagenlab/zDB/pull/16)) (Trestan Pillonel)
+- Fix file extensions in annotation pipeline ([#17](https://github.com/metagenlab/zDB/pull/17)) (Thomas Kozy)
+
+
+## 1.1.1 - 2023-05-16
+
+### Fixed
+
+- Fixed several issues with conda environments. (Bastian Marquis and Trestan Pillonel)
+
+
+## 1.1.0 - 2023-03-30
+
+### Added
+
+- Add ```--resume``` option to ```zdb setup``` ([272b4b434279d725b5860db26458c430934fddd5](https://github.com/metagenlab/zDB/commit/272b4b434279d725b5860db26458c430934fddd5)) (Bastian Marquis)
+
+
+## 1.0.8 - 2023-03-15
+
+### Added
+- Add support for docker and conda. ([#13](https://github.com/metagenlab/zDB/pull/13)) (Bastian Marquis)
+
+### Fixed
+- Several bugfixes
+
+
+## 1.0.5 - 2022-12-08
+
+### Added
+
+- Add ```--resume``` option to ```zdb run``` ([#11](https://github.com/metagenlab/zDB/pull/11)) (Bastian Marquis)
+- Add name field to the input csv file.
+- Accept genbank files with other extensions in the pipeline.
+
+
+## 1.0.4 - 2022-09-21
+
+### Fixed
+
+- Fix conda build ([#10](https://github.com/metagenlab/zDB/pull/10)) (Bastian Marquis)
+
+
+## 1.0.3 - 2022-06-07
+
+### Fixed
+
+- Correctly set number of missing orthogroups. ([b9df07c2668f4d70cea2a345a7b3fdf2f6d55bfb](https://github.com/metagenlab/zDB/commit/b9df07c2668f4d70cea2a345a7b3fdf2f6d55bfb)) (Bastian Marquis)
+- Fix bug with singularity. ([4d37463ed78789f26352c56d1c2af9c50e2b09b9](https://github.com/metagenlab/zDB/commit/4d37463ed78789f26352c56d1c2af9c50e2b09b9)) (Bastian Marquis)
+
+
+## 1.0.2 - 2022-05-10
+
+### Added
+
+- Add support for conda. ([#9](https://github.com/metagenlab/zDB/pull/9)) (Bastian Marquis)
+
+
+## 1.0.0 - 2022-04-01
+
+_Initial release._
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+v1.2.1 (October 2023)
+ - use mamba to build conda environments
+
+v1.1.1 (april 2023):
+ - several fixes with conda environments
+
+v1.0.8 (february 2023):
+- added support for dockers and conda
+- several bugfixes
+
+v1.0.5 (december 2022):
+- added a ```--resume``` option to ```zdb run```
+- added a name field in the input csv file
+- genbank files with other extensions are now accepted by the pipeline

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ todo_include_todos = True
 # ones.
 extensions = [
     'sphinx.ext.todo',
+    'myst_parser',  # Support for markdown
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ zDB documentation
 
    methods/annotation.rst
    tutorial/website.rst
+   CHANGELOG.md
 
 zDB github page
 ===============


### PR DESCRIPTION
I think it makes sense to have the changelog in the documentation.
I also updated the changelog to conform to best practices (see https://common-changelog.org/) and included links to PRs and commits where possible. I also tried to add missing CL entries for older versions.