### PR TITLE
Fix annotation pipeline for nextflow version > 24.03.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,11 @@ Versions are of the form MAJOR.MINOR.PATCH and this changelog tries to conform
 to [Common Changelog](https://common-changelog.org)
 
 
-## Unreleased
-
-### Changed
-
-### Added
+## 1.3.2 - 2024-07-30
 
 ### Fixed
 
+- Fix annotation pipeline for nextflow version > 24.03. ([#120](https://github.com/metagenlab/zDB/pull/120)) (Niklaus Johner)
 
 ## 1.3.1 - 2024-07-19
 

--- a/annotation_pipeline.nf
+++ b/annotation_pipeline.nf
@@ -26,6 +26,9 @@ def gen_arg_string_m(String name, Map m) {
 // this is the only solution
 def gen_arg_string(String s, Object o) {
     prefix = "\"" + s + "\" : "
+    if(o instanceof GString){
+        o = o.toString()
+    }
     if(o instanceof String){
         return prefix + "\"" + (String)o + "\""
     } else if(o instanceof Boolean) {


### PR DESCRIPTION
Config-defined parameters using interpolated strings are no longer cast to `Strings` since nextflow version 24.03. We therefore need to check for `GStrings` ourselves and cast them to Strings.

This issue was reported in https://github.com/nextflow-io/nextflow/issues/4944, and it was fixed in the sense that `GStrings` from the config file behave correctly, but they are still `GStrings` in newer version of nextflow.

## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

