### PR TITLE
Correctly handle group_0 in EntryIdParser.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -62,6 +62,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
+- Correctly handle group_0 in EntryIdParser. ([#93](https://github.com/metagenlab/zDB/pull/93)) (Niklaus Johner)
 - Fix webapp conda environment for macOS. ([#87](https://github.com/metagenlab/zDB/pull/87)) (Niklaus Johner)
 - Fix displaying active tab in search results view. ([#73](https://github.com/metagenlab/zDB/pull/73)) (Niklaus Johner)
 - Fix missing page title for kegg_mapp_ko view. ([#66](https://github.com/metagenlab/zDB/pull/66)) (Niklaus Johner)

--- a/testing/webapp/test_utils.py
+++ b/testing/webapp/test_utils.py
@@ -1,6 +1,8 @@
+from django.conf import settings
 from django.test import SimpleTestCase
+from lib.db_utils import DB
 
-from webapp.views.utils import AccessionFieldHandler
+from webapp.views.utils import AccessionFieldHandler, EntryIdParser
 
 
 class TestAccessionFieldHandler(SimpleTestCase):
@@ -131,3 +133,49 @@ class TestAccessionFieldHandler(SimpleTestCase):
         self.assertEqual(
             ([2, 3], [1]),
             self.handler.extract_choices(["plasmid:1", "2", "group:negative"], True))
+
+
+class TestEntryIdParser(SimpleTestCase):
+
+    def setUp(self):
+        biodb_path = settings.BIODB_DB_PATH
+        self.db = DB.load_db_from_name(biodb_path)
+        self.entry_id_parser = EntryIdParser(self.db)
+
+    def tearDown(self):
+        self.db.server.close()
+
+    def test_handles_orthogroups(self):
+        self.assertEqual(
+            ('orthogroup', 1),
+            self.entry_id_parser.id_to_object_type("group_1"))
+
+    def test_handles_orthogroup_0(self):
+        self.assertEqual(
+            ('orthogroup', 0),
+            self.entry_id_parser.id_to_object_type("group_0"))
+
+    def test_handles_cog(self):
+        self.assertEqual(
+            ('cog', 1234),
+            self.entry_id_parser.id_to_object_type("COG1234"))
+
+    def test_handles_pfam(self):
+        self.assertEqual(
+            ('pfam', 10423),
+            self.entry_id_parser.id_to_object_type("PF10423"))
+
+    def test_handles_ko(self):
+        self.assertEqual(
+            ('ko', 1241),
+            self.entry_id_parser.id_to_object_type("K01241"))
+
+    def test_handles_vf(self):
+        self.assertEqual(
+            ('vf', "VFG048797"),
+            self.entry_id_parser.id_to_object_type("VFG048797"))
+
+    def test_handles_amr(self):
+        self.assertEqual(
+            ('amr', "ybtP"),
+            self.entry_id_parser.id_to_object_type("ybtP"))

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -319,22 +319,22 @@ class EntryIdParser():
     def id_to_object_type(self, identifier):
         match = self.og_re.match(identifier)
         parsed_id = match and int(match.groups()[0])
-        if parsed_id and self.db.check_og_entry_id(parsed_id):
+        if match and self.db.check_og_entry_id(parsed_id):
             return "orthogroup", parsed_id
 
         match = self.cog_re.match(identifier)
         parsed_id = match and int(match.groups()[0])
-        if parsed_id and self.db.check_cog_entry_id(parsed_id):
+        if match and self.db.check_cog_entry_id(parsed_id):
             return "cog", parsed_id
 
         match = self.pfam_re.match(identifier)
         parsed_id = match and int(match.groups()[0])
-        if parsed_id and self.db.check_pfam_entry_id(parsed_id):
+        if match and self.db.check_pfam_entry_id(parsed_id):
             return "pfam", parsed_id
 
         match = self.ko_re.match(identifier)
         parsed_id = match and int(match.groups()[0])
-        if parsed_id and self.db.check_ko_entry_id(parsed_id):
+        if match and self.db.check_ko_entry_id(parsed_id):
             return "ko", parsed_id
 
         match = self.vf_re.match(identifier)


### PR DESCRIPTION
`group_0`  was not correctly mapped back to the orthogroup with ID 0, leading to issues for example when selecting that group for a custom phylogeny plot.

## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [x] Add tests for new features and regression tests for bugfixes whenever possible.

