### PR TITLE
Fix product representation in GWAS view for orthogroups.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -62,6 +62,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
+- Fix product representation in GWAS view for orthogroups. ([#102](https://github.com/metagenlab/zDB/pull/102)) (Niklaus Johner)
 - Fix Scoary-2 integration. ([#101](https://github.com/metagenlab/zDB/pull/101)) (Niklaus Johner)
 - Fix search_bar results view when all loci miss any gene annotation. ([#99](https://github.com/metagenlab/zDB/pull/99)) (Niklaus Johner)
 - Fix locusx view error for loci with homologs without any gene annotation. ([#99](https://github.com/metagenlab/zDB/pull/99)) (Niklaus Johner)

--- a/webapp/views/mixins.py
+++ b/webapp/views/mixins.py
@@ -320,7 +320,7 @@ class OrthogroupViewMixin(BaseViewMixin, OrthogroupMetadata):
         "gene": "Genes"
     }
 
-    table_data_accessors = ["orthogroup", "product", "gene"]
+    table_data_accessors = ["orthogroup", "products", "gene"]
 
     @property
     def get_hit_counts(self):
@@ -335,7 +335,7 @@ class OrthogroupViewMixin(BaseViewMixin, OrthogroupMetadata):
                                     index=pd.Index(ids, name="orthogroup"))
 
         descriptions = descriptions.merge(
-            pd.DataFrame({"gene": genes, "product": products}),
+            pd.DataFrame({"gene": genes, "products": products}),
             "left", left_index=True, right_index=True)
         if transformed:
             descriptions = self.transform_data(descriptions)

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -69,7 +69,7 @@ def format_lst_to_html(lst_elem, add_count=True, format_func=lambda x: x):
     dict_elem = {}
     for elem in lst_elem:
         if pd.isna(elem):
-            elem = "-"
+            continue
         cnt = dict_elem.get(elem, 0)
         dict_elem[elem] = cnt + 1
 
@@ -83,7 +83,7 @@ def format_lst_to_html(lst_elem, add_count=True, format_func=lambda x: x):
             elems.append(f"{token} ({v})")
         else:
             elems.append(f"{token}")
-    return "<br/>".join(elems)
+    return "<br/>".join(elems or ["-"])
 
 
 def format_orthogroup(og, to_url=False, from_str=False):


### PR DESCRIPTION
We also improve formatting of lists to html (such as for products, genes, functions, etc.). See screenshots below for both fixes:

**before fix, products are screwed up and - appear in the middle of the lists**
![fix_gwas_repr_before](https://github.com/metagenlab/zDB/assets/7374243/c7b05dbf-626f-4d3c-87fd-53ed30dfab32)

**after fix, everything is neat**
![fix_gwas_repr](https://github.com/metagenlab/zDB/assets/7374243/3ae619d7-da4c-41ef-b691-369bbccbfec7)

## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

