### PR TITLE
Add plot_heatmap view for AMR genes.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Added
 
+- Add AMR heatmap view. ([#45](https://github.com/metagenlab/zDB/pull/45)) (Niklaus Johner)
 - Add AMR details view. ([#44](https://github.com/metagenlab/zDB/pull/44)) (Niklaus Johner)
 - Add AMR Venn diagram view. ([#41](https://github.com/metagenlab/zDB/pull/41)) (Niklaus Johner)
 - Add AMR hit extraction view. ([#38](https://github.com/metagenlab/zDB/pull/38)) (Niklaus Johner)

--- a/webapp/templates/chlamdb/extract_nav_tabs_template.html
+++ b/webapp/templates/chlamdb/extract_nav_tabs_template.html
@@ -74,6 +74,7 @@
             <li class={% if active_tab == "det" %}"active"{%endif%}><a href="{% url 'extract_amr' %}">Extract form</a></li>
             <li class={% if active_tab == "venn" %}"active"{%endif%}><a href="{% url 'venn_amr' %}">Venn</a></li>
             <li class={% if active_tab == "comp" %}"active"{%endif%}><a href="{% url 'amr_comparison' %}">Presence/absence table</a></li>
+            <li class={% if active_tab == "heat" %}"active"{%endif%}><a href="{% url 'plot_heatmap' 'amr' %}">Heatmaps</a></li>
         </ul>
     </nav>
 {% endif %}

--- a/webapp/templates/chlamdb/plot_heatmap.html
+++ b/webapp/templates/chlamdb/plot_heatmap.html
@@ -31,6 +31,8 @@
                         Kegg orthologous groups (KO)
                     {% elif type == 'orthology' %}
                         orthologous groups
+                    {% elif type == 'amr' %}
+                        AMR genes
                     {% endif %}</b><a href="https://zdb.readthedocs.io/en/latest/tutorial/website.html#comparisons" id="show-option"  target="_blank"><i class="fab fa-info-circle " style="size: 5em;" ></i></a></p>
                 
 
@@ -75,6 +77,8 @@
                     Kegg entries found per each Kegg orthologous groups shared by the genomes of interest.
                     {% elif type == 'orthology' %}
                        homologs found per each Orthogroups shared by the genomes of interest.
+                    {% elif type == 'amr' %}
+                       times an AMR gene is found in each of the genomes of interest.
                     {% endif %}
                     
                     Zooming into an area of interest you can visualize the presence/absence profile.

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -14,7 +14,7 @@ title2page = {
     'COG Ortholog': ['fam_cog'],
     'Comparisons: Antimicrobial Resistance': [
         'amr_comparison', 'index_comp_amr', 'entry_list_amr', 'extract_amr',
-        'venn_amr'],
+        'plot_heatmap_amr', 'venn_amr'],
     'Comparisons: Clusters of Orthologous groups (COGs)': [
         'cog_barchart', 'index_comp_cog', 'cog_phylo_heatmap',
         'cog_comparison', 'entry_list_cog', 'extract_cog', 'heatmap_COG',

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -2729,13 +2729,15 @@ def plot_heatmap(request, type):
     elif type == "pfam":
         mat = db.get_pfam_hits(taxon_ids)
         mat.index = [format_pfam(i) for i in mat.index]
+    elif type == "amr":
+        mat = db.get_amr_hit_counts(taxon_ids)
+        mat.index = [format_amr(i) for i in mat.index]
     else:
         form_venn = form_class()
         return render(request, 'chlamdb/plot_heatmap.html', my_locals(locals()))
 
     target2description = db.get_genomes_description().description.to_dict()
     mat.columns = (target2description[i] for i in mat.columns.values)
-
     # reorder row and columns based on clustering
     Z_rows = shc.linkage(mat.T, method='ward')
     order_rows = hierarchy.leaves_list(Z_rows)

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -178,7 +178,8 @@ class ComparisonIndexView(View, ComparisonViewMixin):
         boxes = ["entry-list", "extraction", "venn",
                  "tabular-comparison", "heatmap", "accumulation-rarefaction"]
         if self.comp_type == "amr":
-            boxes = ["entry-list", "extraction", "venn", "tabular-comparison"]
+            boxes = ["entry-list", "extraction", "venn",
+                     "tabular-comparison", "heatmap"]
         elif self.comp_type == "orthogroup":
             boxes.remove("entry-list")
         elif self.comp_type == "ko":


### PR DESCRIPTION
In this PR we add the heatmap view for AMR genes. Not that the view fails on the testing dataset, as there are not enough hits leading to an empty distance matrix.
![amr_heatmap](https://github.com/metagenlab/zDB/assets/7374243/958169c3-3ffb-4027-9eb3-0578f04efa4b)



## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [x] Add tests for new features and regression tests for bugfixes whenever possible.

