### PR TITLE
Fix binding of folders when running with singularity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
+-  Fix binding of folders when running with singularity. ([#116](https://github.com/metagenlab/zDB/pull/116)) (Niklaus Johner)
+
 
 ## 1.3.0 - 2024-07-11
 

--- a/bin/zdb
+++ b/bin/zdb
@@ -398,7 +398,7 @@ elif [[ "$1" == "webapp" ]]; then
 		done
 
 		bind_singularity="$bind_singularity,$(dirname $bind_path_db):${zdb_folder}/assets/db/"
-		singularity run --bind ${bind_singularity} \
+		singularity run -c --bind ${bind_singularity} \
 			${singularity_dir}/${zdb_container}.sif ${zdb_folder}/start_webapp ${options}
 	fi
 elif [[ "$1" == "run" ]]; then


### PR DESCRIPTION
When running with singularity the current working directory and home folders get mounted by default. It seems that this can collide with our own mounts, which get mounted into webapp/assets of the zDB directory, which usually also is the CWD. I did not quite understand why this works in certain cases but not in others, but it seems this led to zDB not running with singularity on our server. Adding the -c option to avoid sharing the filesystem resolves this issue.

## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

