### PR TITLE
Handle groups when selecting genomes wherever pertinent.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Changed
 
-- Handle groups in hit extraction view. ([#84](https://github.com/metagenlab/zDB/pull/84)) (Niklaus Johner)
+- Handle groups when selecting genomes wherever pertinent. ([#84](https://github.com/metagenlab/zDB/pull/84) and [#85](https://github.com/metagenlab/zDB/pull/85)) (Niklaus Johner)
 - Allow using groups to define phenotype in GWAS view. ([#82](https://github.com/metagenlab/zDB/pull/82)) (Niklaus Johner)
 - Display form validation errors next to the corresponding fields. ([#83](https://github.com/metagenlab/zDB/pull/83)) (Niklaus Johner)
 - Filter VF hits by SeqID and coverage and keep one hit per locus. ([#77](https://github.com/metagenlab/zDB/pull/77)) (Niklaus Johner)

--- a/testing/webapp/test_views.py
+++ b/testing/webapp/test_views.py
@@ -223,7 +223,7 @@ class TestViewsContent(SimpleTestCase):
         self.assertNoPlot(resp)
         self.assertContains(resp, "Barcharts of COG entries categories in selected genomes")
 
-        resp = self.client.post("/cog_barchart/", data={"targets": ["0", "1"]})
+        resp = self.client.post("/cog_barchart/", data={"targets": ["1", "2"]})
         self.assertEqual(200, resp.status_code)
         self.assertTemplateUsed(resp, 'chlamdb/cog_barplot.html')
         self.assertTitle(resp, "Comparisons: Clusters of Orthologous groups (COGs)")
@@ -279,9 +279,8 @@ class TestViewsContent(SimpleTestCase):
 class ComparisonViewsTestMixin():
 
     selection_html = """
-        <option value="0" {0}>Klebsiella pneumoniae R6724_16313</option>
-        <option value="1" {0}>Klebsiella pneumoniae R6726_16314</option>
-        <option value="2">Klebsiella pneumoniae R6728_16315</option>
+        <option value="1" selected="">Klebsiella pneumoniae R6724_16313</option>
+        <option value="2" selected="">Klebsiella pneumoniae R6726_16314</option>
         """
 
     table_html = '<table class="hover" id="mytable"  style="padding-top: 1em;">'
@@ -305,10 +304,8 @@ class ComparisonViewsTestMixin():
         self.assertTrue(resp.context.get("show_comparison_table", False))
         self.assertContains(resp, self.table_html)
 
-    def assertSelection(self, resp, selected=False):
-        expected = self.selection_html.format(
-            'selected=""' if selected else '')
-        self.assertContains(resp, expected, html=True)
+    def assertSelection(self, resp):
+        self.assertContains(resp, self.selection_html, html=True)
 
     def assertNoVennDiagram(self, resp):
         self.assertFalse(resp.context.get("show_results", False))
@@ -350,7 +347,7 @@ class ComparisonViewsTestMixin():
 
     @property
     def tab_comp_form_data_list(self):
-        return [{"targets": ["0", "1"]}]
+        return [{"targets": ["1", "2"]}]
 
     @property
     def venn_view(self):
@@ -358,7 +355,7 @@ class ComparisonViewsTestMixin():
 
     @property
     def venn_form_data(self):
-        return {"targets": ["0", "1"]}
+        return {"targets": ["1", "2"]}
 
     @property
     def heatmap_view(self):
@@ -366,7 +363,7 @@ class ComparisonViewsTestMixin():
 
     @property
     def heatmap_form_data(self):
-        return {"targets": ["0", "1"]}
+        return {"targets": ["1", "2"]}
 
     @property
     def gwas_view(self):
@@ -406,7 +403,6 @@ class ComparisonViewsTestMixin():
         self.assertEqual(200, resp.status_code)
         self.assertTemplateUsed(resp, 'chlamdb/tabular_comparison.html')
         self.assertPageTitle(resp, self.page_title)
-        self.assertSelection(resp)
         self.assertNoCompTable(resp)
         self.assertNav(resp)
 
@@ -416,7 +412,7 @@ class ComparisonViewsTestMixin():
             self.assertEqual(200, resp.status_code)
             self.assertTemplateUsed(resp, 'chlamdb/tabular_comparison.html')
             self.assertPageTitle(resp, self.page_title)
-            self.assertSelection(resp, selected=True)
+            self.assertSelection(resp)
             self.assertCompTable(resp)
             self.assertNav(resp)
 
@@ -427,7 +423,6 @@ class ComparisonViewsTestMixin():
         self.assertEqual(200, resp.status_code)
         self.assertTemplateUsed(resp, 'chlamdb/venn_generic.html')
         self.assertPageTitle(resp, self.page_title)
-        self.assertSelection(resp)
         self.assertNoVennDiagram(resp)
         self.assertNav(resp)
 
@@ -436,7 +431,7 @@ class ComparisonViewsTestMixin():
         self.assertEqual(200, resp.status_code)
         self.assertTemplateUsed(resp, 'chlamdb/venn_generic.html')
         self.assertPageTitle(resp, self.page_title)
-        self.assertSelection(resp, selected=True)
+        self.assertSelection(resp)
         self.assertVennDiagram(resp)
         self.assertNav(resp)
 
@@ -447,7 +442,6 @@ class ComparisonViewsTestMixin():
         self.assertEqual(200, resp.status_code)
         self.assertTemplateUsed(resp, 'chlamdb/plot_heatmap.html')
         self.assertPageTitle(resp, self.page_title)
-        self.assertSelection(resp)
         self.assertNoHeatmap(resp)
         self.assertNav(resp)
 
@@ -456,7 +450,7 @@ class ComparisonViewsTestMixin():
         self.assertEqual(200, resp.status_code)
         self.assertTemplateUsed(resp, 'chlamdb/plot_heatmap.html')
         self.assertPageTitle(resp, self.page_title)
-        self.assertSelection(resp, selected=True)
+        self.assertSelection(resp)
         self.assertHeatmap(resp)
         self.assertNav(resp)
 
@@ -471,7 +465,7 @@ class ComparisonViewsTestMixin():
         self.assertNoRarefactionPlot(resp)
 
         resp = self.client.post(f"/pan_genome/{self.view_type}",
-                                data={"targets": ["0", "1"]})
+                                data={"targets": ["1", "2"]})
         self.assertEqual(200, resp.status_code)
         self.assertTemplateUsed(resp, 'chlamdb/pan_genome.html')
         self.assertEqual(self.view_type, resp.context["object_type"])
@@ -533,7 +527,6 @@ class TestKOViews(SimpleTestCase, ComparisonViewsTestMixin):
         self.assertEqual(200, resp.status_code)
         self.assertTemplateUsed(resp, 'chlamdb/venn_generic.html')
         self.assertPageTitle(resp, self.page_title)
-        self.assertSelection(resp)
         self.assertVennDiagram(resp)
         self.assertNav(resp)
 
@@ -551,7 +544,6 @@ class TestCOGViews(SimpleTestCase, ComparisonViewsTestMixin):
         self.assertEqual(200, resp.status_code)
         self.assertTemplateUsed(resp, 'chlamdb/venn_generic.html')
         self.assertPageTitle(resp, self.page_title)
-        self.assertSelection(resp)
         self.assertVennDiagram(resp)
         self.assertNav(resp)
 
@@ -568,9 +560,9 @@ class TestAMRViews(SimpleTestCase, ComparisonViewsTestMixin):
         """Tests for class and subclass are not worth much as none
         of the AMRs in the DB have a class or subclass...
         """
-        return [{"targets": ["0", "1"], "comp_type": "gene"},
-                {"targets": ["0", "1"], "comp_type": "class"},
-                {"targets": ["0", "1"], "comp_type": "subclass"}]
+        return [{"targets": ["1", "2"], "comp_type": "gene"},
+                {"targets": ["1", "2"], "comp_type": "class"},
+                {"targets": ["1", "2"], "comp_type": "subclass"}]
 
     @skip("Heatmap plot fails because the test data does not provide enough hits")
     def test_plot_heatmap_view(self):
@@ -584,9 +576,9 @@ class TestVFViews(SimpleTestCase, ComparisonViewsTestMixin):
 
     @property
     def tab_comp_form_data_list(self):
-        return [{"targets": ["0", "1"], "comp_type": "vf_gene_id"},
-                {"targets": ["0", "1"], "comp_type": "vfid"},
-                {"targets": ["0", "1"], "comp_type": "category"},]
+        return [{"targets": ["1", "2"], "comp_type": "vf_gene_id"},
+                {"targets": ["1", "2"], "comp_type": "vfid"},
+                {"targets": ["1", "2"], "comp_type": "category"},]
 
 
 class TestOrthogroupViews(SimpleTestCase, ComparisonViewsTestMixin):

--- a/webapp/chlamdb/forms.py
+++ b/webapp/chlamdb/forms.py
@@ -459,7 +459,8 @@ def make_pathway_overview_form(db):
 
 
 def make_single_genome_form(db):
-    accession_choices, rev_index = get_accessions(db)
+    accession_choices = AccessionFieldHandler().get_choices(
+        with_plasmids=False, with_groups=False)
 
     class SingleGenomeForm(forms.Form):
         genome = forms.ChoiceField(choices=accession_choices, widget=forms.Select(
@@ -467,7 +468,9 @@ def make_single_genome_form(db):
 
         def get_genome(self):
             target = self.cleaned_data["genome"]
-            return rev_index[int(target)]
+            taxids, plasmids = AccessionFieldHandler().extract_choices(
+                [target], False)
+            return taxids[0]
 
     return SingleGenomeForm
 

--- a/webapp/chlamdb/forms.py
+++ b/webapp/chlamdb/forms.py
@@ -279,9 +279,7 @@ def make_circos_form(database_name):
 
         def get_ref_taxid(self):
             index = self.cleaned_data["circos_reference"]
-            taxids, plasmids = AccessionFieldHandler().extract_choices(
-                [index], False)
-            return taxids[0]
+            return AccessionFieldHandler().extract_taxid(index)
 
     return CircosForm
 
@@ -442,9 +440,7 @@ def make_single_genome_form(db):
 
         def get_genome(self):
             target = self.cleaned_data["genome"]
-            taxids, plasmids = AccessionFieldHandler().extract_choices(
-                [target], False)
-            return taxids[0]
+            return AccessionFieldHandler().extract_taxid(target)
 
     return SingleGenomeForm
 
@@ -553,9 +549,7 @@ def make_blast_form(biodb):
             target = self.cleaned_data["target"]
             if target == "all":
                 return target
-            taxids, plasmids = AccessionFieldHandler().extract_choices(
-                [target], False)
-            return taxids[0]
+            return AccessionFieldHandler().extract_taxid(target)
 
     return BlastForm
 

--- a/webapp/chlamdb/forms.py
+++ b/webapp/chlamdb/forms.py
@@ -135,16 +135,16 @@ def make_plot_form(db):
 
 def make_metabo_from(db, type_choices=None):
 
-    accession_choices, rev_index = get_accessions(db)
+    accession_choices = AccessionFieldHandler().get_choices(with_plasmids=False)
 
     class MetaboForm(forms.Form):
         targets = forms.MultipleChoiceField(
             choices=accession_choices,
-            widget=forms.SelectMultiple(
-                attrs={'size': '%s' % (20),
-                       "class": "selectpicker",
-                       "data-live-search": "true",
-                       "multiple data-actions-box": "true"}
+            widget=Select2Multiple(
+                url="autocomplete_taxid",
+                forward=(forward.Field("targets", "exclude_taxids_in_groups"),),
+                attrs={"data-close-on-select": "false",
+                       "data-placeholder": "Nothing selected"}
                 ),
             required=True
         )
@@ -166,7 +166,6 @@ def make_metabo_from(db, type_choices=None):
                 rows.append(Row('comp_type'))
 
             self.helper.layout = Layout(
-
                 Fieldset("",
                          Column(
                              *rows,
@@ -179,10 +178,8 @@ def make_metabo_from(db, type_choices=None):
 
         def get_choices(self):
             targets = self.cleaned_data["targets"]
-            taxids = []
-            for index in targets:
-                taxid = rev_index[int(index)]
-                taxids.append(taxid)
+            taxids, plasmids = AccessionFieldHandler().extract_choices(
+                targets, False)
             return taxids
 
     return MetaboForm

--- a/webapp/chlamdb/forms.py
+++ b/webapp/chlamdb/forms.py
@@ -14,32 +14,6 @@ from django.core.exceptions import ValidationError
 from views.utils import AccessionFieldHandler, EntryIdParser
 
 
-def get_accessions(db, all=False, plasmid=False):
-    result = db.get_genomes_description()
-    accession_choices = []
-    index = 0
-    reverse_index = []
-
-    # cannot use taxid because plasmids have the same
-    # taxids as the chromosome
-    for taxid, data in result.iterrows():
-        accession_choices.append((index, data.description))
-        index += 1
-
-        if plasmid:
-            reverse_index.append((taxid, False))
-        else:
-            reverse_index.append(taxid)
-        if plasmid and data.has_plasmid == 1:
-            accession_choices.append((index, data.description + " plasmid"))
-            reverse_index.append((taxid, True))
-            index += 1
-
-    if all:
-        accession_choices = [["all", "all"]] + accession_choices
-    return accession_choices, reverse_index
-
-
 def make_plot_form(db):
     import pandas as pd
     accession_choices = AccessionFieldHandler().get_choices(with_plasmids=False)

--- a/webapp/chlamdb/forms.py
+++ b/webapp/chlamdb/forms.py
@@ -476,7 +476,9 @@ def make_single_genome_form(db):
 
 
 def make_blast_form(biodb):
-    accession_choices, rev_index = get_accessions(biodb, all=True)
+    accession_choices = AccessionFieldHandler().get_choices(
+        with_plasmids=False, with_groups=False)
+    accession_choices = (("all", "all"),) + accession_choices
 
     class BlastForm(forms.Form):
         DEFAULT_E_VALUE = 10
@@ -577,7 +579,9 @@ def make_blast_form(biodb):
             target = self.cleaned_data["target"]
             if target == "all":
                 return target
-            return rev_index[int(target)]
+            taxids, plasmids = AccessionFieldHandler().extract_choices(
+                [target], False)
+            return taxids[0]
 
     return BlastForm
 

--- a/webapp/chlamdb/forms.py
+++ b/webapp/chlamdb/forms.py
@@ -188,10 +188,10 @@ def make_metabo_from(db, type_choices=None):
     return MetaboForm
 
 
-def make_venn_from(db, plasmid=False, label="Orthologs", limit=None,
+def make_venn_from(db, label="Orthologs", limit=None,
                    limit_type="upper", action=""):
 
-    accession_choices = AccessionFieldHandler().get_choices(with_plasmids=plasmid)
+    accession_choices = AccessionFieldHandler().get_choices(with_plasmids=False)
 
     class VennForm(forms.Form):
         attrs = {"data-close-on-select": "false",
@@ -233,7 +233,7 @@ def make_venn_from(db, plasmid=False, label="Orthologs", limit=None,
         def get_taxids(self):
             indices = self.cleaned_data["targets"]
             taxids, plasmids = AccessionFieldHandler().extract_choices(
-                indices, plasmid)
+                indices, False)
             return taxids
 
         def clean_targets(self):

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -492,7 +492,8 @@ class AccessionFieldHandler():
             self._db = DB.load_db_from_name(biodb_path)
         return self._db
 
-    def get_choices(self, with_plasmids=True, exclude=[], exclude_taxids_in_groups=[]):
+    def get_choices(self, with_plasmids=True, with_groups=True,
+                    exclude=[], exclude_taxids_in_groups=[]):
         result = self.db.get_genomes_description()
         result.set_index(result.index.astype(str), inplace=True)
         accession_choices = []
@@ -503,9 +504,9 @@ class AccessionFieldHandler():
                 plasmid = self.plasmid_id_to_key(taxid)
                 accession_choices.append((plasmid,
                                           f"{data.description} plasmid"))
-
-        accession_choices.extend([(self.group_id_to_key(group[0]), group[0])
-                                  for group in self.db.get_groups()])
+        if with_groups:
+            accession_choices.extend([(self.group_id_to_key(group[0]), group[0])
+                                      for group in self.db.get_groups()])
 
         # We also exclude taxids contained in the excluded groups
         groups_to_exclude = [self.group_key_to_id(key) for key in exclude

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -511,21 +511,24 @@ class AccessionFieldHandler():
         # We also exclude taxids contained in the excluded groups
         groups_to_exclude = [self.group_key_to_id(key) for key in exclude
                              if self.is_group(key)]
-        in_groups = self.db.get_taxids_for_groups(groups_to_exclude)
-        exclude = set(exclude).union({str(el) for el in in_groups})
+        if groups_to_exclude:
+            in_groups = self.db.get_taxids_for_groups(groups_to_exclude)
+            exclude = set(exclude).union({str(el) for el in in_groups})
 
         # And we exclude groups containing an excluded taxid
         taxids_to_exclude = list(filter(self.is_taxid, exclude))
-        exclude = exclude.union(
-            {self.group_id_to_key(groupid) for groupid in
-             self.db.get_groups_containing_taxids(taxids_to_exclude)})
+        if taxids_to_exclude:
+            exclude = exclude.union(
+                {self.group_id_to_key(groupid) for groupid in
+                 self.db.get_groups_containing_taxids(taxids_to_exclude)})
 
         # Finally we exclude taxids from groups in exclude_taxids_in_groups
         groups_to_exclude = [self.group_key_to_id(key)
                              for key in exclude_taxids_in_groups
                              if self.is_group(key)]
-        in_groups = self.db.get_taxids_for_groups(groups_to_exclude)
-        exclude = set(exclude).union({str(el) for el in in_groups})
+        if groups_to_exclude:
+            in_groups = self.db.get_taxids_for_groups(groups_to_exclude)
+            exclude = set(exclude).union({str(el) for el in in_groups})
 
         accession_choices = filter(lambda choice: choice[0] not in exclude,
                                    accession_choices)

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -534,6 +534,9 @@ class AccessionFieldHandler():
                                    accession_choices)
         return tuple(accession_choices)
 
+    def extract_taxid(self, index):
+        return int(index)
+
     def extract_choices(self, indices, include_plasmids):
         plasmids = []
         groups = []


### PR DESCRIPTION
With this PR we now allow selecting groups in the forms wherever pertinent, notably in all the comparison views and the plot region view.

Of note is that we lost the "all" and "None" buttons in the process, which are not built-in with select2 and not that easy to implement with choices being fetched with asynchronous requests. I think this is OK though as groups allow for easy selection and I will implement group management next.

## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

