### PR TITLE
Fix Scoary-2 integration.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -62,6 +62,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
+- Fix Scoary-2 integration. ([#101](https://github.com/metagenlab/zDB/pull/101)) (Niklaus Johner)
 - Fix search_bar results view when all loci miss any gene annotation. ([#99](https://github.com/metagenlab/zDB/pull/99)) (Niklaus Johner)
 - Fix locusx view error for loci with homologs without any gene annotation. ([#99](https://github.com/metagenlab/zDB/pull/99)) (Niklaus Johner)
 - Fix extract_contigs view error for contigs without any gene annotation. ([#99](https://github.com/metagenlab/zDB/pull/99)) (Niklaus Johner)

--- a/webapp/views/gwas.py
+++ b/webapp/views/gwas.py
@@ -9,6 +9,7 @@ from django.views import View
 from ete3 import Tree
 from lib.ete_phylo import EteTree, MatchingColorColumn, ValueColoredColumn
 from scoary import scoary
+from scoary.permutations import CONFINT_CACHE
 
 from views.analysis_view_metadata import GwasMetadata
 from views.mixins import (AmrViewMixin, CogViewMixin, KoViewMixin,
@@ -160,6 +161,9 @@ class GWASBaseView(View):
             tree = Tree(self.db.get_reference_phylogeny())
             tree.write(format=8, outfile=tree_path)
 
+            # Reset the db connection as it otherwise leads to issues with
+            # using an SQL object that was created in a separate thread.
+            CONFINT_CACHE.con, CONFINT_CACHE.cur = CONFINT_CACHE.get_cur()
             scoary(genotype_path,
                    phenotype_path,
                    os.path.join(tmp, "out"),


### PR DESCRIPTION
Scoary-2 uses a database to store scores for topologies and it caches the connection and cursor to that database when scoary gets loaded. This leads to issues for the integration as the SQL object might be used in a different thread than it was created in. We fix it here by resetting the connection before calling scoary.

Note that I have also opened [a PR in the scoary repo](https://github.com/MrTomRod/scoary-2/pull/13), so the current fix would not be necessary anymore if it gets fixed there and a new release is made...

## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

