### PR TITLE
Display form validation errors next to the corresponding fields.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Changed
 
+- Display form validation errors next to the corresponding fields. ([#83](https://github.com/metagenlab/zDB/pull/83)) (Niklaus Johner)
 - Filter VF hits by SeqID and coverage and keep one hit per locus. ([#77](https://github.com/metagenlab/zDB/pull/77)) (Niklaus Johner)
 - Improve layout for various views, making better use of available space. ([#70](https://github.com/metagenlab/zDB/pull/70)) (Niklaus Johner)
 - Configure repository to publish the docs to [readthedocs](https://zdb.readthedocs.io)

--- a/webapp/assets/css/style_FILE_zDB.css
+++ b/webapp/assets/css/style_FILE_zDB.css
@@ -976,10 +976,9 @@ background: #81F7F3;
 }
 
 #id_blast_input {
-    width: 300px;
-    height: 200px;
-    word-wrap: break-word;
+    width: 100%;
 }
+
 #id_motif_input {
     width: 300px;
     height: 20px;

--- a/webapp/assets/js/genomic_region.js
+++ b/webapp/assets/js/genomic_region.js
@@ -10,7 +10,7 @@
 //   	strand: either +1 or -1
 //   	locus_tag
 //   highlight: a list of locus tag to highlight in red
-function createGenomicRegion(div, div_width, svg_id, regions, connections, highlight, window_size, ident_range) {
+function createGenomicRegion(div, div_width, svg_id, regions, connections, highlight, ident_range) {
 	const text_field_size = 40;
 	const margin = { top:5, right: 5, bottom:5, left:5 };
 	const max_arrow_size = 350;

--- a/webapp/chlamdb/forms.py
+++ b/webapp/chlamdb/forms.py
@@ -377,6 +377,22 @@ def make_extract_form(db, action, plasmid=False, label="Orthologs"):
             )
 
             super(ExtractForm, self).__init__(*args, **kwargs)
+
+        def clean(self):
+            cleaned_data = super(ExtractForm, self).clean()
+            self.included_taxids, self.included_plasmids = self.get_include_choices()
+            self.excluded_taxids, self.excluded_plasmids = self.get_exclude_choices()
+            self.n_missing = self.get_n_missing()
+            self.n_included = len(self.included_taxids)
+            if self.included_plasmids is not None:
+                self.n_included += len(self.included_plasmids)
+            if self.n_missing >= self.n_included:
+                err = ValidationError(
+                    "This must be smaller than the number of included genomes.",
+                    code="invalid")
+                self.add_error("frequency", err)
+            return cleaned_data
+
     return ExtractForm
 
 

--- a/webapp/chlamdb/forms.py
+++ b/webapp/chlamdb/forms.py
@@ -488,21 +488,27 @@ def make_blast_form(biodb):
                                        "data-live-search": "true"})
             )
 
+        input_help = "This can be either an amino-acid or a nucleotide "\
+                     "sequence, or a set (one or more) of fasta sequences."
         blast_input = forms.CharField(
-            widget=forms.Textarea(attrs={'cols': 50, 'rows': 5}))
+            widget=forms.Textarea(attrs={"placeholder": input_help, "rows": 10}))
 
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.helper = FormHelper()
             self.helper.form_method = 'post'
-            self.helper.label_class = 'col-lg-4 col-md-6 col-sm-6'
-            self.helper.field_class = 'col-lg-6 col-md-6 col-sm-6'
             self.helper.layout = Layout(
                 Fieldset(
-                    Row("BLAST"),
-                    Row('target'),
-                    Row('blast_input'),
-                    css_class="col-lg-5 col-md-6 col-sm-6")
+                    "",
+                    Row(
+                        Column("blast", css_class='col-lg-4 col-md-4 col-sm-12'),
+                        Column("max_number_of_hits", css_class='col-lg-4 col-md-4 col-sm-12'),
+                        Column('target', css_class='col-lg-4 col-md-4 col-sm-12'),
+                    ),
+                    Row(Column('blast_input', css_class='col-lg-12 col-md-12 col-sm-12')),
+                    Submit('submit', 'Submit',
+                           style="padding-left:15px; margin-top:1em"),
+                    css_class="col-lg-10 col-md-10 col-sm-12")
             )
             super(BlastForm, self).__init__(*args, **kwargs)
 

--- a/webapp/chlamdb/forms.py
+++ b/webapp/chlamdb/forms.py
@@ -507,7 +507,7 @@ def make_blast_form(biodb):
                     ),
                     Row(Column('blast_input', css_class='col-lg-12 col-md-12 col-sm-12')),
                     Submit('submit', 'Submit',
-                           style="padding-left:15px; margin-top:1em"),
+                           style="padding-left:15px; margin-top:1em; margin-bottom:15px "),
                     css_class="col-lg-10 col-md-10 col-sm-12")
             )
             super(BlastForm, self).__init__(*args, **kwargs)

--- a/webapp/chlamdb/forms.py
+++ b/webapp/chlamdb/forms.py
@@ -703,7 +703,7 @@ class CustomPlotsForm(forms.Form):
             Column(
                 Row(Column(
                         "entries",
-                        css_class='form-group col-lg-6 col-md-6 col-sm-12'),
+                        css_class='form-group col-lg-12 col-md-12 col-sm-12'),
                     ),
                 Row(Submit('submit', 'Make plot'),
                     css_class='form-group col-lg-12 col-md-12 col-sm-12'),

--- a/webapp/chlamdb/forms.py
+++ b/webapp/chlamdb/forms.py
@@ -3,7 +3,7 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Column, Fieldset, Layout, Row, Submit
 from django import forms
 from django.core.exceptions import ValidationError
-from django.core.validators import MaxLengthValidator
+from django.core.validators import MaxLengthValidator, MinLengthValidator
 
 
 def get_accessions(db, all=False, plasmid=False):
@@ -167,7 +167,7 @@ def make_metabo_from(db, type_choices=None):
 
 
 def make_venn_from(db, plasmid=False, label="Orthologs", limit=None,
-                   action=""):
+                   limit_type="upper", action=""):
 
     accession_choices, rev_index = get_accessions(db, plasmid=plasmid)
 
@@ -177,13 +177,20 @@ def make_venn_from(db, plasmid=False, label="Orthologs", limit=None,
                  "data-actions-box": "true"}
         help_text = ""
         targets_validators = []
-        if limit is not None:
+        if limit is not None and limit_type == "upper":
             attrs["data-max-options"] = f"{limit}"
             help_text = f"Select a maximum of {limit} genomes"
             targets_validators.append(
                 MaxLengthValidator(
                     limit,
-                    message=f"Select a maximum of {limit} genomes")
+                    message=f"Please select at most {limit} genomes")
+            )
+        elif limit is not None and limit_type == "lower":
+            help_text = f"Select a minimum of {limit} genomes"
+            targets_validators.append(
+                MinLengthValidator(
+                    limit,
+                    message=f"Please select at least {limit} genomes")
             )
 
         targets = forms.MultipleChoiceField(

--- a/webapp/chlamdb/forms.py
+++ b/webapp/chlamdb/forms.py
@@ -111,7 +111,7 @@ def make_plot_form(db):
     return PlotForm
 
 
-def make_metabo_from(db, add_box=False, type_choices=None):
+def make_metabo_from(db, type_choices=None):
 
     accession_choices, rev_index = get_accessions(db)
 
@@ -127,10 +127,6 @@ def make_metabo_from(db, add_box=False, type_choices=None):
             required=True
         )
 
-        if add_box:
-            input_box = forms.CharField(
-                widget=forms.Textarea(attrs={'cols': 10, 'rows': 10}))
-
         if type_choices:
             comp_type = forms.ChoiceField(
                 choices=type_choices,
@@ -144,8 +140,6 @@ def make_metabo_from(db, add_box=False, type_choices=None):
             self.helper.label_class = 'col-lg-1 col-md-6 col-sm-6'
             self.helper.field_class = 'col-lg-4 col-md-6 col-sm-6'
             rows = [Row('targets')]
-            if add_box:
-                rows.append(Row('input_box'))
             if type_choices:
                 rows.append(Row('comp_type'))
 

--- a/webapp/chlamdb/forms.py
+++ b/webapp/chlamdb/forms.py
@@ -124,7 +124,7 @@ def make_metabo_from(db, add_box=False, type_choices=None):
                        "data-live-search": "true",
                        "multiple data-actions-box": "true"}
                 ),
-            required=False
+            required=True
         )
 
         if add_box:

--- a/webapp/lib/db_utils.py
+++ b/webapp/lib/db_utils.py
@@ -2631,6 +2631,28 @@ class DB:
         query = "SELECT COUNT(*) FROM (SELECT DISTINCT ko_id FROM ko_hits)"
         return self.server.adaptor.execute_and_fetchall(query)[0][0]
 
+    def check_entry_existence(self, entry_id, entry_col, table):
+        query = f'SELECT 1 FROM {table} WHERE {entry_col}="{entry_id}" LIMIT 1'
+        return bool(self.server.adaptor.execute_one(query))
+
+    def check_og_entry_id(self, entry_id):
+        return self.check_entry_existence(entry_id, "orthogroup", "og_hits")
+
+    def check_ko_entry_id(self, entry_id):
+        return self.check_entry_existence(entry_id, "ko_id", "ko_def")
+
+    def check_cog_entry_id(self, entry_id):
+        return self.check_entry_existence(entry_id, "cog_id", "cog_names")
+
+    def check_pfam_entry_id(self, entry_id):
+        return self.check_entry_existence(entry_id, "pfam_id", "pfam_table")
+
+    def check_vf_entry_id(self, entry_id):
+        return self.check_entry_existence(entry_id, "vf_gene_id", "vf_defs")
+
+    def check_amr_entry_id(self, entry_id):
+        return self.check_entry_existence(entry_id, "gene", "amr_hits")
+
     def gen_placeholder_string(self, args):
         return ",".join(self.placeholder for _ in args)
 

--- a/webapp/templates/chlamdb/blast.html
+++ b/webapp/templates/chlamdb/blast.html
@@ -153,126 +153,124 @@ margin-top: 15em;
   <div class="container-fluid" id="main_container">
     <div class="row">
       <div id="wrapper">
-          <div id="page-content-wrapper">
-            <div class="row">
-                <div class="col-lg-12">
-                  {% include "chlamdb/menu.html" %}
+        <div id="page-content-wrapper">
+          <div class="row">
+            <div class="col-lg-12">
+              {% include "chlamdb/menu.html" %}
 
-                  <p class="page-title"><b>Blast a sequence of interest against the genomes of the database </b><a href="https://zdb.readthedocs.io/en/latest/tutorial/website.html#homology-search-blast" id="show-option" target="_blank"><i class="fab fa-info-circle " style="size: 5em;" ></i></a></p>
-                  <hr class="lines-home">
-         
-                  <div class="panel panel-success">
-                      <div class="panel-heading" style="width:100%">
-                          <h3 class="panel-title">Help</h3>
-                      </div>
-                      <table class="table">
-                          <tr><td>ffn </td><td> CDS nucleotide sequences</td></tr>
-                          <tr><td>fna</td><td>genome sequence(s) </td></tr>
-                          <tr><td>faa</td><td>protein sequences </td></tr>
-                          <tr><td>blastn</td><td>dna sequence vs dna sequences database</td></tr>
-                          <tr><td>blastp</td><td>protein sequence vs protein sequences database</td></tr>
-                          <tr><td>blastx</td><td>translated dna sequence vs protein sequences database </td></tr>
-                          <tr><td>tblastn</td><td>protein sequence vs translated nucleotide sequences database</td></tr>
-                      </table>
-        </div>
+              <p class="page-title">
+                <b>Blast a sequence of interest against the genomes of the database </b>
+                <a href="https://zdb.readthedocs.io/en/latest/tutorial/website.html#homology-search-blast" id="show-option" target="_blank"><i class="fab fa-info-circle " style="size: 5em;" ></i></a>
+              </p>
+              <hr class="lines-home">
 
-
-                  {% block content %}
-                    {% csrf_token %}
-                    {% crispy form %}
-                  {% endblock %}
-
-                  {% if wrong_format %}
-            <div class="panel panel-danger" style="width:80%; top: 200px; margin: 10px 10px 10px 10px">
-              <div class="panel-heading" style="width:100%">
-                <h3 class="panel-title">{{ error_title }}</h3>
-              </div>
-              {{ error_message }}
-            </div>
-                  {% endif %}
-
-
-                  {% if envoi %}
-        <br>
-          <div class="row" style="padding-top:1em ;background-color: rgba(245, 245, 245, 0.986)" >
-                    <div class="panel panel-success" style="margin:1em;">
-                        <div class="panel-heading" style="width:100%">
-                            <h5 class="panel-title">Help to interpret the results</h5>
-                        </div>
-                        <p style="margin: 10px 10px 10px 10px">
-                            The blast search generates two output pages according to the search parameters set up in the analysis:
-                            <br><b>Details</b>: this page showa the graphical overview of blast hits identified on the genome(s) of interest colored according to the max score or E-value. Each hit is listed in the following table. It reportes the alignment scores and the contigs or locus tags of the match (Note that the locus tag is clickable and redirects you to a comphensive locus tag overview).
-              {% if phylo_distrib %}
-              <br><b>Phylogenetic distribution</b>: Heatmap of the amino-acid/nucleotide identity of the best hit for each taxa.
-              {% endif %}
-                        </p>
-                    </div>
-                    </div>
+              <div class="panel panel-success">
+                <div class="panel-heading" style="width:100%">
+                    <h3 class="panel-title">Help</h3>
                 </div>
-             {% if phylo_distrib %}
-             <br>
-              <nav>
-              <ul id="tabs_blast" class="nav nav-tabs">
-                <li class="active">
-                  <a href="#blast_details" data-toggle="tab">
-                    Details
-                  </a>
-                </li>
-                <li>
-                  <a href="#phylo_distrib" data-toggle="tab">
-                    Phylogenetic distribution
-                  </a>
-                </li>
-              </ul>
-            </nav>
-            {% endif %}
-
-
-            <div class="tab-content">
-              <div class="tab-pane active" id="blast_details">
-
-                {% if js_out %}
-                  <div id='snippetDiv'></div>
-                  <div id="blast-multiple-alignments"></div>
-                  <div id="blast-alignments-table"></div>
-                  <div id="blast-single-alignment"></div>
-                {% endif %}
-
-                {% if blast_result %}
-                  <h3>Result</h3>
-                   <div id="blast_res">
-                  {% autoescape off %}{{blast_result}}{% endautoescape %}</div>
-                {% elif blast_no_hits %}
-                  <h3>No hits</h3>
-                {% elif blast_err %}
-                  <h3>Error</h3>
-                  <pre id="blast_result">
-                   {% autoescape off %}{{blast_err}}{% endautoescape %}
-                  </pre>
-                {% endif %}
+                <table class="table">
+                  <tr><td>ffn </td><td> CDS nucleotide sequences</td></tr>
+                  <tr><td>fna</td><td>genome sequence(s) </td></tr>
+                  <tr><td>faa</td><td>protein sequences </td></tr>
+                  <tr><td>blastn</td><td>dna sequence vs dna sequences database</td></tr>
+                  <tr><td>blastp</td><td>protein sequence vs protein sequences database</td></tr>
+                  <tr><td>blastx</td><td>translated dna sequence vs protein sequences database </td></tr>
+                  <tr><td>tblastn</td><td>protein sequence vs translated nucleotide sequences database</td></tr>
+                </table>
               </div>
 
-              {% if phylo_distrib %}
-                <div class="tab-pane" id="phylo_distrib">
+              {% block content %}
+                {% csrf_token %}
+                {% crispy form %}
+              {% endblock %}
 
+              {% if wrong_format %}
+                <div class="panel panel-danger" style="width:80%; top: 200px; margin: 10px 10px 10px 10px">
+                  <div class="panel-heading" style="width:100%">
+                    <h3 class="panel-title">{{ error_title }}</h3>
+                  </div>
+                  {{ error_message }}
+                </div>
+              {% endif %}
+
+              {% if envoi %}
                 <br>
-                  <object type="image/svg+xml" data="{% static asset_path %}">
-                  </object>
+                <div class="row" style="padding-top:1em ;background-color: rgba(245, 245, 245, 0.986)" >
+                  <div class="panel panel-success" style="margin:1em;">
+                    <div class="panel-heading" style="width:100%">
+                      <h5 class="panel-title">Help to interpret the results</h5>
+                    </div>
+                    <p style="margin: 10px 10px 10px 10px">
+                      The blast search generates two output pages according to the search parameters set up in the analysis:
+                      <br><b>Details</b>: this page showa the graphical overview of blast hits identified on the genome(s) of interest colored according to the max score or E-value. Each hit is listed in the following table. It reportes the alignment scores and the contigs or locus tags of the match (Note that the locus tag is clickable and redirects you to a comphensive locus tag overview).
 
-                  <a download="profile.svg" class="btn" href="{% static asset_path %}">
-                    <i class="fa fa-download"></i> Download SVG</a>
+                      {% if phylo_distrib %}
+                        <br><b>Phylogenetic distribution</b>: Heatmap of the amino-acid/nucleotide identity of the best hit for each taxa.
+                      {% endif %}
+                    </p>
+                  </div>
+                </div>
+                {% if phylo_distrib %}
+                  <br>
+                  <nav>
+                    <ul id="tabs_blast" class="nav nav-tabs">
+                      <li class="active">
+                        <a href="#blast_details" data-toggle="tab">
+                          Details
+                        </a>
+                      </li>
+                      <li>
+                        <a href="#phylo_distrib" data-toggle="tab">
+                          Phylogenetic distribution
+                        </a>
+                      </li>
+                    </ul>
+                  </nav>
+                {% endif %}
+
+                <div class="tab-content">
+                  <div class="tab-pane active" id="blast_details">
+
+                    {% if js_out %}
+                      <div id='snippetDiv'></div>
+                      <div id="blast-multiple-alignments"></div>
+                      <div id="blast-alignments-table"></div>
+                      <div id="blast-single-alignment"></div>
+                    {% endif %}
+
+                    {% if blast_result %}
+                      <h3>Result</h3>
+                      <div id="blast_res">
+                        {% autoescape off %}{{blast_result}}{% endautoescape %}
+                      </div>
+                    {% elif blast_no_hits %}
+                      <h3>No hits</h3>
+                    {% elif blast_err %}
+                      <h3>Error</h3>
+                      <pre id="blast_result">
+                        {% autoescape off %}{{blast_err}}{% endautoescape %}
+                      </pre>
+                    {% endif %}
+                  </div>
+
+                  {% if phylo_distrib %}
+                    <div class="tab-pane" id="phylo_distrib">
+                      <br>
+                      <object type="image/svg+xml" data="{% static asset_path %}"></object>
+
+                      <a download="profile.svg" class="btn" href="{% static asset_path %}">
+                        <i class="fa fa-download"></i> Download SVG
+                      </a>
+                    </div>
+                  {% endif %}
                 </div>
               {% endif %}
-            </div>
-
-
-                  {% endif %}
-                  
-                </div>
-              </div>
             </div>
           </div>
         </div>
+      </div>
+    </div>
+  </div>
 </body>
 
 <script>

--- a/webapp/templates/chlamdb/blast.html
+++ b/webapp/templates/chlamdb/blast.html
@@ -154,8 +154,8 @@ margin-top: 15em;
     <div class="row">
       <div id="wrapper">
         <div id="page-content-wrapper">
-          <div class="row">
-            <div class="col-lg-12">
+          <div class="col-lg-12">
+            <div class="row">
               {% include "chlamdb/menu.html" %}
 
               <p class="page-title">
@@ -183,89 +183,79 @@ margin-top: 15em;
                 {% csrf_token %}
                 {% crispy form %}
               {% endblock %}
-
-              {% if wrong_format %}
-                <div class="panel panel-danger" style="width:80%; top: 200px; margin: 10px 10px 10px 10px">
-                  <div class="panel-heading" style="width:100%">
-                    <h3 class="panel-title">{{ error_title }}</h3>
-                  </div>
-                  {{ error_message }}
-                </div>
-              {% endif %}
-
-              {% if envoi %}
-                <br>
-                <div class="row" style="padding-top:1em ;background-color: rgba(245, 245, 245, 0.986)" >
-                  <div class="panel panel-success" style="margin:1em;">
-                    <div class="panel-heading" style="width:100%">
-                      <h5 class="panel-title">Help to interpret the results</h5>
-                    </div>
-                    <p style="margin: 10px 10px 10px 10px">
-                      The blast search generates two output pages according to the search parameters set up in the analysis:
-                      <br><b>Details</b>: this page showa the graphical overview of blast hits identified on the genome(s) of interest colored according to the max score or E-value. Each hit is listed in the following table. It reportes the alignment scores and the contigs or locus tags of the match (Note that the locus tag is clickable and redirects you to a comphensive locus tag overview).
-
-                      {% if phylo_distrib %}
-                        <br><b>Phylogenetic distribution</b>: Heatmap of the amino-acid/nucleotide identity of the best hit for each taxa.
-                      {% endif %}
-                    </p>
-                  </div>
-                </div>
-                {% if phylo_distrib %}
-                  <br>
-                  <nav>
-                    <ul id="tabs_blast" class="nav nav-tabs">
-                      <li class="active">
-                        <a href="#blast_details" data-toggle="tab">
-                          Details
-                        </a>
-                      </li>
-                      <li>
-                        <a href="#phylo_distrib" data-toggle="tab">
-                          Phylogenetic distribution
-                        </a>
-                      </li>
-                    </ul>
-                  </nav>
-                {% endif %}
-
-                <div class="tab-content">
-                  <div class="tab-pane active" id="blast_details">
-
-                    {% if js_out %}
-                      <div id='snippetDiv'></div>
-                      <div id="blast-multiple-alignments"></div>
-                      <div id="blast-alignments-table"></div>
-                      <div id="blast-single-alignment"></div>
-                    {% endif %}
-
-                    {% if blast_result %}
-                      <h3>Result</h3>
-                      <div id="blast_res">
-                        {% autoescape off %}{{blast_result}}{% endautoescape %}
-                      </div>
-                    {% elif blast_no_hits %}
-                      <h3>No hits</h3>
-                    {% elif blast_err %}
-                      <h3>Error</h3>
-                      <pre id="blast_result">
-                        {% autoescape off %}{{blast_err}}{% endautoescape %}
-                      </pre>
-                    {% endif %}
-                  </div>
-
-                  {% if phylo_distrib %}
-                    <div class="tab-pane" id="phylo_distrib">
-                      <br>
-                      <object type="image/svg+xml" data="{% static asset_path %}"></object>
-
-                      <a download="profile.svg" class="btn" href="{% static asset_path %}">
-                        <i class="fa fa-download"></i> Download SVG
-                      </a>
-                    </div>
-                  {% endif %}
-                </div>
-              {% endif %}
             </div>
+            {% if envoi %}
+              <div class="row" style="background-color: rgba(245, 245, 245, 0.986)">
+                <div class="panel panel-success" style="margin:1em;">
+                  <div class="panel-heading" style="width:100%">
+                    <h5 class="panel-title">Help to interpret the results</h5>
+                  </div>
+                  <p style="margin: 10px 10px 10px 10px">
+                    The blast search generates two output pages according to the search parameters set up in the analysis:
+                    <br><b>Details</b>: this page showa the graphical overview of blast hits identified on the genome(s) of interest colored according to the max score or E-value. Each hit is listed in the following table. It reportes the alignment scores and the contigs or locus tags of the match (Note that the locus tag is clickable and redirects you to a comphensive locus tag overview).
+
+                    {% if phylo_distrib %}
+                      <br><b>Phylogenetic distribution</b>: Heatmap of the amino-acid/nucleotide identity of the best hit for each taxa.
+                    {% endif %}
+                  </p>
+                </div>
+                <div class="col-lg-12">
+                  {% if phylo_distrib %}
+                    <nav>
+                      <ul id="tabs_blast" class="nav nav-tabs">
+                        <li class="active">
+                          <a href="#blast_details" data-toggle="tab">
+                            Details
+                          </a>
+                        </li>
+                        <li>
+                          <a href="#phylo_distrib" data-toggle="tab">
+                            Phylogenetic distribution
+                          </a>
+                        </li>
+                      </ul>
+                    </nav>
+                  {% endif %}
+
+                  <div class="tab-content">
+                    <div class="tab-pane active" id="blast_details">
+
+                      {% if js_out %}
+                        <div id='snippetDiv'></div>
+                        <div id="blast-multiple-alignments"></div>
+                        <div id="blast-alignments-table"></div>
+                        <div id="blast-single-alignment"></div>
+                      {% endif %}
+
+                      {% if blast_result %}
+                        <h3>Result</h3>
+                        <div id="blast_res">
+                          {% autoescape off %}{{blast_result}}{% endautoescape %}
+                        </div>
+                      {% elif blast_no_hits %}
+                        <h3>No hits</h3>
+                      {% elif blast_err %}
+                        <h3>Error</h3>
+                        <pre id="blast_result">
+                          {% autoescape off %}{{blast_err}}{% endautoescape %}
+                        </pre>
+                      {% endif %}
+                    </div>
+
+                    {% if phylo_distrib %}
+                      <div class="tab-pane" id="phylo_distrib">
+                        <br>
+                        <object type="image/svg+xml" data="{% static asset_path %}"></object>
+
+                        <a download="profile.svg" class="btn" href="{% static asset_path %}">
+                          <i class="fa fa-download"></i> Download SVG
+                        </a>
+                      </div>
+                    {% endif %}
+                  </div>
+                </div>
+              </div>
+            {% endif %}
           </div>
         </div>
       </div>

--- a/webapp/templates/chlamdb/blast.html
+++ b/webapp/templates/chlamdb/blast.html
@@ -144,6 +144,8 @@ margin-top: 15em;
 <script type="text/javascript" src="{% static 'js/blaster.min.js' %}"></script>
 
 {% include "chlamdb/header.html" %}
+{% load crispy_forms_tags %}
+
 </head>
 
 <body>
@@ -175,17 +177,10 @@ margin-top: 15em;
         </div>
 
 
-
-      <div class="alert alert-info fade in" style="width:80%;  margin: 10px 10px 10px 10px">
-        <a href="#" class="close" data-dismiss="alert">&times;</a>
-        <strong>Note!</strong>  The blast input can be either an amino-acid or a nucleotide sequence, or a set (one or more) of fasta sequences.
-      </div>
-
-                  <form action="{% url "blast" %}" method="post">{% csrf_token %}
-                    {{ form.as_p }}
-                    <input type="submit" value="Submit" />
-                  </form>
-
+                  {% block content %}
+                    {% csrf_token %}
+                    {% crispy form %}
+                  {% endblock %}
 
                   {% if wrong_format %}
             <div class="panel panel-danger" style="width:80%; top: 200px; margin: 10px 10px 10px 10px">

--- a/webapp/templates/chlamdb/plot_region.html
+++ b/webapp/templates/chlamdb/plot_region.html
@@ -109,14 +109,13 @@
 var regions = {{genomic_regions|safe}};
 var to_highlight = {{to_highlight|safe}};
 var connections = {{connections | safe}};
-var window_size = {{window_size}};
 var ident_range = [{{min_ident}}, {{max_ident}}];
 var genomic_region_rect = document.querySelector("#div_alignment_bounding")
     .getBoundingClientRect();
 var genomic_width = genomic_region_rect.right-genomic_region_rect.left;
 
 createGenomicRegion(d3.select("#div_alignment"), genomic_width*0.95, "genomic_region",
-    regions, connections, to_highlight, window_size, ident_range);
+    regions, connections, to_highlight, ident_range);
 
 document.querySelector("#download_svg_button").onclick = function() {
   var svg_elem = document.querySelector("#genomic_region");

--- a/webapp/views/custom_plots.py
+++ b/webapp/views/custom_plots.py
@@ -6,10 +6,9 @@ from ete3 import Tree
 from lib.db_utils import DB
 from lib.ete_phylo import EteTree, SimpleColorColumn
 
-from views.errors import errors
 from views.mixins import ComparisonViewMixin
 from views.object_type_metadata import my_locals
-from views.utils import EntryIdIdentifier, ResultTab, TabularResultTab
+from views.utils import ResultTab, TabularResultTab
 
 
 class CusomPlotsView(View):
@@ -52,27 +51,25 @@ class CusomPlotsView(View):
         return my_locals(context)
 
     def get(self, request, *args, **kwargs):
-        self.form = self.form_class()
+        self.form = self.form_class(self.db)
         return render(request, self.template, self.get_context())
 
     def post(self, request, *args, **kwargs):
-        self.form = self.form_class(request.POST)
+        self.form = self.form_class(self.db, request.POST)
         if not self.form.is_valid():
             return render(request, self.template, self.get_context())
 
-        entries, entry2label = self.form.get_entries()
+        entries = self.form.cleaned_data["entries"]
 
         # We make 1 query for each entry, although we could of course make
         # a single query for each object type, but I don't expect any
         # performance issues here, so I'd rather keep it simple (and maintain
         # the order of the entries as defined by the user).
-        entry_id_identifier = EntryIdIdentifier()
         counts = []
         for entry in entries:
-            object_type, entry_id = entry_id_identifier.id_to_object_type(entry)
-            mixin = ComparisonViewMixin.type2mixin[object_type]
-            hits = mixin().get_hit_counts([entry_id], search_on=object_type)
-            hits = hits.rename({entry_id: entry2label.get(entry, entry)})
+            mixin = ComparisonViewMixin.type2mixin[entry.type]
+            hits = mixin().get_hit_counts([entry.id], search_on=entry.type)
+            hits = hits.rename({entry.id: entry.label})
             counts.append(hits)
 
         genome_descriptions = self.db.get_genomes_description()

--- a/webapp/views/custom_plots.py
+++ b/webapp/views/custom_plots.py
@@ -58,9 +58,7 @@ class CusomPlotsView(View):
     def post(self, request, *args, **kwargs):
         self.form = self.form_class(request.POST)
         if not self.form.is_valid():
-            self.form = self.form_class()
-            return render(request, self.template,
-                          self.get_context(**errors["invalid_form"]))
+            return render(request, self.template, self.get_context())
 
         entries, entry2label = self.form.get_entries()
 

--- a/webapp/views/errors.py
+++ b/webapp/views/errors.py
@@ -5,24 +5,14 @@ errors = {
         "error_title": "Empty result set.",
         "error_message":  "No hits were found for the current selection."
     },
-    "invalid_form": {
-        "error": True,
-        "error_title": "Invalid input.",
-        "error_message":  "Form data is invalid."
-    },
-    "generic_error": {
-        "error": True,
-        "error_title": "Error.",
-        "error_message":  "Something went wrong."
-    },
     "no_module_info": {
         "error": True,
         "error_title": "No information.",
         "error_message":  "No information was found for this module."
     },
-    "too_many_targets": {
+    "unknown_accession": {
         "error": True,
-        "error_title": "Invalid form.",
-        "error_message":  "Venn diagrams are limited to 6 genomes."
-    }
+        "error_title": "Unknown accession.",
+        "error_message":  "Accepts protein ids, locus tags and orthogroup IDs."
+    },
 }

--- a/webapp/views/errors.py
+++ b/webapp/views/errors.py
@@ -20,12 +20,6 @@ errors = {
         "error_title": "No information.",
         "error_message":  "No information was found for this module."
     },
-    "wrong_n_missing": {
-        "error": True,
-        "error_title": "Invalid form.",
-        "error_message":  "You cannot set a number of missing data bigger "\
-                          "than the number of included genomes"
-    },
     "too_many_targets": {
         "error": True,
         "error_title": "Invalid form.",

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -283,7 +283,7 @@ class TabularResultTab(ResultTab):
             tabid, title, template, show_badge=show_badge, badge=badge, **kwargs)
 
 
-class EntryIdIdentifier():
+class EntryIdParser():
 
     og_re = re.compile("group_([0-9]*)")
     cog_re = re.compile("COG([0-9]{4})")
@@ -291,27 +291,38 @@ class EntryIdIdentifier():
     ko_re = re.compile("K([0-9]{5})")
     vf_re = re.compile("VFG[0-9]{6}")
 
+    def __init__(self, db):
+        self.db = db
+
     def id_to_object_type(self, identifier):
         match = self.og_re.match(identifier)
-        if match:
-            return "orthogroup", int(match.groups()[0])
+        parsed_id = match and int(match.groups()[0])
+        if parsed_id and self.db.check_orthogroup_entry_id(parsed_id):
+            return "orthogroup", parsed_id
 
         match = self.cog_re.match(identifier)
-        if match:
-            return "cog", int(match.groups()[0])
+        parsed_id = match and int(match.groups()[0])
+        if parsed_id and self.db.check_cog_entry_id(parsed_id):
+            return "cog", parsed_id
 
         match = self.pfam_re.match(identifier)
-        if match:
-            return "pfam", int(match.groups()[0])
+        parsed_id = match and int(match.groups()[0])
+        if parsed_id and self.db.check_pfam_entry_id(parsed_id):
+            return "pfam", parsed_id
 
         match = self.ko_re.match(identifier)
-        if match:
-            return "ko", int(match.groups()[0])
+        parsed_id = match and int(match.groups()[0])
+        if parsed_id and self.db.check_ko_entry_id(parsed_id):
+            return "ko", parsed_id
 
         match = self.vf_re.match(identifier)
-        if match:
+        if match and self.db.check_vf_entry_id(identifier):
             return "vf", identifier
-        return "amr", identifier
+
+        if self.db.check_amr_entry_id(identifier):
+            return "amr", identifier
+
+        return None
 
 
 def locusx_genomic_region(db, seqid, window):

--- a/webapp/views/venn.py
+++ b/webapp/views/venn.py
@@ -51,15 +51,9 @@ class VennBaseView(View):
     def post(self, request, *args, **kwargs):
         self.form = self.form_class(request.POST)
         if not self.form.is_valid():
-            self.form = self.form_class()
-            return render(request, self.template,
-                          self.get_context(**errors["invalid_form"]))
+            return render(request, self.template, self.get_context())
 
         self.targets = self.form.get_taxids()
-        if len(self.targets) > 6:
-            self.form = self.form_class()
-            return render(request, self.template,
-                          self.get_context(**errors["too_many_targets"]))
         return self.render_venn(request)
 
     def render_venn(self, request):

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -858,7 +858,7 @@ class CogBarchart(CogViewMixin, View):
         self.form = self.form_class(request.POST)
         if not self.form.is_valid():
             return render(request, 'chlamdb/cog_barplot.html',
-                          self.get_context(**errors["invalid_form"]))
+                          self.get_context())
 
         target_bioentries = self.form.get_taxids()
 

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -937,6 +937,7 @@ class PanGenome(ComparisonViewMixin, View):
     @property
     def form_class(self):
         return make_venn_from(self.db, label=self.object_name_plural,
+                              limit=2, limit_type="lower",
                               action=f"/pan_genome/{self.object_type}")
 
     def get(self, request, *args, **kwargs):
@@ -947,10 +948,8 @@ class PanGenome(ComparisonViewMixin, View):
     def post(self, request, *args, **kwargs):
         self.form = self.form_class(request.POST)
         if not self.form.is_valid():
-            self.form = self.form_class()
             return render(request, 'chlamdb/pan_genome.html',
-                          self.get_context(**errors["invalid_form"],
-                                           form=self.form))
+                          self.get_context(form=self.form))
 
         taxids = self.form.get_taxids()
         df_hits = self.get_hit_counts(taxids, search_on="taxid")

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -1512,8 +1512,6 @@ def circos(request):
         form = circos_form_class()
 
     local_vars = my_locals(locals())
-    # local_vars["form"] = form
-
     return render(request, 'chlamdb/circos.html', local_vars)
 
 
@@ -1612,7 +1610,6 @@ def kegg_genomes(request):
 
     form = single_genome_form(request.POST)
     if not form.is_valid():
-        form = single_genome_form()
         return render(request, 'chlamdb/kegg_genomes.html',
                       my_locals(locals()))
 
@@ -1660,7 +1657,6 @@ def kegg_genomes_modules(request):
 
     form = single_genome_form(request.POST)
     if not form.is_valid():
-        form = single_genome_form()
         return render(request, 'chlamdb/kegg_genomes_modules.html',
                       my_locals(locals()))
 
@@ -1737,10 +1733,8 @@ def kegg_module_subcat(request):
 
     form = module_overview_form(request.POST)
     if not form.is_valid():
-        form = module_overview_form()
-        context = my_locals(locals())
-        context.update(errors["invalid_form"])
-        return render(request, 'chlamdb/module_subcat.html', context)
+        return render(request, 'chlamdb/module_subcat.html',
+                      my_locals(locals()))
 
     cat = form.cleaned_data["subcategory"]
     ko_count_subcat = db.get_ko_count_cat(subcategory=cat)
@@ -1810,10 +1804,8 @@ def kegg_module(request):
 
     form = module_overview_form(request.POST)
     if not form.is_valid():
-        context = my_locals(locals())
-        context.update(errors["invalid_form"])
-        form = module_overview_form()
-        return render(request, 'chlamdb/module_overview.html', context)
+        return render(request, 'chlamdb/module_overview.html',
+                      my_locals(locals()))
 
     cat = form.cleaned_data["category"]
     modules_infos = db.get_modules_info(ids=[cat], search_on="category")
@@ -1880,14 +1872,9 @@ def module_comparison(request):
 
     form = comp_metabo_form(request.POST)
     if not form.is_valid():
-        form = comp_metabo_form()
         return render(request, 'chlamdb/module_comp.html', my_locals(locals()))
 
     taxids = form.get_choices()
-
-    if len(taxids) == 0:
-        form = comp_metabo_form()
-        return render(request, 'chlamdb/module_comp.html', my_locals(locals()))
 
     module_hits = db.get_ko_count_cat(taxon_ids=taxids)
     tipo = type(taxids)

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -457,9 +457,8 @@ def KEGG_module_map(request, module_name):
     try:
         module_id = int(module_name[len("M"):])
     except Exception:
-        error = True
-        error_title = "Unknown accession"
-        error_message = "Accepts protein ids, locus tags and orthogroup IDs"
+        context = my_locals(locals())
+        context.update(errors["unknown_accession"])
         return render(request, 'chlamdb/KEGG_module_map.html',
                       my_locals(locals()))
 


### PR DESCRIPTION
Instead of doing custom error handling in the forms, we now use the default django forms behavior. This is much better as the errors get displayed next to the corresponding fields whenever possible, i.e. when validation fails for a specific field, the error will get displayed there, for other errors, we end up with an error message in a banner above the form, as we had before. See screenshot below and screenshots in https://github.com/metagenlab/zDB/pull/82 for more examples.

We also add more error handling for the custom plots view and improve the blast view notably by displaying the help as to what is expected in the "blast input" field as a placeholder in the `TextArea` widget.

![venn_error](https://github.com/metagenlab/zDB/assets/7374243/2ef7c225-43a4-4ba8-a7c8-b4a50f89f9b5)


## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

