### PR TITLE
Fix orthogroup comparison view navigation tabs.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,10 @@ to [Common Changelog](https://common-changelog.org)
 - Add unitesting for pipelines. ([#26](https://github.com/metagenlab/zDB/pull/26)) (Niklaus Johner)
 - Add antimicrobial resistance annotations. ([#23](https://github.com/metagenlab/zDB/pull/23)) (Niklaus Johner)
 
+### Fixed
+
+- Fix orthogroup comparison view navigation tabs. ([#30](https://github.com/metagenlab/zDB/pull/30)) (Niklaus Johner)
+
 
 ## 1.2.1 - 2023-10-16
 

--- a/webapp/chlamdb/views.py
+++ b/webapp/chlamdb/views.py
@@ -4099,7 +4099,7 @@ class CogComparisonView(TabularComparisonViewBase):
 
 class OrthogroupComparisonView(TabularComparisonViewBase):
 
-    view_type = "orthogroup"
+    view_type = "orthology"
     base_info_headers = ["Orthogroup", "Annotaion"]
 
     table_help = """
@@ -4112,6 +4112,10 @@ class OrthogroupComparisonView(TabularComparisonViewBase):
     """
 
     compared_obj_name = "orthogroups"
+
+    @property
+    def view_name(self):
+        return "orthogroup_comparison"
 
     def get_table_rows(self):
         og_count = self.db.get_og_count(self.targets)

--- a/webapp/templates/chlamdb/extract_nav_tabs_template.html
+++ b/webapp/templates/chlamdb/extract_nav_tabs_template.html
@@ -1,71 +1,71 @@
 
 
 {% if type == "COG" %}
-                <nav>
-                    <ul id="tabs_main" class="nav nav-tabs">
-                        <li class={% if active_tab == "index" %}"active"{%endif%}><a href="{% url 'entry_list_cog' %}">Index</a></li>
-                        <li class={% if active_tab == "det" %}"active"{%endif%}><a href="{% url 'extract_cog' %}">Extract form</a></li>
-                        <li class={% if active_tab == "venn" %}"active"{%endif%}><a href="{% url 'venn_cog' %}">Venn</a></li>
-                        <li class={% if active_tab == "comp" %}"active"{%endif%}><a href="{% url 'cog_comparison' %}">Presence/absence table</a></li>
-                        <li class={% if active_tab == "heat" %}"active"{%endif%}><a href="{% url 'plot_heatmap' 'COG' %}">Heatmap</a></li>
-                        <li class={% if active_tab == "pan" %}"active"{%endif%}><a href="{% url 'pan_genome' 'COG' %}">Accumulation/rarefaction plot</a></li>
-                        <li class={% if active_tab == "bar" %}"active"{%endif%}><a href="{% url 'cog_barchart' %}">Categories barchart</a></li>
-                        <li class={% if active_tab == "COG_freq" %}"active"{%endif%}><a href="{% url 'COG_phylo_heatmap' True %}">Cat. heatmap freq.</a></li>
-                        <li class={% if active_tab == "COG_counts" %}"active"{%endif%}><a href="{% url 'COG_phylo_heatmap' False %}">Cat. heatmap counts</a></li>
-                    </ul>
-                </nav>
+    <nav>
+        <ul id="tabs_main" class="nav nav-tabs">
+            <li class={% if active_tab == "index" %}"active"{%endif%}><a href="{% url 'entry_list_cog' %}">Index</a></li>
+            <li class={% if active_tab == "det" %}"active"{%endif%}><a href="{% url 'extract_cog' %}">Extract form</a></li>
+            <li class={% if active_tab == "venn" %}"active"{%endif%}><a href="{% url 'venn_cog' %}">Venn</a></li>
+            <li class={% if active_tab == "comp" %}"active"{%endif%}><a href="{% url 'cog_comparison' %}">Presence/absence table</a></li>
+            <li class={% if active_tab == "heat" %}"active"{%endif%}><a href="{% url 'plot_heatmap' 'COG' %}">Heatmap</a></li>
+            <li class={% if active_tab == "pan" %}"active"{%endif%}><a href="{% url 'pan_genome' 'COG' %}">Accumulation/rarefaction plot</a></li>
+            <li class={% if active_tab == "bar" %}"active"{%endif%}><a href="{% url 'cog_barchart' %}">Categories barchart</a></li>
+            <li class={% if active_tab == "COG_freq" %}"active"{%endif%}><a href="{% url 'COG_phylo_heatmap' True %}">Cat. heatmap freq.</a></li>
+            <li class={% if active_tab == "COG_counts" %}"active"{%endif%}><a href="{% url 'COG_phylo_heatmap' False %}">Cat. heatmap counts</a></li>
+        </ul>
+    </nav>
 {% elif type == "ko" %}
-                <nav>
-                    <ul id="tabs_main" class="nav nav-tabs">
-                        <li class={% if active_tab == "index" %}"active"{%endif%}><a href="{% url 'entry_list_ko' %}">Index</a></li>
-                        <li class={% if active_tab == "det" %}"active"{%endif%}><a href="{% url 'extract_ko' %}">Extract form</a></li>
-                        <li class={% if active_tab == "venn" %}"active"{%endif%}><a href="{% url 'venn_ko' %}">Venn</a></li>
-                        <li class={% if active_tab == "comp" %}"active"{%endif%}><a href="{% url 'ko_comparison' %}">Presence/absence table</a></li>
-                        <li class={% if active_tab == "heat" %}"active"{%endif%}><a href="{% url 'plot_heatmap' 'ko' %}">Heatmap</a></li>
-                        <li class={% if active_tab == "pan" %}"active"{%endif%}><a href="{% url 'pan_genome' 'ko' %}">Accumulation/rarefaction plot </a></li>
-                        <li class={% if active_tab == "bar" %}"active"{%endif%}><a href="{% url 'module_barchart' %}">Categories barchart</a></li>
-                    </ul>
-                </nav>
+    <nav>
+        <ul id="tabs_main" class="nav nav-tabs">
+            <li class={% if active_tab == "index" %}"active"{%endif%}><a href="{% url 'entry_list_ko' %}">Index</a></li>
+            <li class={% if active_tab == "det" %}"active"{%endif%}><a href="{% url 'extract_ko' %}">Extract form</a></li>
+            <li class={% if active_tab == "venn" %}"active"{%endif%}><a href="{% url 'venn_ko' %}">Venn</a></li>
+            <li class={% if active_tab == "comp" %}"active"{%endif%}><a href="{% url 'ko_comparison' %}">Presence/absence table</a></li>
+            <li class={% if active_tab == "heat" %}"active"{%endif%}><a href="{% url 'plot_heatmap' 'ko' %}">Heatmap</a></li>
+            <li class={% if active_tab == "pan" %}"active"{%endif%}><a href="{% url 'pan_genome' 'ko' %}">Accumulation/rarefaction plot </a></li>
+            <li class={% if active_tab == "bar" %}"active"{%endif%}><a href="{% url 'module_barchart' %}">Categories barchart</a></li>
+        </ul>
+    </nav>
 
 {% elif type == "Pfam" %}
-                <nav>
-                    <ul id="tabs_main" class="nav nav-tabs">
-                        <li class={% if active_tab == "index" %}"active"{%endif%}><a href="{% url 'entry_list_pfam' %}">Index</a></li>
-                        <li class={% if active_tab == "det" %}"active"{%endif%}><a href="{% url 'extract_pfam' %}">Extract form</a></li>
-                        <li class={% if active_tab == "venn" %}"active"{%endif%}><a href="{% url 'venn_pfam' %}">Venn</a></li>
-                        <li class={% if active_tab == "comp" %}"active"{%endif%}><a href="{% url 'pfam_comparison' %}">Presence/absence table</a></li>
-                        <li class={% if active_tab == "heat" %}"active"{%endif%}><a href="{% url 'plot_heatmap' 'Pfam' %}">Heatmaps</a></li>
-                        <li class={% if active_tab == "pan" %}"active"{%endif%}><a href="{% url 'pan_genome' 'Pfam' %}">Accumulation/rarefaction plot </a></li>
-                    </ul>
-                </nav>
+    <nav>
+        <ul id="tabs_main" class="nav nav-tabs">
+            <li class={% if active_tab == "index" %}"active"{%endif%}><a href="{% url 'entry_list_pfam' %}">Index</a></li>
+            <li class={% if active_tab == "det" %}"active"{%endif%}><a href="{% url 'extract_pfam' %}">Extract form</a></li>
+            <li class={% if active_tab == "venn" %}"active"{%endif%}><a href="{% url 'venn_pfam' %}">Venn</a></li>
+            <li class={% if active_tab == "comp" %}"active"{%endif%}><a href="{% url 'pfam_comparison' %}">Presence/absence table</a></li>
+            <li class={% if active_tab == "heat" %}"active"{%endif%}><a href="{% url 'plot_heatmap' 'Pfam' %}">Heatmaps</a></li>
+            <li class={% if active_tab == "pan" %}"active"{%endif%}><a href="{% url 'pan_genome' 'Pfam' %}">Accumulation/rarefaction plot </a></li>
+        </ul>
+    </nav>
 
 {% elif type == "EC" %}
-                <nav>
-                    <ul id="tabs_main" class="nav nav-tabs">
-                        <li class={% if active_tab == "det" %}"active"{%endif%}><a href="{% url 'extract_EC' %}">Extract form</a></li>
-                        <li class={% if active_tab == "venn" %}"active"{%endif%}><a href="{% url 'venn_EC' %}">Venn diagram</a></li>
-                        <li class={% if active_tab == "heat" %}"active"{%endif%}><a href="{% url 'plot_heatmap' 'EC' %}">Heatmaps</a></li>
-                        <li class={% if active_tab == "pan" %}"active"{%endif%}><a href="{% url 'pan_genome' 'EC' %}">Accumulation/rarefaction plot </a></li>
-                    </ul>
-                </nav>
+    <nav>
+        <ul id="tabs_main" class="nav nav-tabs">
+            <li class={% if active_tab == "det" %}"active"{%endif%}><a href="{% url 'extract_EC' %}">Extract form</a></li>
+            <li class={% if active_tab == "venn" %}"active"{%endif%}><a href="{% url 'venn_EC' %}">Venn diagram</a></li>
+            <li class={% if active_tab == "heat" %}"active"{%endif%}><a href="{% url 'plot_heatmap' 'EC' %}">Heatmaps</a></li>
+            <li class={% if active_tab == "pan" %}"active"{%endif%}><a href="{% url 'pan_genome' 'EC' %}">Accumulation/rarefaction plot </a></li>
+        </ul>
+    </nav>
 {% elif type == "interpro" %}
-                <nav>
-                    <ul id="tabs_main" class="nav nav-tabs">
-                        <li class={% if active_tab == "det" %}"active"{%endif%}><a href="{% url 'extract_interpro' %}">Extract form</a></li>
-                        <li class={% if active_tab == "venn" %}"active"{%endif%}><a href="{% url 'venn_interpro' %}">Venn</a></li>
-                        <li class={% if active_tab == "heat" %}"active"{%endif%}><a href="{% url 'plot_heatmap' 'interpro' %}">Heatmaps</a></li>
-                        <li class={% if active_tab == "pan" %}"active"{%endif%}><a href="{% url 'pan_genome' 'interpro' %}">Accumulation/rarefaction plot </a></li>
-                    </ul>
-                </nav>
+    <nav>
+        <ul id="tabs_main" class="nav nav-tabs">
+            <li class={% if active_tab == "det" %}"active"{%endif%}><a href="{% url 'extract_interpro' %}">Extract form</a></li>
+            <li class={% if active_tab == "venn" %}"active"{%endif%}><a href="{% url 'venn_interpro' %}">Venn</a></li>
+            <li class={% if active_tab == "heat" %}"active"{%endif%}><a href="{% url 'plot_heatmap' 'interpro' %}">Heatmaps</a></li>
+            <li class={% if active_tab == "pan" %}"active"{%endif%}><a href="{% url 'pan_genome' 'interpro' %}">Accumulation/rarefaction plot </a></li>
+        </ul>
+    </nav>
 {% elif type == 'orthology' %}
-                <nav>
-                    <ul id="tabs_main" class="nav nav-tabs">
-                        <li class={% if active_tab == "det" %}"active"{%endif%}><a href="{% url 'extract_orthogroup' %}">Extract form</a></li>
-                        <li class={% if active_tab == "venn" %}"active"{%endif%}><a href="{% url 'venn_orthogroup' %}">Venn</a></li>
-                        <li class={% if active_tab == "comp" %}"active"{%endif%}><a href="{% url 'orthogroup_comparison' %}">Presence/absence table</a></li>
-                        <li class={% if active_tab == "heat" %}"active"{%endif%}><a href="{% url 'plot_heatmap' 'orthology' %}">Heatmap</a></li>
-                        <li class={% if active_tab == "pan" %}"active"{%endif%}><a href="{% url 'pan_genome' 'orthology' %}">Accumulation/rarefaction plot </a></li>
-                    </ul>
-                </nav>
+    <nav>
+        <ul id="tabs_main" class="nav nav-tabs">
+            <li class={% if active_tab == "det" %}"active"{%endif%}><a href="{% url 'extract_orthogroup' %}">Extract form</a></li>
+            <li class={% if active_tab == "venn" %}"active"{%endif%}><a href="{% url 'venn_orthogroup' %}">Venn</a></li>
+            <li class={% if active_tab == "comp" %}"active"{%endif%}><a href="{% url 'orthogroup_comparison' %}">Presence/absence table</a></li>
+            <li class={% if active_tab == "heat" %}"active"{%endif%}><a href="{% url 'plot_heatmap' 'orthology' %}">Heatmap</a></li>
+            <li class={% if active_tab == "pan" %}"active"{%endif%}><a href="{% url 'pan_genome' 'orthology' %}">Accumulation/rarefaction plot </a></li>
+        </ul>
+    </nav>
 {% endif %}
 

--- a/webapp/templates/chlamdb/tabular_comparison.html
+++ b/webapp/templates/chlamdb/tabular_comparison.html
@@ -18,85 +18,82 @@
   <div class="container-fluid" id="main_container">
     <div class="row">
       <div id="wrapper">
-          <div id="page-content-wrapper">
-            <div class="row">
-              <div class="col-lg-12">
-                 {% include "chlamdb/menu.html" %}
-                 {% include "chlamdb/extract_nav_tabs_template.html" with type=view_type active_tab="comp" %}
+        <div id="page-content-wrapper">
+          <div class="row">
+            <div class="col-lg-12">
+              {% include "chlamdb/menu.html" %}
+              {% include "chlamdb/extract_nav_tabs_template.html" with type=view_type active_tab="comp" %}
+              <br>
+              <p class="page-title"><b>{{form_title}} </b><a href="/docs/index.html" id="show-option" title="{{form_help}}"><i class="fab fa-info-circle " style="size: 5em;" ></i></a></p>
+            </div>
 
-                  <br>
-                  <p class="page-title"><b>{{form_title}} </b><a href="/docs/index.html" id="show-option" title="{{form_help}}"><i class="fab fa-info-circle " style="size: 5em;" ></i></a></p>
+            <form action='{% url view_name %}' method="post">
+              {% csrf_token %}
+              {{ form.as_p }}
+              <input type="submit" value="Submit" />
+            </form>
+
+            {% if show_comparison_table %}
+              <div class="row" style="padding-top:10px ;background-color: rgba(245, 245, 245, 0.986); margin-top: 1em;" >
+
+                <h4>{{table_title|safe}}</h4>
+                <div class="panel panel-success" style="margin: 1em;">
+                  <div class="panel-heading" style="width:100%;">
+                    <h5 class="panel-title">Help to interpret the results</h5>
+                  </div>
+                  <p style="margin: 10px 10px 10px 10px">
+                    {{table_help|safe}}
+                  </p>
                 </div>
-                      <form action='{% url view_name %}' method="post">
-                          {% csrf_token %}
-                          {{ form.as_p }}
-                          <input type="submit" value="Submit" />
+              </div>
 
-                      </form>
-
-                      {% if show_comparison_table %}
-                         
-
-                          <div class="row" style="padding-top:10px ;background-color: rgba(245, 245, 245, 0.986); margin-top: 1em;" >
-                                
-                      <h4>{{table_title|safe}}</h4>
-                             <div class="panel panel-success" style="margin: 1em;">
-                                 <div class="panel-heading" style="width:100%;">
-                                     <h5 class="panel-title">Help to interpret the results</h5>
-                                 </div>
-                                 <p style="margin: 10px 10px 10px 10px">
-                                    {{table_help|safe}}
-                                 </p>
-                             </div>
-                            </div>
-
-                            <br>
-                            <div class="col-lg-12">
-                              <table class="hover" id="mytable"  style="padding-top: 1em;">
-                               <style>
-                               table {
-                                 table-layout: fixed;
-                               } </style>
-                                  <thead>
-                                    <tr>
-                                        {% for title in table_headers %}
-                                        <th>{{title}}</th>
-                                        {% endfor %}
-                                    </tr>
-                                  </thead>
-                                  <tbody>
-                                    {% for row in table_rows %}
-									                    <tr>
-                                        {% for value in row|slice_up_to:n_data_columns %}
-                                          {% if forloop.counter0 < first_coloured_row %}
-                                            <td>{{value|safe}}</td>
-                                          {% else %}
-                                            {% with color_i=forloop.counter0|add:hist_colour_index_shift %}
-                                              {% with colour=row|return_item:color_i %}
-                                                {% if colour != 0 %}
-                                                  <td data-hist="{{colour}}">{{value}}</td>
-                                                {% else %}
-                                                  <td>{{value}}</td>
-                                                {% endif %}
-                                              {% endwith %}
-                                            {% endwith %}
-                                          {% endif %}
-                                        {% endfor %}
-                                      </tr>
-                                    {% endfor %}
-                                  </tbody>
-                              </table>
-                      </div>
-                      {% endif %}
+              <br>
+              <div class="col-lg-12">
+                <table class="hover" id="mytable"  style="padding-top: 1em;">
+                  <style>
+                    table {
+                      table-layout: fixed;
+                    }
+                  </style>
+                  <thead>
+                    <tr>
+                      {% for title in table_headers %}
+                        <th>{{title}}</th>
+                      {% endfor %}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for row in table_rows %}
+	                    <tr>
+                        {% for value in row|slice_up_to:n_data_columns %}
+                          {% if forloop.counter0 < first_coloured_row %}
+                            <td>{{value|safe}}</td>
+                          {% else %}
+                            {% with color_i=forloop.counter0|add:hist_colour_index_shift %}
+                              {% with colour=row|return_item:color_i %}
+                                {% if colour != 0 %}
+                                  <td data-hist="{{colour}}">{{value}}</td>
+                                {% else %}
+                                  <td>{{value}}</td>
+                                {% endif %}
+                              {% endwith %}
+                            {% endwith %}
+                          {% endif %}
+                        {% endfor %}
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            {% endif %}
 
           </div>
         </div>
       </div>
     </div>
   </div>
-
-
 </body>
+
 <script src="{% static 'js/jquery.hottie.js' %}"></script>
 <script>
 $(function(){


### PR DESCRIPTION
Navigation tabs were broken for the orthogroup comparison view. While I was at it I cleaned-up two more html templates to make them more readable (just fixed the indentations).