### PR TITLE
Fix webapp conda environment for macOS.

### DIFF
--- a/conda/webapp.yaml
+++ b/conda/webapp.yaml
@@ -21,7 +21,7 @@ dependencies:
     - pyqt
     - bibtexparser
     - blast>=2.9.0
-    - gxx
     - django-autocomplete-light
     - pip:
         - scoary-2
+        - gxx ; sys_platform != 'darwin'


### PR DESCRIPTION
On Mac gxx is already installed and should not be in the requirements.

## Checklist
- [x] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

