### PR TITLE
Fix blast against the VFDB.

### DIFF
--- a/bin/zdb
+++ b/bin/zdb
@@ -513,6 +513,7 @@ elif [[ "$1" == "run" ]]; then
 				echo " --pfam: peform PFAM domain annotation"
 				echo " --swissprot: search for homologs in the swissprot database"
 				echo " --vfdb: search for homologs in the virulence factor database"
+				echo " --vf_evalue: evalue cutoff for the blast against the VF database. Defaults to 1e-10."
 				echo " --ref_dir: directory where the reference databases were setup up (default zdb_ref)"
 				echo " --cpu: number of parallel processes allowed (default 8)"
 				echo " --mem: max memory usage allowed (default 8GB)"

--- a/db_setup.nf
+++ b/db_setup.nf
@@ -161,11 +161,11 @@ process download_vfdb {
 
     script:
     """
-    wget http://www.mgc.ac.cn/VFs/Down/VFDB_setB_nt.fas.gz
+    wget http://www.mgc.ac.cn/VFs/Down/VFDB_setB_pro.fas.gz
     wget http://www.mgc.ac.cn/VFs/Down/VFs.xls.gz
-    gunzip < VFDB_setB_nt.fas.gz > vfdb.fasta
+    gunzip < VFDB_setB_pro.fas.gz > vfdb.fasta
     gunzip < VFs.xls.gz > VFs.xls
-    rm VFDB_setB_nt.fas.gz
+    rm VFDB_setB_pro.fas.gz
     rm VFs.xls.gz
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -36,7 +36,7 @@ params.blast_swissprot = false
 params.diamond_refseq = false
 
 // evalue for blast against VFDB
-params.vf_evalue = "10.0"
+params.vf_evalue = "1e-10"
 
 //////
 //// Internals


### PR DESCRIPTION
As we blast protein sequences against the VFDB we now download the protein database instead of the nucleotide database.

## Checklist
- [ ] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

