### PR TITLE
Allow defining groups of genomes in input file.

### DIFF
--- a/annotation_pipeline.nf
+++ b/annotation_pipeline.nf
@@ -84,7 +84,7 @@ process check_gbk {
         if not os.path.isdir("filtered"):
           os.mkdir("filtered")
 
-        annotations.InputHandler().check_and_revise_gbks("$input_file")
+        annotations.InputHandler("$input_file").check_and_revise_gbks()
     """
 }
 

--- a/annotation_pipeline.nf
+++ b/annotation_pipeline.nf
@@ -84,7 +84,7 @@ process check_gbk {
         if not os.path.isdir("filtered"):
           os.mkdir("filtered")
 
-        annotations.check_and_revise_gbks("$input_file")
+        annotations.InputHandler().check_and_revise_gbks("$input_file")
     """
 }
 

--- a/annotation_pipeline.nf
+++ b/annotation_pipeline.nf
@@ -84,7 +84,7 @@ process check_gbk {
         if not os.path.isdir("filtered"):
           os.mkdir("filtered")
 
-        annotations.check_gbk("$input_file")
+        annotations.check_and_revise_gbks("$input_file")
     """
 }
 

--- a/annotation_pipeline.nf
+++ b/annotation_pipeline.nf
@@ -562,6 +562,7 @@ process load_base_db {
 
     input:
         path db_base
+        path input_file
         path gbks
         path orthofinder
         path alignments
@@ -587,6 +588,9 @@ process load_base_db {
 
     print("Loading gbks", flush=True)
     setup_chlamdb.load_gbk(gbk_list, kwargs, "$db_base")
+
+    print("Loading groups", flush=True)
+    setup_chlamdb.load_groups("$input_file", kwargs, "$db_base")
 
     # kept for now, need to check whether this is really necessary to keep the hash
     print("Loading seq hashes", flush=True)
@@ -964,7 +968,7 @@ workflow {
     checkm_table = checkm_analyse(faa_files.collect())
 
     db = setup_db(Channel.fromPath("${params.zdb.file}"))
-    db = load_base_db(db, checked_gbks, orthogroups, to_load_alignment.collect(), nr_mapping_to_db_setup, checkm_table, core_genome_phylogeny, gene_phylogeny.collect(), og_summary)
+    db = load_base_db(db, input_file, checked_gbks, orthogroups, to_load_alignment.collect(), nr_mapping_to_db_setup, checkm_table, core_genome_phylogeny, gene_phylogeny.collect(), og_summary)
 
     if(params.pfam) {
         Channel.fromPath("${params.pfam_db}", type: "dir").set { pfam_db }

--- a/bin/annotations.py
+++ b/bin/annotations.py
@@ -94,14 +94,16 @@ def parse_csv(csv_file):
 
 def check_gbk(csv_file):
     """
+    This method ensures that we do not run into name conflicts in zDB.
+    For this we check that the taxid, the contig name, accession
+    and locus_tags are unique and if not we assign them new names.
+
     As BioSQL uses the organism/source entries of the records to assign
     a taxid when it is not allowed to access the ncbi online,
     we need to ensure that the same organism name is not used
     twice in the genomes to prevent bioentries from different genbank
-    files to be entered under the same taxon_id (as chlamdb uses the taxon_id
+    files to be entered under the same taxon_id (as zdb uses the taxon_id
     to differentiate between genomes).
-
-    Display an error message and stop the pipeline if this arises
     """
 
     # NOTE: biosql uses source to assign taxid. One must ensure

--- a/bin/annotations.py
+++ b/bin/annotations.py
@@ -34,6 +34,10 @@ def orthogroups_to_fasta(genomes_list):
                     SeqIO.write(new_fasta, out_handle, "fasta")
 
 
+class InvalidInput(Exception):
+    pass
+
+
 class InputHandler():
     """
     This class is in charge of parsing the input csv, checking
@@ -83,7 +87,8 @@ class InputHandler():
 
         for colname in csv.columns:
             if not self.allowed_headers_expr.fullmatch(colname):
-                raise Exception(f"Invalid column header {colname} in input file")
+                raise InvalidInput(
+                    f'Invalid column header "{colname}" in input file.')
 
         filenames = set()
         entries = []
@@ -91,14 +96,16 @@ class InputHandler():
             name = entry.get("name", None) or None
             if name:
                 if name in names:
-                    raise Exception(f"Name {name} appears twice in the input file.")
+                    raise InvalidInput(
+                        f'Name "{name}" appears twice in the input file.')
                 names.add(name)
 
             # only get the filename, as nextflow will symlink it
             # in the current work directory
             filename = os.path.basename(entry.file)
             if filename in filenames:
-                raise Exception(f"File {filename} appears twice in the input file.")
+                raise InvalidInput(
+                    f'File "{filename}" appears twice in the input file.')
             filenames.add(filename)
 
             entries.append(self.CsvEntry(name, filename))

--- a/bin/annotations.py
+++ b/bin/annotations.py
@@ -78,24 +78,19 @@ class InputHandler():
     def parse_csv(self, csv_file):
         csv = pd.read_csv(csv_file).fillna('')
         entries = []
-        has_names = False
-
         names = set()
 
         for i in csv.columns:
-            if i == "name":
-                has_names = True
             if i not in self.header_entries:
                 raise Exception("Unknown entry in header: " + i)
 
         filenames = set()
         entries = []
         for index, entry in csv.iterrows():
-            name = None
-            if has_names and len(entry["name"]) > 0:
-                name = entry["name"]
+            name = entry.get("name", None) or None
+            if name:
                 if name in names:
-                    raise Exception(name + " is duplicated")
+                    raise Exception(f"Name {name} appears twice in the input file.")
                 names.add(name)
 
             # only get the filename, as nextflow will symlink it

--- a/bin/annotations.py
+++ b/bin/annotations.py
@@ -79,6 +79,7 @@ class InputHandler():
             cnt += 1
             new_name = f"{prefix}{cnt}"
         self.organisms[new_name] += 1
+        self.organisms[organism] -= 1
         return new_name
 
     @classmethod
@@ -252,7 +253,6 @@ class InputHandler():
                     sci_name = record.annotations["organism"]
                     if self.organisms[sci_name] > 1:
                         sci_name = self.gen_new_organism(sci_name)
-                        self.organisms[sci_name] -= 1
                 record.annotations["source"] = sci_name
                 record.annotations["organism"] = sci_name
 

--- a/bin/annotations.py
+++ b/bin/annotations.py
@@ -49,7 +49,7 @@ class InputHandler():
     group_header_expr = re.compile(r"group:([\w\s]*)")
 
     def __init__(self, csv_file):
-        self.csv_entries = self.parse_csv(csv_file)
+        self.csv_entries, self.group_names = self.parse_csv(csv_file)
 
         # NOTE: biosql uses source to assign taxid. One must ensure
         # that the source are unique to each gbk file to avoid conflicts
@@ -104,7 +104,8 @@ class InputHandler():
             f'Invalid entry "{value}" in group column. Should be one of '
             '"yes", "true", "x", "1", "no", "false", "0" or empty')
 
-    def parse_csv(self, csv_file):
+    @classmethod
+    def parse_csv(cls, csv_file):
         csv = pd.read_csv(csv_file, dtype=str,
                           skipinitialspace=True).fillna('')
         entries = []
@@ -112,11 +113,11 @@ class InputHandler():
 
         group_names = {}
         for colname in csv.columns:
-            if not self.is_header_allowed(colname):
+            if not cls.is_header_allowed(colname):
                 raise InvalidInput(
                     f'Invalid column header "{colname}" in input file.')
-            if self.header_is_group(colname):
-                group_names[colname] = self.header_to_group_label(colname)
+            if cls.header_is_group(colname):
+                group_names[colname] = cls.header_to_group_label(colname)
 
         filenames = set()
         entries = []
@@ -138,14 +139,14 @@ class InputHandler():
 
             groups = []
             for group_name, group_label in group_names.items():
-                if self.is_in_group(entry, group_name):
+                if cls.is_in_group(entry, group_name):
                     groups.append(group_label)
-            entries.append(self.CsvEntry(name, filename, groups))
+            entries.append(cls.CsvEntry(name, filename, groups))
 
         if len(entries) == 0:
             raise Exception(csv_file + " is empty")
 
-        return entries
+        return entries, group_names
 
     def check_and_revise_gbks(self):
         """

--- a/bin/annotations.py
+++ b/bin/annotations.py
@@ -105,7 +105,8 @@ class InputHandler():
             '"yes", "true", "x", "1", "no", "false", "0" or empty')
 
     def parse_csv(self, csv_file):
-        csv = pd.read_csv(csv_file, dtype=str).fillna('')
+        csv = pd.read_csv(csv_file, dtype=str,
+                          skipinitialspace=True).fillna('')
         entries = []
         names = set()
 

--- a/bin/annotations.py
+++ b/bin/annotations.py
@@ -5,6 +5,7 @@ import pandas as pd
 from Bio import AlignIO, SeqIO
 from Bio.Align import MultipleSeqAlignment
 from Bio.SeqUtils import CheckSum
+import re
 
 
 def chunks(lst, n):
@@ -40,7 +41,7 @@ class InputHandler():
     """
 
     CsvEntry = namedtuple("CsvEntry", "name file")
-    header_entries = ["name", "file"]
+    allowed_headers_expr = re.compile("name|file")
 
     def __init__(self, csv_file):
         self.csv_entries = self.parse_csv(csv_file)
@@ -80,9 +81,9 @@ class InputHandler():
         entries = []
         names = set()
 
-        for i in csv.columns:
-            if i not in self.header_entries:
-                raise Exception("Unknown entry in header: " + i)
+        for colname in csv.columns:
+            if not self.allowed_headers_expr.fullmatch(colname):
+                raise Exception(f"Invalid column header {colname} in input file")
 
         filenames = set()
         entries = []

--- a/bin/annotations.py
+++ b/bin/annotations.py
@@ -88,6 +88,7 @@ class InputHandler():
             if i not in self.header_entries:
                 raise Exception("Unknown entry in header: " + i)
 
+        filenames = set()
         entries = []
         for index, entry in csv.iterrows():
             name = None
@@ -99,7 +100,12 @@ class InputHandler():
 
             # only get the filename, as nextflow will symlink it
             # in the current work directory
-            entries.append(self.CsvEntry(name, os.path.basename(entry.file)))
+            filename = os.path.basename(entry.file)
+            if filename in filenames:
+                raise Exception(f"File {filename} appears twice in the input file.")
+            filenames.add(filename)
+
+            entries.append(self.CsvEntry(name, filename))
 
         if len(entries) == 0:
             raise Exception(csv_file + " is empty")

--- a/bin/setup_chlamdb.py
+++ b/bin/setup_chlamdb.py
@@ -9,6 +9,8 @@ from Bio import SeqIO, SeqUtils
 from lib import KO_module, search_bar
 from lib.db_utils import DB
 
+from annotations import InputHandler
+
 
 # assumes orthofinder named: OG000N
 # returns the N as int
@@ -76,6 +78,20 @@ def load_gbk(gbks, args, db_file):
     db.commit()
     db.update_plasmid_status(bioentry_plasmids)
     db.set_status_in_config_table("gbk_files", 1)
+    db.commit()
+
+
+def load_groups(input_file, kwargs, db_file):
+    db = DB.load_db(db_file, kwargs)
+    csv_entries, group_names = InputHandler.parse_csv(input_file)
+    filenames_to_taxid = db.get_filenames_to_taxon_id()
+    group_taxon = []
+    for entry in csv_entries:
+        taxon_id = filenames_to_taxid[os.path.splitext(entry.file)[0]]
+        for group in entry.groups:
+            group_taxon.append((group, taxon_id))
+
+    db.load_groups([[name] for name in group_names.values()], group_taxon)
     db.commit()
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Added
 
+- Allow defining groups of genomes in input file. ([#82](https://github.com/metagenlab/zDB/pull/82)) (Niklaus Johner)
 - Add view to produce custom plots (phylogenetic trees and table). ([#78](https://github.com/metagenlab/zDB/pull/78)) (Niklaus Johner)
 - Add AMRs and VFs to search index. ([#73](https://github.com/metagenlab/zDB/pull/73)) (Niklaus Johner)
 - Add VFs to locus and orthogroup views. ([#71](https://github.com/metagenlab/zDB/pull/71)) (Niklaus Johner)

--- a/testing/pipelines/assets/test_input.csv
+++ b/testing/pipelines/assets/test_input.csv
@@ -1,4 +1,4 @@
-file
-assets/R6724_16313_small.gbk
-assets/R6726_16314_small.gbk
-assets/R6728_16315_small.gbk
+file,group:positive, group:negative, group:all
+assets/R6724_16313_small.gbk,0,1,1
+assets/R6726_16314_small.gbk,1,0,1
+assets/R6728_16315_small.gbk,0,1,1

--- a/testing/pipelines/assets/test_input.csv
+++ b/testing/pipelines/assets/test_input.csv
@@ -1,4 +1,4 @@
 file,group:positive, group:negative, group:all
-assets/R6724_16313_small.gbk,0,1,1
+assets/R6724_16313_small.gbk,1,0,1
 assets/R6726_16314_small.gbk,1,0,1
 assets/R6728_16315_small.gbk,0,1,1

--- a/testing/pipelines/base.py
+++ b/testing/pipelines/base.py
@@ -10,6 +10,10 @@ class BaseTestCase(TestCase):
     def assertItemsEqual(self, actual, expected):
         self.assertEqual(sorted(actual), sorted(expected))
 
+    @property
+    def test_dir(self):
+        return os.path.dirname(os.path.abspath(__file__))
+
 
 class BasePipelineTestCase(BaseTestCase):
 
@@ -18,8 +22,8 @@ class BasePipelineTestCase(BaseTestCase):
 
     def setUp(self):
         super(BasePipelineTestCase, self).setUp()
-        self.execution_dir = os.path.dirname(os.path.abspath(__file__))
-        self.basedir = os.path.dirname(self.execution_dir)
+        self.execution_dir = self.test_dir
+        self.basedir = os.path.dirname(os.path.dirname(self.execution_dir))
         self.nf_file_path = os.path.join(self.basedir, self.nf_filename)
         self.singularity_dir = tempfile.TemporaryDirectory()
 

--- a/testing/pipelines/test_annotation_pipeline.py
+++ b/testing/pipelines/test_annotation_pipeline.py
@@ -22,6 +22,7 @@ base_tables = [
     'filenames',
     'gene_phylogeny',
     'genome_summary',
+    'groups',
     'ko_class',
     'ko_def',
     'ko_module_def',
@@ -42,6 +43,7 @@ base_tables = [
     'seqfeature_relationship',
     'sequence_hash_dictionnary',
     'taxon',
+    'taxon_in_group',
     'taxon_name',
     'term',
     'term_dbxref',
@@ -92,13 +94,14 @@ class TestAnnotationPipeline(BasePipelineTestCase):
         self.assertEqual(304, self.query("og_hits").count())
         self.assertEqual(304, self.query("sequence_hash_dictionnary").count())
         self.assertEqual(32, self.query("term").count())
+        self.assertEqual(3, self.query("groups").count())
+        self.assertEqual(6, self.query("taxon_in_group").count())
 
     def test_base_pipeline(self):
         execution = self.execute_pipeline()
         self.assert_success(execution)
 
         self.load_db(execution)
-
         # Let's check that tables were correctly created and filled
         self.assertItemsEqual(base_tables, self.metadata_obj.tables.keys())
         self.assert_db_base_table_row_counts()

--- a/testing/pipelines/test_annotation_pipeline.py
+++ b/testing/pipelines/test_annotation_pipeline.py
@@ -2,7 +2,7 @@ import os
 
 from sqlalchemy import MetaData, create_engine
 from sqlalchemy.orm import Session
-from testing.base import BasePipelineTestCase
+from testing.pipelines.base import BasePipelineTestCase
 
 base_tables = [
     'biodatabase',
@@ -72,18 +72,13 @@ class TestAnnotationPipeline(BasePipelineTestCase):
         self.session = Session(self.engine)
         self.metadata_obj.reflect(bind=self.engine)
 
-    @property
-    def test_dir(self):
-        return os.path.dirname(os.path.abspath(__file__))
-
     def query(self, tablename):
         return self.session.query(self.metadata_obj.tables[tablename])
 
     def setUp(self):
         super(TestAnnotationPipeline, self).setUp()
-        filedir = os.path.dirname(os.path.abspath(__file__))
         self.nf_params["input"] = os.path.join(
-            filedir, "assets", "test_input.csv")
+            self.test_dir, "assets", "test_input.csv")
 
     def assert_created_files(self, proc, files):
         created_files = os.listdir(proc.path)

--- a/testing/pipelines/test_annotations_functional.py
+++ b/testing/pipelines/test_annotations_functional.py
@@ -44,4 +44,11 @@ class TestInputHandler(BaseTestCase):
         with self.assertRaises(Exception) as exc:
             InputHandler(input_file)
         self.assertEqual('File file1.gbk appears twice in the input file.',
-                         str(exc))
+                         str(exc.exception))
+
+    def test_raises_for_dupplicate_name(self):
+        input_file = StringIO("file,name\nfile1.gbk,foo\nfile2.gbk,foo")
+        with self.assertRaises(Exception) as exc:
+            InputHandler(input_file)
+        self.assertEqual('Name foo appears twice in the input file.',
+                         str(exc.exception))

--- a/testing/pipelines/test_annotations_functional.py
+++ b/testing/pipelines/test_annotations_functional.py
@@ -30,7 +30,7 @@ class TestInputHandler(BaseTestCase):
                                     'R6728_16315_small.gbk'])
 
     def test_handles_name_column(self):
-        input_file = StringIO("name,file\nfoo,file1.gbk\nbar,file2.gbk")
+        input_file = StringIO("name, file\nfoo,file1.gbk\nbar, file2.gbk")
         handler = InputHandler(input_file)
         self.assertEqual(2, len(handler.csv_entries))
         self.assert_names(handler, ["foo", "bar"])

--- a/testing/pipelines/test_annotations_functional.py
+++ b/testing/pipelines/test_annotations_functional.py
@@ -1,0 +1,47 @@
+import os
+import sys
+from io import StringIO
+from testing.pipelines.base import BaseTestCase
+
+sys.path.append(os.path.join(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))), "bin"))
+
+from annotations import InputHandler  # noqa
+
+
+class TestInputHandler(BaseTestCase):
+
+    def assert_names(self, handler, names):
+        self.assertEqual(names, [entry.name for entry in handler.csv_entries])
+
+    def assert_files(self, handler, files):
+        self.assertEqual(files, [entry.file for entry in handler.csv_entries])
+
+    def test_handles_list_of_files(self):
+        input_file = os.path.join(self.test_dir, "assets", "test_input.csv")
+        handler = InputHandler(input_file)
+        self.assert_names(handler, [None, None, None])
+        self.assert_files(handler, ['R6724_16313_small.gbk',
+                                    'R6726_16314_small.gbk',
+                                    'R6728_16315_small.gbk'])
+
+    def test_handles_name_column(self):
+        input_file = StringIO("name,file\nfoo,file1.gbk\nbar,file2.gbk")
+        handler = InputHandler(input_file)
+        self.assertEqual(2, len(handler.csv_entries))
+        self.assert_names(handler, ["foo", "bar"])
+        self.assert_files(handler, ['file1.gbk', 'file2.gbk'])
+
+    def test_handles_incomplete_name_column(self):
+        input_file = StringIO("name,file\n,file1.gbk\nbar,file2.gbk")
+        handler = InputHandler(input_file)
+        self.assertEqual(2, len(handler.csv_entries))
+        self.assert_names(handler, [None, "bar"])
+        self.assert_files(handler, ['file1.gbk', 'file2.gbk'])
+
+    def test_raises_for_dupplicate_filename(self):
+        input_file = StringIO("file\nfile1.gbk\nfile1.gbk")
+        with self.assertRaises(Exception) as exc:
+            InputHandler(input_file)
+        self.assertEqual('File file1.gbk appears twice in the input file.',
+                         str(exc))

--- a/testing/pipelines/test_annotations_functional.py
+++ b/testing/pipelines/test_annotations_functional.py
@@ -52,3 +52,10 @@ class TestInputHandler(BaseTestCase):
             InputHandler(input_file)
         self.assertEqual('Name foo appears twice in the input file.',
                          str(exc.exception))
+
+    def test_raises_for_invalid_column_header(self):
+        input_file = StringIO("filee,name\nfile1.gbk,foo\nfile2.gbk,foo")
+        with self.assertRaises(Exception) as exc:
+            InputHandler(input_file)
+        self.assertEqual("Invalid column header filee in input file",
+                         str(exc.exception))

--- a/testing/pipelines/test_annotations_functional.py
+++ b/testing/pipelines/test_annotations_functional.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from io import StringIO
+
 from testing.pipelines.base import BaseTestCase
 
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(
@@ -16,6 +17,9 @@ class TestInputHandler(BaseTestCase):
 
     def assert_files(self, handler, files):
         self.assertEqual(files, [entry.file for entry in handler.csv_entries])
+
+    def assert_groups(self, handler, groups):
+        self.assertEqual(groups, [entry.groups for entry in handler.csv_entries])
 
     def test_handles_list_of_files(self):
         input_file = os.path.join(self.test_dir, "assets", "test_input.csv")
@@ -39,6 +43,16 @@ class TestInputHandler(BaseTestCase):
         self.assert_names(handler, [None, "bar"])
         self.assert_files(handler, ['file1.gbk', 'file2.gbk'])
 
+    def test_handles_group_columns(self):
+        input_file = StringIO("name,file,group:first one,group:second_group\n"
+                              "foo,file1.gbk,1,\n"
+                              "bar,file2.gbk,false,True\n")
+        handler = InputHandler(input_file)
+        self.assertEqual(2, len(handler.csv_entries))
+        self.assert_names(handler, ["foo", "bar"])
+        self.assert_files(handler, ['file1.gbk', 'file2.gbk'])
+        self.assert_groups(handler, [["first one"], ["second_group"]])
+
     def test_raises_for_dupplicate_filename(self):
         input_file = StringIO("file\nfile1.gbk\nfile1.gbk")
         with self.assertRaises(InvalidInput) as exc:
@@ -59,3 +73,26 @@ class TestInputHandler(BaseTestCase):
             InputHandler(input_file)
         self.assertEqual('Invalid column header "filee" in input file.',
                          str(exc.exception))
+
+    def test_is_header_allowed(self):
+        allowed_headers = ["file", "name", "group:foo", "group:foo bar",
+                           "group:foo_bar", "group:foo1"]
+        for header in allowed_headers:
+            self.assertTrue(InputHandler.is_header_allowed(header))
+
+        disallowed_headers = ["filee", "names", "group foo", "group-foo",
+                              "foo:bar"]
+        for header in disallowed_headers:
+            self.assertFalse(InputHandler.is_header_allowed(header))
+
+    def test_is_in_group(self):
+        for value in ["true", "True", "Y", "yes", "x", "1"]:
+            self.assertTrue(InputHandler.is_in_group({"g1": value}, "g1"))
+        for value in ["false", "False", "n", "No", "0", ""]:
+            self.assertFalse(InputHandler.is_in_group({"g1": value}, "g1"))
+        with self.assertRaises(InvalidInput) as exc:
+            InputHandler.is_in_group({"g1": "maybe"}, "g1")
+        self.assertEqual(
+            'Invalid entry "maybe" in group column. Should be one of '
+            '"yes", "true", "x", "1", "no", "false", "0" or empty',
+            str(exc.exception))

--- a/testing/pipelines/test_annotations_functional.py
+++ b/testing/pipelines/test_annotations_functional.py
@@ -6,7 +6,7 @@ from testing.pipelines.base import BaseTestCase
 sys.path.append(os.path.join(os.path.dirname(os.path.dirname(
     os.path.dirname(os.path.abspath(__file__)))), "bin"))
 
-from annotations import InputHandler  # noqa
+from annotations import InputHandler, InvalidInput  # noqa
 
 
 class TestInputHandler(BaseTestCase):
@@ -41,21 +41,21 @@ class TestInputHandler(BaseTestCase):
 
     def test_raises_for_dupplicate_filename(self):
         input_file = StringIO("file\nfile1.gbk\nfile1.gbk")
-        with self.assertRaises(Exception) as exc:
+        with self.assertRaises(InvalidInput) as exc:
             InputHandler(input_file)
-        self.assertEqual('File file1.gbk appears twice in the input file.',
+        self.assertEqual('File "file1.gbk" appears twice in the input file.',
                          str(exc.exception))
 
     def test_raises_for_dupplicate_name(self):
         input_file = StringIO("file,name\nfile1.gbk,foo\nfile2.gbk,foo")
-        with self.assertRaises(Exception) as exc:
+        with self.assertRaises(InvalidInput) as exc:
             InputHandler(input_file)
-        self.assertEqual('Name foo appears twice in the input file.',
+        self.assertEqual('Name "foo" appears twice in the input file.',
                          str(exc.exception))
 
     def test_raises_for_invalid_column_header(self):
         input_file = StringIO("filee,name\nfile1.gbk,foo\nfile2.gbk,foo")
-        with self.assertRaises(Exception) as exc:
+        with self.assertRaises(InvalidInput) as exc:
             InputHandler(input_file)
-        self.assertEqual("Invalid column header filee in input file",
+        self.assertEqual('Invalid column header "filee" in input file.',
                          str(exc.exception))

--- a/testing/pipelines/test_db_setup.py
+++ b/testing/pipelines/test_db_setup.py
@@ -2,7 +2,7 @@ import glob
 import os
 import tempfile
 
-from testing.base import BasePipelineTestCase
+from testing.pipelines.base import BasePipelineTestCase
 
 
 class TestDBSetupPipeline(BasePipelineTestCase):

--- a/testing/webapp/test_views.py
+++ b/testing/webapp/test_views.py
@@ -370,6 +370,12 @@ class ComparisonViewsTestMixin():
                 "bonferroni_cutoff": 0.99,
                 "phenotype_file": phenotype}
 
+    @property
+    def gwas_groups_form_data(self):
+        return {"max_number_of_hits": "all",
+                "bonferroni_cutoff": 0.99,
+                "groups": ["positive"]}
+
     def test_comparison_index_view(self):
         resp = self.client.get(f"/index_comp/{self.view_type}")
         self.assertEqual(200, resp.status_code)
@@ -475,6 +481,17 @@ class ComparisonViewsTestMixin():
 
         resp = self.client.post(self.gwas_view,
                                 data=self.gwas_form_data)
+        self.assertEqual(200, resp.status_code)
+        self.assertTemplateUsed(resp, 'chlamdb/gwas.html')
+        self.assertPageTitle(resp, self.page_title)
+        # No results because there is no hit.
+        self.assertNoGwasTable(resp)
+        self.assertNav(resp)
+        self.assertContains(resp, 'id="error"')
+        self.assertContains(resp, 'No significant association')
+
+        resp = self.client.post(self.gwas_view,
+                                data=self.gwas_groups_form_data)
         self.assertEqual(200, resp.status_code)
         self.assertTemplateUsed(resp, 'chlamdb/gwas.html')
         self.assertPageTitle(resp, self.page_title)

--- a/webapp/assets/css/style_FILE_zDB.css
+++ b/webapp/assets/css/style_FILE_zDB.css
@@ -117,6 +117,17 @@
 }
 
 
+form > div.alert-block.alert-error:before {
+    content: 'Invalid input';
+    font-weight: bold;
+    font-size: 17px;
+}
+
+
+form > div.alert-block.alert-error {
+    background-color: mistyrose;
+    position: sticky;
+}
 
 
 .genome_search {

--- a/webapp/assets/css/style_FILE_zDB.css
+++ b/webapp/assets/css/style_FILE_zDB.css
@@ -130,6 +130,10 @@ form > div.alert-block.alert-error {
 }
 
 
+form div.error span.help-inline {
+    background-color: mistyrose;
+}
+
 .genome_search {
     font-family: inherit, Arial, Helvetica, sans-serif;
     font-size: 1em;

--- a/webapp/chlamdb/forms.py
+++ b/webapp/chlamdb/forms.py
@@ -1,12 +1,8 @@
 # -*- coding: utf-8 -*-
-
-import re
-
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Column, Fieldset, Layout, Row, Submit
 from django import forms
-
-choices = []
+from django.core.exceptions import ValidationError
 
 
 def get_accessions(db, all=False, plasmid=False):
@@ -476,15 +472,29 @@ def make_blast_form(biodb):
     return BlastForm
 
 
+def get_groups(db):
+    return [(el[0], el[0]) for el in db.get_groups()]
+
+
 def make_gwas_form(biodb):
-    accession_choices, rev_index = get_accessions(biodb, all=True)
+
+    group_choices = get_groups(biodb)
 
     class GwasForm(forms.Form):
 
         file_help = "CSV file containing 2 columns: taxon IDs or taxon names "\
                     "in the first column and presence (1) or absence (0) "\
                     "of the trait in the second."
-        phenotype_file = forms.FileField(help_text=file_help)
+        phenotype_file = forms.FileField(help_text=file_help, required=False)
+
+        groups = forms.MultipleChoiceField(
+            choices=group_choices,
+            widget=forms.SelectMultiple(attrs={
+                'size': '1',
+                "class": "selectpicker",
+                "data-live-search": "true",
+                "multiple data-actions-box": "true"}),
+            required=False)
 
         max_number_of_hits = forms.TypedChoiceField(
             choices=[("all", "all"),
@@ -510,6 +520,7 @@ def make_gwas_form(biodb):
                 Fieldset(
                     "",
                     Row("phenotype_file"),
+                    Row("groups", style="margin-top:1em"),
                     Row('bonferroni_cutoff', style="margin-top:1em"),
                     Row('max_number_of_hits', style="margin-top:1em"),
                     Submit('submit', 'Submit',
@@ -518,6 +529,17 @@ def make_gwas_form(biodb):
                     css_class="col-lg-5 col-md-6 col-sm-6")
             )
             super(GwasForm, self).__init__(*args, **kwargs)
+
+        def clean(self):
+            cleaned_data = super(GwasForm, self).clean()
+            self.phenotype_file_or_groups()
+            return cleaned_data
+
+        def phenotype_file_or_groups(self):
+            has_groups = bool(self.cleaned_data["groups"])
+            has_file = bool(self.cleaned_data["phenotype_file"])
+            if (has_groups and has_file) or not (has_groups or has_file):
+                raise ValidationError('You have to provide either "Groups" or "Phenotype file" but not both.')
 
     return GwasForm
 

--- a/webapp/lib/db_utils.py
+++ b/webapp/lib/db_utils.py
@@ -1453,10 +1453,29 @@ class DB:
 
     def load_filenames(self, data):
         sql = (
-            "CREATE TABLE filenames (taxon_id INTEGER, filename TEXT);"
+            "CREATE TABLE filenames (taxon_id INTEGER, filename TEXT, "
+            "PRIMARY KEY (taxon_id));"
         )
         self.server.adaptor.execute(sql)
         self.load_data_into_table("filenames", data)
+
+    def load_groups(self, groups, group_taxons):
+        sql = (
+            "CREATE TABLE groups "
+            "(group_name TINYTEXT, PRIMARY KEY (group_name));"
+        )
+        self.server.adaptor.execute(sql)
+        sql = (
+            "CREATE TABLE taxon_in_group "
+            "(group_name INT, taxon_id INT, "
+            "FOREIGN KEY (group_name) REFERENCES groups(group_name), "
+            "FOREIGN KEY (taxon_id) REFERENCES filenames(taxon_id), "
+            "PRIMARY KEY (group_name, taxon_id));"
+        )
+        self.server.adaptor.execute(sql)
+
+        self.load_data_into_table("groups", groups)
+        self.load_data_into_table("taxon_in_group", group_taxons)
 
     def load_genomes_info(self, data):
         sql = (

--- a/webapp/lib/db_utils.py
+++ b/webapp/lib/db_utils.py
@@ -1477,6 +1477,16 @@ class DB:
         self.load_data_into_table("groups", groups)
         self.load_data_into_table("taxon_in_group", group_taxons)
 
+    def get_groups(self):
+        query = "SELECT * FROM groups;"
+        return self.server.adaptor.execute_and_fetchall(query)
+
+    def get_taxids_for_groups(self, group_names):
+        plchd = self.gen_placeholder_string(group_names)
+        query = f"SELECT taxon_id from taxon_in_group WHERE group_name IN ({plchd})"
+        results = self.server.adaptor.execute_and_fetchall(query, group_names)
+        return (el[0] for el in results)
+
     def load_genomes_info(self, data):
         sql = (
             "CREATE TABLE genome_summary (taxon_id INTEGER, completeness FLOAT, "

--- a/webapp/lib/db_utils.py
+++ b/webapp/lib/db_utils.py
@@ -1483,7 +1483,8 @@ class DB:
 
     def get_taxids_for_groups(self, group_names):
         plchd = self.gen_placeholder_string(group_names)
-        query = f"SELECT taxon_id from taxon_in_group WHERE group_name IN ({plchd})"
+        query = f"SELECT DISTINCT taxon_id from taxon_in_group "\
+            f"WHERE group_name IN ({plchd})"
         results = self.server.adaptor.execute_and_fetchall(query, group_names)
         return (el[0] for el in results)
 

--- a/webapp/views/gwas.py
+++ b/webapp/views/gwas.py
@@ -11,7 +11,6 @@ from lib.ete_phylo import EteTree, MatchingColorColumn, ValueColoredColumn
 from scoary import scoary
 
 from views.analysis_view_metadata import GwasMetadata
-from views.errors import errors
 from views.mixins import (AmrViewMixin, CogViewMixin, KoViewMixin,
                           OrthogroupViewMixin, PfamViewMixin, VfViewMixin)
 from views.utils import ResultTab, TabularResultTab
@@ -71,9 +70,7 @@ class GWASBaseView(View):
     def post(self, request, *args, **kwargs):
         self.form = self.form_class(request.POST, request.FILES)
         if not self.form.is_valid():
-            self.form = self.form_class()
-            return render(request, self.template,
-                          self.get_context(**errors["invalid_form"]))
+            return render(request, self.template, self.get_context())
 
         qval_threshold = self.form.cleaned_data["bonferroni_cutoff"]
         max_genes = self.form.cleaned_data["max_number_of_hits"]
@@ -145,19 +142,26 @@ class GWASBaseView(View):
         return e_tree
 
     def get_phenotype(self):
-        phenotype = pd.read_csv(self.form.cleaned_data["phenotype_file"],
-                                header=None, names=["taxids", "trait"])
-        phenotype["trait"] = phenotype["trait"].astype(bool)
         genomes = self.db.get_genomes_description()
-        if all(phenotype.taxids.isin(genomes.index)):
+        if self.form.cleaned_data["phenotype_file"]:
+            phenotype = pd.read_csv(self.form.cleaned_data["phenotype_file"],
+                                    header=None, names=["taxids", "trait"])
+            phenotype["trait"] = phenotype["trait"].astype(bool)
+            if all(phenotype.taxids.isin(genomes.index)):
+                return phenotype
+            elif all(phenotype.taxids.isin(genomes.description)):
+                mapping = {genome.description: taxid
+                           for taxid, genome in genomes.iterrows()}
+                phenotype.taxids = phenotype.taxids.apply(lambda x: mapping[x])
+            else:
+                return None
             return phenotype
-        elif all(phenotype.taxids.isin(genomes.description)):
-            mapping = {genome.description: taxid
-                       for taxid, genome in genomes.iterrows()}
-            phenotype.taxids = phenotype.taxids.apply(lambda x: mapping[x])
         else:
-            return None
-        return phenotype
+            taxids_with_phenotype = set(self.db.get_taxids_for_groups(
+                self.form.cleaned_data["groups"]))
+            phenotype = [[taxid, 1 if taxid in taxids_with_phenotype else 0]
+                         for taxid in genomes.index]
+            return pd.DataFrame(phenotype, columns=["taxids", "trait"])
 
     def run_gwas(self, phenotype, qval_threshold, max_genes):
         genomes_data = self.db.get_genomes_infos()


### PR DESCRIPTION
With this PR we introduce the possibility of defining groups of genomes. 

For now the groups can only be defined in the input CSV file and they can only be used in the GWAS view. 

Also note that we are no longer handling errors ourselves in the GWAS view, but let django forms take care of error handling. This has the advantage that field validation errors will get displayed on that particular field in the form, whereas other form validation errors (e.g. depending on several fields) will be displayed at the top of the form, as seen in the screenshots below. I plan on refactoring all forms in the future to apply this approach.

I will continue to work on this feature in future commits, notably to enable the use of the groups in other views, add the possibility to add and edit groups and add a group details view.

![gwas_form_error](https://github.com/metagenlab/zDB/assets/7374243/00440cb4-a3ed-4a1c-8f85-a29c83915a5b)
![gwas_form_error2](https://github.com/metagenlab/zDB/assets/7374243/fc3f121b-5cfb-4475-bdd1-fe4d502d7653)


## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [x] Add tests for new features and regression tests for bugfixes whenever possible.

