### PR TITLE
Fix filtering of COGs in annotation pipeline.

### DIFF
--- a/bin/setup_chlamdb.py
+++ b/bin/setup_chlamdb.py
@@ -290,9 +290,12 @@ def load_cog(params, filelist, db_file, cdd_to_cog, cog_db_dir):
                                        "qend", "sstart", "send", "evalue", "bitscore"])
 
         # Select only the best hits: using pandas clearly is an overkill here
-        min_hits = cogs_hits.groupby("seq_hsh")[["cdd", "evalue"]].min()
+        cogs_hits = cogs_hits[["seq_hsh", "cdd", "evalue", "pident"]]
+        min_hits = cogs_hits.sort_values(
+            ["evalue", "pident"],
+            ascending=[True, False]).drop_duplicates("seq_hsh")
         for index, row in min_hits.iterrows():
-            hsh = hsh_from_s(index[len("CRC-"):])
+            hsh = hsh_from_s(row["seq_hsh"][len("CRC-"):])
             #  cdd in the form cdd:N
             cog = hsh_cdd_to_cog[int(row["cdd"].split(":")[1])]
             evalue = float(row["evalue"])

--- a/conda/annotation.yaml
+++ b/conda/annotation.yaml
@@ -1,7 +1,7 @@
 name: annotation-base
 channels:
-    - anaconda
     - conda-forge
+    - anaconda
 dependencies:
     - python=3.9
     - whoosh

--- a/conda/webapp.yaml
+++ b/conda/webapp.yaml
@@ -24,4 +24,3 @@ dependencies:
     - django-autocomplete-light
     - pip:
         - scoary-2
-        - gxx ; sys_platform != 'darwin'

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -65,6 +65,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
+- Fix filtering of COGs in annotation pipeline. ([#108](https://github.com/metagenlab/zDB/pull/108)
 - Fix blast view for hits with identifier containing a version number. ([#106](https://github.com/metagenlab/zDB/pull/106)
 - Fix PFAM identifiers missing leading 0. ([#105](https://github.com/metagenlab/zDB/pull/105)) (Niklaus Johner)
 - Fix product representation in GWAS view for orthogroups. ([#102](https://github.com/metagenlab/zDB/pull/102)) (Niklaus Johner)

--- a/webapp/lib/db_utils.py
+++ b/webapp/lib/db_utils.py
@@ -1744,7 +1744,7 @@ class DB:
                 return df
             df = df.set_index(["seqid", "name"]).unstack(level="name")
             df.columns = [col for col in df.value.columns.values]
-            for colname in to_return:
+            for colname in term_names:
                 if colname not in df.columns:
                     df[colname] = None
             return df


### PR DESCRIPTION
Filtering of COGs in the annotation pipeline was actually picking the hits with lowest target sequence id, i.e. random ones, instead of the best ones. We now instead pick the hits with lowest E-value and highest sequence identity.

We also fix a small bug that was introduced with https://github.com/metagenlab/zDB/pull/99 and we fix some conda environment issues.

## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

