### PR TITLE
Fix blast view

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,7 @@ to [Common Changelog](https://common-changelog.org)
 ### Fixed
 
 - Fix tabular comparison views navigation tabs. ([#30](https://github.com/metagenlab/zDB/pull/30), [#31](https://github.com/metagenlab/zDB/pull/31)) (Niklaus Johner)
+- Fix missing page title on error in blast view. ([#64](https://github.com/metagenlab/zDB/pull/64)) (Niklaus Johner)
 
 
 ## 1.2.1 - 2023-10-16

--- a/testing/webapp/test_views.py
+++ b/testing/webapp/test_views.py
@@ -208,6 +208,31 @@ class TestViewsContent(SimpleTestCase):
         self.assertPlot(resp)
         self.assertContains(resp, "Distribution of COGs within COG categories")
 
+    def test_blast(self):
+        resp = self.client.get("/blast/")
+        self.assertEqual(200, resp.status_code)
+        self.assertTemplateUsed(resp, 'chlamdb/blast.html')
+        self.assertTitle(resp, "Homology search: Blast")
+        self.assertNotIn("envoi", resp.context.keys())
+        self.assertNotContains(resp, "Help to interpret the results")
+        self.assertNotContains(resp, 'id="phylo_distrib"')
+        self.assertNotContains(resp, 'id="blast_details"')
+
+        data = {
+            "blast_input": "ATCGCCACGGTGGTGCAGGCGCAGAAAGCGGGCAAAACGCTCAGCGTCG",
+            "blast": "blastn_ffn",
+            "max_number_of_hits": 10,
+            "target": "all"
+        }
+        resp = self.client.post("/blast/", data=data)
+        self.assertEqual(200, resp.status_code)
+        self.assertTemplateUsed(resp, 'chlamdb/blast.html')
+        self.assertTitle(resp, "Homology search: Blast")
+        self.assertIn("envoi", resp.context.keys())
+        self.assertContains(resp, "Help to interpret the results")
+        self.assertContains(resp, 'id="phylo_distrib"')
+        self.assertContains(resp, 'id="blast_details"')
+
 
 class ComparisonViewsTestMixin():
 

--- a/webapp/templates/chlamdb/blast.html
+++ b/webapp/templates/chlamdb/blast.html
@@ -212,7 +212,6 @@ margin-top: 15em;
               {% endif %}
                         </p>
                     </div>
-                    {% include "chlamdb/venn_template_orthogroups.html" with series=series description_dico=orthogroup2description %}
                     </div>
                 </div>
              {% if phylo_distrib %}

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -1825,8 +1825,8 @@ class PanGenome(ComparisonViewMixin, View):
 
 blast_input_dir = {"blastp": "faa",
                    "tblastn": "ffn",
-                   "blastn_fna": "ffn",
-                   "blastn_ffn": "fna",
+                   "blastn_fna": "fna",
+                   "blastn_ffn": "ffn",
                    "blastx": "faa"}
 
 blast_command = {"blastp": NcbiblastpCommandline,

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -1912,7 +1912,8 @@ def blast(request):
 
     form = blast_form_class(request.POST)
     if not form.is_valid():
-        return render(request, 'chlamdb/blast.html', my_locals({"form": form}))
+        return render(request, 'chlamdb/blast.html',
+                      my_locals({"form": form, "page_title": page_title}))
 
     input_sequence = form.cleaned_data['blast_input']
     number_blast_hits = form.cleaned_data['max_number_of_hits']
@@ -1928,13 +1929,15 @@ def blast(request):
                     context = {
                         "error_message": "Empty sequence in input",
                         "error_title": "Query format error", "envoi": True,
-                        "form": form, "wrong_format": True}
+                        "form": form, "wrong_format": True,
+                        "page_title": page_title}
                     return render(request, 'chlamdb/blast.html',
                                   my_locals(context))
         except Exception:
             context = {"error_message": "Error while parsing the fasta query",
                        "error_title": "Query format error",
-                       "envoi": True, "form": form, "wrong_format": True}
+                       "envoi": True, "form": form, "wrong_format": True,
+                       "page_title": page_title}
             return render(request, 'chlamdb/blast.html', my_locals(context))
     else:
         no_query_name = True
@@ -1956,7 +1959,8 @@ def blast(request):
         else:
             errmsg = f"Unexpected character in amino-acid query: {wrong_chars}"
         context = {"error_message": errmsg, "error_title": "Query format error",
-                   "envoi": True, "form": form, "wrong_format": True}
+                   "envoi": True, "form": form, "wrong_format": True,
+                   "page_title": page_title}
         return render(request, 'chlamdb/blast.html', my_locals(context))
     elif check_seq_DNA and blast_type in ["blastn", "blastn_ffn",
                                           "blast_fna", "blastx"]:
@@ -1967,7 +1971,7 @@ def blast(request):
             errmsg = f"Unexpected character in nucleotide query: {wrong_chars}"
         context = {"error_message": errmsg, "wrong_format": True,
                    "error_title": "Query format error", "envoi": True,
-                   "form": form}
+                   "form": form, "page_title": page_title}
         return render(request, 'chlamdb/blast.html', my_locals(context))
 
     query_file = NamedTemporaryFile(mode='w')
@@ -1996,7 +2000,8 @@ def blast(request):
     except Exception as e:
         context = {
             "error_message": "Error in blast " + str(e), "wrong_format": True,
-            "error_title": "Blast error", "envoi": True, "form": form}
+            "error_title": "Blast error", "envoi": True, "form": form,
+            "page_title": page_title}
         return render(request, 'chlamdb/blast.html', my_locals(context))
 
     if blast_stdout.find("No hits found") != -1:


### PR DESCRIPTION
Blast view was broken because of two things:
- [ Fix of mixup in the annotation pipeline between ffn and fna databases](https://github.com/metagenlab/zDB/pull/17/files#diff-440f682582f0857326c90c97e62e794a581bd01b8c2711f9120e34b96177688cR2862) got [partially overwritten in a subsequent PR](https://github.com/metagenlab/zDB/commit/571c162a7f77d33b9daad1199768515ac8b613cf#diff-440f682582f0857326c90c97e62e794a581bd01b8c2711f9120e34b96177688cR2887), probably because of some rebase fail.
- A template that got deleted was being used by the view, but it was unnecessary as it actually never generated the venn diagram.

## Checklist
- [ ] Changelog entry
- [x] Check that tests still pass
- [x] Add tests for new features and regression tests for bugfixes whenever possible.

