### PR TITLE
Add fam_amr view (AMR gene details view)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Added
 
+- Add AMR details view. ([#44](https://github.com/metagenlab/zDB/pull/44)) (Niklaus Johner)
 - Add AMR Venn diagram view. ([#41](https://github.com/metagenlab/zDB/pull/41)) (Niklaus Johner)
 - Add AMR hit extraction view. ([#38](https://github.com/metagenlab/zDB/pull/38)) (Niklaus Johner)
 - Add AMR entry list view. ([#37](https://github.com/metagenlab/zDB/pull/37)) (Niklaus Johner)

--- a/testing/webapp/test_views.py
+++ b/testing/webapp/test_views.py
@@ -41,6 +41,7 @@ urls = [
     '/extract_ko/',
     '/extract_orthogroup/',
     '/extract_pfam/',
+    '/fam_amr/ybtP',
     '/fam_cog/COG0775',
     '/fam_ko/K01241',
     '/fam_pfam/PF10423',

--- a/webapp/chlamdb/urls.py
+++ b/webapp/chlamdb/urls.py
@@ -53,6 +53,7 @@ urlpatterns = [
     re_path(r'^fam_pfam/(PF[0-9]+)$', views.fam_pfam, name="fam_pfam"),
     re_path(r'^fam_ko/(K[0-9]+)$', views.fam_ko, name="fam_ko"),
     re_path(r'^fam_cog/(COG[0-9]+)$', views.fam_cog, name="fam_cog"),
+    re_path(r'^fam_amr/([a-zA-Z0-9_\.\(\)\-\']+)$', views.fam_amr, name="fam_amr"),
     re_path(r'^extract_pfam/$', hits_extraction.ExtractPfamView.as_view(), name="extract_pfam"),  # noqa
     re_path(r'^extract_orthogroup/$', hits_extraction.ExtractOrthogroupView.as_view(), name="extract_orthogroup"),  # noqa
     re_path(r'^extract_ko/$', hits_extraction.ExtractKoView.as_view(), name="extract_ko"),  # noqa

--- a/webapp/templates/chlamdb/fam.html
+++ b/webapp/templates/chlamdb/fam.html
@@ -38,6 +38,9 @@
             {{ fam }}
 
             <a href="https://zdb.readthedocs.io/en/latest/tutorial/website.html#kegg-module-overview-page" id="show-option" target="_blank" title="help with the overview page"><i class="fab fa-info-circle " style="size: 5em;" ></i></a>
+
+          {% elif type == 'amr' %}
+                {{ fam }}
           {% endif %}
 
         </b></p>
@@ -60,6 +63,8 @@
                 Kegg Ortholog
               {% elif type == 'pfam' %}
                 Pfam domain
+              {% elif type == 'amr' %}
+                AMR gene
               {% endif %}
 
               {{ fam }}, of which KO pathways and KO modules it is part. Additionally, its occurence in the database is reported.
@@ -71,6 +76,8 @@
                 Kegg Ortholog
               {% elif type == 'pfam' %}
                 Pfam domain
+              {% elif type == 'amr' %}
+                AMR gene
               {% endif %}
 
               within the database. {{ all_locus_data|length }} occurences are identified.
@@ -85,6 +92,8 @@
                 Kegg Ortholog(s)
               {% elif type == 'pfam' %}
                 Pfam domain(s)
+              {% elif type == 'amr' %}
+                AMR gene(s)
               {% endif %} of interest within all the genomes of the database (first column)
 
               <br>- the size of the orthogroup(s) in which the reported
@@ -95,6 +104,8 @@
                 Ko entry
               {% elif type == 'pfam' %}
                 Pfam domain
+              {% elif type == 'amr' %}
+                AMR gene
               {% endif %} has been clustered.
 
               <br>In red the <font size="2" color="red">{{type}} with positive hit(s)</font> in the corresponding genome.
@@ -143,6 +154,12 @@
                           <td><a href="{{ external_link }}" target="_blank">  {{ fam }} <i class="fas fa-external-link-alt"></i></a></td>
                         </tr>
 
+                      {% elif type == 'amr' %}
+                        <tr>
+                          <th>Gene</th>
+                          <td><a href="https://www.ncbi.nlm.nih.gov/pathogens/isolates/#AMR_genotypes:{{ gene }}*" target="_blank">  {{ fam }} <i class="fas fa-external-link-alt"></i></a></td>
+                        </tr>
+
                       {% endif %}
 
                       {% if type == 'EC' %}
@@ -157,10 +174,13 @@
                           </tr>
                         {% endfor %}
 
-                        <tr>
-                          <th>{{key}}</th>
-                          <td>{{value}}</td>
-                        </tr>
+                      {% elif type == 'amr' %}
+                        {% for key, value in info.items %}
+                          <tr>
+                            <th>{{key}}</th>
+                            <td>{{value}}</td>
+                          </tr>
+                        {% endfor %}
 
                       {% elif type == 'ko'%}
                         <tr>

--- a/webapp/views/hits_extraction.py
+++ b/webapp/views/hits_extraction.py
@@ -8,10 +8,11 @@ from django.views import View
 from lib.db_utils import DB
 
 from views.mixins import AmrAnnotationsMixin, ComparisonViewMixin
-from views.utils import (format_cog, format_cog_url, format_gene_to_ncbi_hmm,
-                         format_ko, format_ko_modules, format_ko_path,
-                         format_ko_url, format_locus, format_lst_to_html,
-                         format_orthogroup, format_pfam, my_locals)
+from views.utils import (format_amr, format_cog, format_cog_url,
+                         format_hmm_url, format_ko, format_ko_modules,
+                         format_ko_path, format_ko_url, format_locus,
+                         format_lst_to_html, format_orthogroup, format_pfam,
+                         my_locals)
 
 ResultTab = collections.namedtuple("Tab", ["id", "title", "template"])
 
@@ -342,7 +343,7 @@ class ExtractAmrView(ExtractHitsBaseView, AmrAnnotationsMixin):
     comp_type = "amr"
 
     _table_headers = ["Gene", "Description", "Scope", "Type", "Class",
-                      "Subclass"]
+                      "Subclass", "HMM"]
 
     @property
     def get_hit_counts(self):
@@ -356,10 +357,12 @@ class ExtractAmrView(ExtractHitsBaseView, AmrAnnotationsMixin):
 
         for gene in self.selection:
             amr_annot = amr_annotations[amr_annotations.gene == gene].iloc[0]
-            data = [format_gene_to_ncbi_hmm(amr_annot[["gene", "hmm_id"]]),
+            data = [format_amr(amr_annot.gene, to_url=True),
                     amr_annot.seq_name, amr_annot.scope, amr_annot.type,
                     amr_annot["class"], amr_annot.subclass,
+                    format_hmm_url(amr_annot.hmm_id),
                     hit_counts.presence.loc[gene], hit_counts_all.loc[gene]]
+            data = [el if el is not None else "-" for el in data]
             self.table_data.append(data)
 
         self.show_results = True

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -143,15 +143,6 @@ def format_hmm_url(hmm_id):
     return hmm_id
 
 
-def format_gene_to_ncbi_hmm(gene_and_hmmid):
-    gene, hmm_id = gene_and_hmmid
-    if hmm_id:
-        # The hmm_id contains a version number, which is not in the ncbi URL.
-        hmm_id = hmm_id.rsplit(".", 1)[0]
-        return f"<a href=\"https://www.ncbi.nlm.nih.gov/genome/annotation_prok/evidence/{hmm_id}\">{gene}</a>"  # noqa
-    return gene
-
-
 def format_pfam(pfam_id, base=None, to_url=False):
     if base is None:
         fmt_entry = f"PF{pfam_id:04d}"

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -10,6 +10,7 @@ def safe_replace(string, search_string, replace_string):
 
 
 title2page = {
+    'Antimicrobial Resistance Gene': ["fam_amr"],
     'COG Ortholog': ['fam_cog'],
     'Comparisons: Antimicrobial Resistance': [
         'amr_comparison', 'index_comp_amr', 'entry_list_amr', 'extract_amr',
@@ -127,6 +128,19 @@ def format_ko(ko_id, as_url=False, base=None):
 
 def format_ko_url(ko_id):
     return format_ko(ko_id, as_url=True)
+
+
+def format_amr(gene, to_url=False):
+    if not to_url:
+        return gene
+    return f"<a href=\"/fam_amr/{gene}\">{gene}</a>"
+
+
+def format_hmm_url(hmm_id):
+    if hmm_id:
+        hmm_id = hmm_id.rsplit(".", 1)[0]
+        return f"<a href=\"https://www.ncbi.nlm.nih.gov/genome/annotation_prok/evidence/{hmm_id}\">{hmm_id}</a>"  # noqa
+    return hmm_id
 
 
 def format_gene_to_ncbi_hmm(gene_and_hmmid):

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -3365,7 +3365,7 @@ class AmrComparisonView(TabularComparisonViewBase):
     @property
     def base_info_headers(self):
         if self.comp_type == "gene":
-            return ["Gene", "scope", "Class", "Subclass", "Annotation"]
+            return ["Gene", "scope", "Class", "Subclass", "Annotation", "HMM"]
         elif self.comp_type == "subclass":
             return ["Subclass", "Class"]
         elif self.comp_type == "class":
@@ -3380,21 +3380,19 @@ class AmrComparisonView(TabularComparisonViewBase):
 
     def get_row_data(self, groupid, data):
         if self.comp_type == "class":
-            return [groupid]
+            return [safe_replace(groupid, "/", " / ")]
         elif self.comp_type == "subclass":
             return [
-                format_gene_to_ncbi_hmm((groupid, data.iloc[0].hmm_id)),
-                data.iloc[0]["scope"],
-                safe_replace(data.iloc[0]["class"], "/", " / "),
-                safe_replace(data.iloc[0]["subclass"], "/", " / "),
-                data.iloc[0]["seq_name"]]
+                safe_replace(groupid, "/", " / "),
+                safe_replace(data.iloc[0]["class"], "/", " / ") or "-"]
         elif self.comp_type == "gene":
             return [
-                format_gene_to_ncbi_hmm((groupid, data.iloc[0].hmm_id)),
-                data.iloc[0]["scope"],
-                safe_replace(data.iloc[0]["class"], "/", " / "),
-                safe_replace(data.iloc[0]["subclass"], "/", " / "),
-                data.iloc[0]["seq_name"]]
+                format_amr(groupid, to_url=True),
+                data.iloc[0]["scope"] or "-",
+                safe_replace(data.iloc[0]["class"], "/", " / ") or "-",
+                safe_replace(data.iloc[0]["subclass"], "/", " / ") or "-",
+                data.iloc[0]["seq_name"],
+                format_hmm_url(data.iloc[0].hmm_id) or "-"]
 
     def get_table_rows(self):
         hits = self.db.get_amr_hits_from_taxonids(self.targets)

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -43,12 +43,11 @@ from lib.KO_module import ModuleParser
 from reportlab.lib import colors
 
 from views.mixins import ComparisonViewMixin
-from views.utils import (format_amr, format_cog, format_gene_to_ncbi_hmm,
-                         format_hmm_url, format_ko, format_ko_module,
-                         format_ko_modules, format_ko_path, format_locus,
-                         format_lst_to_html, format_orthogroup, format_pfam,
-                         my_locals, optional2status, page2title, safe_replace,
-                         to_s)
+from views.utils import (format_amr, format_cog, format_hmm_url, format_ko,
+                         format_ko_module, format_ko_modules, format_ko_path,
+                         format_locus, format_lst_to_html, format_orthogroup,
+                         format_pfam, my_locals, optional2status, page2title,
+                         safe_replace, to_s)
 
 
 def id_generator(size=6, chars=string.ascii_uppercase + string.ascii_lowercase + string.digits):
@@ -578,10 +577,12 @@ def og_tab_get_amr_annot(db, seqids):
     if amr_hits.empty:
         return {}
 
-    col_titles = {"closest_seq": "Closest Sequence"}
+    col_titles = {"closest_seq": "Closest Sequence",
+                  "hmm_id": "HMM"}
 
     amr_hits["closest_seq"] = amr_hits["closest_seq"].map(format_refseqid_to_ncbi)
-    amr_hits["gene"] = amr_hits[["gene", "hmm_id"]].apply(format_gene_to_ncbi_hmm, axis=1)
+    amr_hits["gene"] = amr_hits["gene"].apply(format_amr, to_url=True)
+    amr_hits["hmm_id"] = amr_hits["hmm_id"].apply(format_hmm_url)
     return {
         "amr_entries": amr_hits.values,
         "amr_header": [col_titles.get(col, col.capitalize())


### PR DESCRIPTION
We add a details view (`fam_amr`) for AMR genes. These views (`fam_cog`, `fam_ko`, `fam_pfam`) already share a single template. It also seems that these views share a lot of code but I did not take the time to refactor them as class-based views to avoid code repetition.
![fam_amr](https://github.com/metagenlab/zDB/assets/7374243/0840f051-4803-46af-afb8-726d8d5df533)

## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [x] Add tests for new features and regression tests for bugfixes whenever possible.

