### PR TITLE
Fix various views for cases where there are no gene annotations.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -62,6 +62,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
+- Fix extract_contigs view error for contigs without any gene annotation. ([#99](https://github.com/metagenlab/zDB/pull/99)) (Niklaus Johner)
 - Correctly handle group_0 in EntryIdParser. ([#93](https://github.com/metagenlab/zDB/pull/93)) (Niklaus Johner)
 - Fix webapp conda environment for macOS. ([#87](https://github.com/metagenlab/zDB/pull/87)) (Niklaus Johner)
 - Fix displaying active tab in search results view. ([#73](https://github.com/metagenlab/zDB/pull/73)) (Niklaus Johner)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -62,6 +62,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
+- Fix search_bar results view when all loci miss any gene annotation. ([#99](https://github.com/metagenlab/zDB/pull/99)) (Niklaus Johner)
 - Fix locusx view error for loci with homologs without any gene annotation. ([#99](https://github.com/metagenlab/zDB/pull/99)) (Niklaus Johner)
 - Fix extract_contigs view error for contigs without any gene annotation. ([#99](https://github.com/metagenlab/zDB/pull/99)) (Niklaus Johner)
 - Correctly handle group_0 in EntryIdParser. ([#93](https://github.com/metagenlab/zDB/pull/93)) (Niklaus Johner)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -62,6 +62,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
+- Fix locusx view error for loci with homologs without any gene annotation. ([#99](https://github.com/metagenlab/zDB/pull/99)) (Niklaus Johner)
 - Fix extract_contigs view error for contigs without any gene annotation. ([#99](https://github.com/metagenlab/zDB/pull/99)) (Niklaus Johner)
 - Correctly handle group_0 in EntryIdParser. ([#93](https://github.com/metagenlab/zDB/pull/93)) (Niklaus Johner)
 - Fix webapp conda environment for macOS. ([#87](https://github.com/metagenlab/zDB/pull/87)) (Niklaus Johner)

--- a/webapp/lib/db_utils.py
+++ b/webapp/lib/db_utils.py
@@ -2150,6 +2150,10 @@ class DB:
             ["bioentry_id", "seqfeature_id", "start_pos", "end_pos", "strand",
              "term_name", "qualifier_name"]).unstack("qualifier_name")
         df = df.reset_index()
+        # Make sure all expected columns are there.
+        for colname in ["gene", "locus_tag", "product"]:
+            if ("qualifier_value", colname) not in df.columns:
+                df[("qualifier_value", colname)] = None
         df.columns = ['_'.join(col).strip('_') for col in df.columns]
 
         # bioentry_id  start_pos  end_pos  strand  gene locus_tag product

--- a/webapp/lib/db_utils.py
+++ b/webapp/lib/db_utils.py
@@ -1744,6 +1744,9 @@ class DB:
                 return df
             df = df.set_index(["seqid", "name"]).unstack(level="name")
             df.columns = [col for col in df.value.columns.values]
+            for colname in to_return:
+                if colname not in df.columns:
+                    df[colname] = None
             return df
 
         hsh_results = {}

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -274,6 +274,8 @@ def search_bar(request):
     if sb.GeneEntry.entry_type in df.entry_type.values:
         df["gene"] = df.get("name")
 
+    df = df.where(df.notna(), "-")
+
     tabs = []
     for entry_type_name in df.entry_type.unique():
         entry_type = sb.entry_type_to_cls[entry_type_name]()

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -269,6 +269,11 @@ def search_bar(request):
         ctx = {"search_failed": True, "search_term": user_query}
         return render(request, "chlamdb/search.html", my_locals(ctx))
 
+    # when iterating over the df, accessing the name attribute will
+    # give back the name of the series, so we cannot use that attribute
+    if sb.GeneEntry.entry_type in df.entry_type.values:
+        df["gene"] = df.get("name")
+
     tabs = []
     for entry_type_name in df.entry_type.unique():
         entry_type = sb.entry_type_to_cls[entry_type_name]()
@@ -276,9 +281,6 @@ def search_bar(request):
         sel = df[df.entry_type == entry_type_name]
         if object_type == "locus":
             sel[object_type] = sel.locus_tag.apply(format_locus, to_url=True)
-            # when iterating over the df, accessing the name attribute will
-            # give back the name of the series, so we cannot use that attribute
-            sel["gene"] = sel["name"]
             tabs.append(TabularResultTab(
                 object_type,
                 "Genes",


### PR DESCRIPTION
With this PR we fix various bugs in views that fail when there are no gene annotations. Indeed we had cases where the `gene` column was entirely missing in the `dataframe` because it did not appear in any of the query results, which led to failing views. We fix that case for
- `search_bar` results
- `extract_contigs` view
- `locusx` view

## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

