### PR TITLE
Filter VF hits by SeqID and coverage and keep one hit per locus.

### DIFF
--- a/annotation_pipeline.nf
+++ b/annotation_pipeline.nf
@@ -525,7 +525,10 @@ process blast_vfdb {
 
   n = seq.name
   """
-  blastp -db $vf_db/vfdb.fasta -query ${n} -outfmt 6 -evalue ${params.vf_evalue} -num_threads ${task.cpus} > ${n}.tab
+  blastp -db $vf_db/vfdb.fasta -query ${n} \
+  -outfmt "6 qaccver saccver pident length evalue bitscore qcovs" \
+  -evalue ${params.vf_evalue} -qcov_hsp_perc ${params.vf_coverage} \
+  -max_hsps 1 -num_threads ${task.cpus} > ${n}.tab
   """
 }
 
@@ -831,6 +834,7 @@ process load_vfdb_hits_into_db {
         path db
 
     script:
+    min_seqid = params.vf_seqid
     """
         #!/usr/bin/env python
         import setup_chlamdb
@@ -838,7 +842,7 @@ process load_vfdb_hits_into_db {
         kwargs = ${gen_python_args()}
         blast_results = "$blast_results".split()
 
-        setup_chlamdb.load_vfdb_hits(kwargs, blast_results, "$db", "$vf_db_fasta", "$vf_db_defs")
+        setup_chlamdb.load_vfdb_hits(kwargs, blast_results, "$db", "$vf_db_fasta", "$vf_db_defs", float("$min_seqid"))
     """
 }
 

--- a/bin/setup_chlamdb.py
+++ b/bin/setup_chlamdb.py
@@ -805,40 +805,40 @@ def setup_chlamdb_search_index(params, db_name, index_name):
                 og = format_og(data.orthogroup)
 
             organism = genomes.loc[taxid].description
-            search_bar.GeneEntry.add_to_index(
+            search_bar.GeneEntry().add_to_index(
                 index, locus_tag, gene, product, organism, og)
 
     if has_cog:
         cog_data = db.get_cog_summaries(cog_ids=None, only_cog_desc=True)
         for cog, (func, descr) in cog_data.items():
-            search_bar.CogEntry.add_to_index(index, cog, descr)
+            search_bar.CogEntry().add_to_index(index, cog, descr)
 
     if has_ko:
         ko_data = db.get_ko_desc(ko_ids=None)
         for ko, descr in ko_data.items():
-            search_bar.KoEntry.add_to_index(index, ko, descr)
+            search_bar.KoEntry().add_to_index(index, ko, descr)
 
         mod_data = db.get_modules_info(ids=None, search_on=None)
         for mod_id, mod_desc, _, _, _ in mod_data:
-            search_bar.ModuleEntry.add_to_index(index, mod_id, mod_desc)
+            search_bar.ModuleEntry().add_to_index(index, mod_id, mod_desc)
 
         pat_data = db.get_pathways()
         for pat_id, path_desc in pat_data:
-            search_bar.PathwayEntry.add_to_index(index, pat_id, path_desc)
+            search_bar.PathwayEntry().add_to_index(index, pat_id, path_desc)
 
     if has_pfam:
         pfam_data = db.get_pfam_def(pfam_ids=None)
         for pfam, data in pfam_data.iterrows():
-            search_bar.PfamEntry.add_to_index(index, pfam, data["def"])
+            search_bar.PfamEntry().add_to_index(index, pfam, data["def"])
 
     if has_amr:
         amr_data = db.get_amr_descriptions()
         for amr, data in amr_data.iterrows():
-            search_bar.AmrEntry.add_to_index(index, data["gene"], data["seq_name"])
+            search_bar.AmrEntry().add_to_index(index, data["gene"], data["seq_name"])
 
     if has_vf:
         vf_data = db.vf.get_hit_descriptions(hit_ids=None)
         for vf, data in vf_data.iterrows():
-            search_bar.VfEntry.add_to_index(index, data["vf_gene_id"], data["prot_name"])
+            search_bar.VfEntry().add_to_index(index, data["vf_gene_id"], data["prot_name"])
 
     index.done_adding()

--- a/conda/annotation.yaml
+++ b/conda/annotation.yaml
@@ -6,7 +6,8 @@ dependencies:
     - python=3.9
     - whoosh
     - sqlite
-    - biopython>=1.8
+    - biopython>=1.80
     - numpy
     - pandas
     - xlrd
+    - ete3

--- a/conda/testing.yaml
+++ b/conda/testing.yaml
@@ -6,7 +6,7 @@ dependencies:
     - python=3.9
     - whoosh
     - sqlite
-    - biopython>=1.8
+    - biopython>=1.80
     - numpy
     - pandas
     - singularity=3.8.4

--- a/conda/webapp.yaml
+++ b/conda/webapp.yaml
@@ -9,7 +9,7 @@ dependencies:
     - pandas
     - seaborn
     - django>=4
-    - biopython>=1.8
+    - biopython>=1.80
     - matplotlib
     - celery
     - django-crispy-forms=1.14.0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Changed
 
+- Filter VF hits by SeqID and coverage and keep one hit per locus. ([#77](https://github.com/metagenlab/zDB/pull/77)) (Niklaus Johner)
 - Improve layout for various views, making better use of available space. ([#70](https://github.com/metagenlab/zDB/pull/70)) (Niklaus Johner)
 - Configure repository to publish the docs to [readthedocs](https://zdb.readthedocs.io)
 - Port nextflow pipelines to DSL2 language. ([#26](https://github.com/metagenlab/zDB/pull/26)) (Niklaus Johner)

--- a/nextflow.config
+++ b/nextflow.config
@@ -37,6 +37,8 @@ params.diamond_refseq = false
 
 // evalue for blast against VFDB
 params.vf_evalue = "1e-10"
+params.vf_seqid = "60"
+params.vf_coverage = "60"
 
 //////
 //// Internals

--- a/testing/pipelines/test_annotation_pipeline.py
+++ b/testing/pipelines/test_annotation_pipeline.py
@@ -185,8 +185,8 @@ class TestAnnotationPipeline(BasePipelineTestCase):
             base_tables + ['vf_hits', 'vf_defs'],
             self.metadata_obj.tables.keys())
         self.assert_db_base_table_row_counts()
-        self.assertTrue(6500 < self.query("vf_hits").count() < 6600)
-        self.assertTrue(2700 < self.query("vf_defs").count() < 2800)
+        self.assertEqual(36, self.query("vf_hits").count())
+        self.assertEqual(35, self.query("vf_defs").count())
 
     def test_full_pipeline(self):
         self.nf_params["pfam"] = "true"
@@ -226,8 +226,8 @@ class TestAnnotationPipeline(BasePipelineTestCase):
         self.assertTrue(self.query("swissprot_defs").count() > 19400)
         self.assertTrue(self.query("swissprot_hits").count() > 29400)
         self.assertEqual(2, self.query("amr_hits").count())
-        self.assertTrue(6500 < self.query("vf_hits").count() < 6600)
-        self.assertTrue(2700 < self.query("vf_defs").count() < 2800)
+        self.assertEqual(36, self.query("vf_hits").count())
+        self.assertEqual(35, self.query("vf_defs").count())
 
         self.assertItemsEqual(
             ["Pfam", "SwissProt", "Ko", "CDD", "AMRFinderSoftware", "AMRFinderDB", "VFDB"],

--- a/testing/webapp/test_views.py
+++ b/testing/webapp/test_views.py
@@ -48,7 +48,7 @@ urls = [
     '/fam_cog/COG0775',
     '/fam_ko/K01241',
     '/fam_pfam/PF10423',
-    '/fam_vf/VFG029227',
+    '/fam_vf/VFG048797',
     '/FAQ',
     '/genomes',
     '/get_cog/3/L?h=1&h=2&h=3',

--- a/webapp/lib/db_utils.py
+++ b/webapp/lib/db_utils.py
@@ -305,8 +305,8 @@ class DB:
     def create_vf_tables(self):
         query = (
             "CREATE TABLE vf_hits ("
-            " hsh INT, vf_gene_id INT, evalue INT, score INT,"
-            " perc_id INT, gaps INT, leng INT"
+            " hsh INT, vf_gene_id INT, evalue DOUBLE, score INT,"
+            " perc_id FLOAT, leng INT, coverage INT"
             ");"
         )
         self.server.adaptor.execute(query,)


### PR DESCRIPTION
We can use the `-max_hsps 1` option to limit search results as it will return the best (lowest evalue) hit for each subject/query pair. As we only want to keep one hit per locus, we further filter the results before uploading to the DB.

## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

