### PR TITLE
Fix bug in ValueColoredColumn.

### DIFF
--- a/webapp/lib/ete_phylo.py
+++ b/webapp/lib/ete_phylo.py
@@ -214,7 +214,7 @@ class ValueColoredColumn(Column):
         self.values = values
         self.col_func = col_func
         self.header = header
-        self.face_params = face_params,
+        self.face_params = face_params
         self.header_params = header_params
 
     def get_color(self, index, val):


### PR DESCRIPTION
because of a trailing coma, face_params were defined as a tuple in ValueColoredColumn, which breaks various views. This used to work as face_params were simply always ignored before.

## Checklist
- [ ] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

