### PR TITLE
Add missing assets when running webapp with nginx and gunicorn.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,13 +10,8 @@ testing/pipelines/rc.txt
 testing/pipelines/stderr.txt
 testing/pipelines/stdout.txt
 testing/pipelines/zdb
-webapp/assets/alignments
-webapp/assets/blast_DB/
-webapp/assets/db/
-webapp/assets/search_index/
-webapp/assets/temp
+webapp/served_assets/
 work/
-zdb/assets
 zdb/gunicorn/gunicorn.log
 zdb/gunicorn/gunicorn.pid
 zdb/nginx/*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
+- Add missing assets when running webapp with nginx and gunicorn. ([#122](https://github.com/metagenlab/zDB/pull/122)) (Niklaus Johner)
 - Fix checkm conda environment. ([#121](https://github.com/metagenlab/zDB/pull/121)) (Niklaus Johner)
 
 

--- a/bin/zdb
+++ b/bin/zdb
@@ -197,7 +197,6 @@ elif [[ "$1" == "webapp" ]]; then
 	debug=false
 	use_dev_server=false
 	singularity_dir="$(pwd)/singularity"
-	bind_path=()
 
 	for i in "$@"; do
 		case $i in
@@ -291,10 +290,6 @@ elif [[ "$1" == "webapp" ]]; then
 		mkdir ${dir}/zdb/nginx/var
 	fi
 
-	if [ ! -d "${dir}/zdb/assets" ]; then
-		mkdir ${dir}/zdb/assets
-	fi
-
 	if [ ! -z "${allowed_host}" ]; then
 		allowed_host="--hosts=${allowed_host}"
 	fi
@@ -305,19 +300,20 @@ elif [[ "$1" == "webapp" ]]; then
 		debugging_mode="-d"
 	fi
 
-	bind_path_results=()
+	# We will be serving ${dir}/zdb/assets/, so everything needs
+	# to be in there. When using nginx, we will use the collectstatic command
+	# to get all static files from installed applications and zDB into served_assets,
+	# otherwise we will symlink everything from ${zdb_folder}/assets/ into ${zdb_folder}/assets/
+	# and django will take care of serving static files from other installed apps.
+	bind_path=() # Used for docker and singularity
+	bind_path_results=() # Used for conda, docker and singularity
 
 	bind_path+=("$zdb_folder":"$zdb_folder")
 
-	# Necessary to make an exception for this one, as singularity
-	# seemingly does not support binding a single writable file
-	bind_path_db="${dir}/zdb/results/db/$run_name"
-
-	bind_path_results+=("${dir}/zdb/assets":"${zdb_folder}/assets/temp")
-	bind_path_results+=($(realpath "${dir}/zdb/results/search_index/index_${run_name}"):"${zdb_folder}/assets/search_index/${run_name}")
-	bind_path_results+=("${dir}/zdb/results/blast_DB/${run_name}":"${zdb_folder}/assets/blast_DB/${run_name}")
-	bind_path_results+=("${dir}/zdb/results/alignments/${run_name}":"${zdb_folder}/assets/alignments")
-
+	bind_path_results+=($(realpath "${dir}/zdb/results/search_index/index_${run_name}"):"${zdb_folder}/served_assets/search_index/${run_name}")
+	bind_path_results+=("${dir}/zdb/results/blast_DB/${run_name}":"${zdb_folder}/served_assets/blast_DB/${run_name}")
+	bind_path_results+=("${dir}/zdb/results/alignments/${run_name}":"${zdb_folder}/served_assets/alignments")
+	bind_path_results+=(""${dir}/zdb/results/db/$run_name":${zdb_folder}/served_assets/db/${run_name}")
 
 	bind_path+=("${bind_path_results[@]}")
 	bind_path+=("${dir}/zdb/gunicorn":"/usr/local/gunicorn/")
@@ -329,14 +325,29 @@ elif [[ "$1" == "webapp" ]]; then
 	bind_path+=("${dir}/zdb/nginx/var":"/var/log/nginx")
 	bind_path+=("${dir}/zdb/nginx/proxy_temp":"/usr/local/nginx/proxy_temp")
 
+	# We prepare all the folders that we will need and make the symlinks for conda.
+	# This would not be necessary for singularity but for docker it allows the folders
+	# to not get created on mount by root, so that we can easily remove them when shutting down.
+	for bd in ${bind_path_results[@]}; do
+		target=$(echo $bd | cut -d':' -f 2)
+		base=$(echo $bd | cut -d':' -f 1)
+		basedir=$(dirname $target)
+		if [ -e "$target" ]; then
+			rm -rf $target
+		fi
+		mkdir -p $basedir
+		if [[ "$conda" = true ]]; then
+			ln -s $base $target
+		fi
+	done
+	mkdir -p $zdb_folder/served_assets/temp
 
 	options="--run_name=${run_name} --port=${port} ${debugging_mode} ${allowed_host} ${dev_server}"
 	if [[ "$docker" = true ]]; then
 		full_docker_name="registry.hub.docker.com/metagenlab/${zdb_container}"
 		docker pull ${full_docker_name}
-		bind_docker=""
-		bind_path+=("$bind_path_db:${zdb_folder}/assets/db/${run_name}")
 
+		bind_docker=""
 		for index in ${bind_path[@]}; do
 			bind_docker="$bind_docker -v $index"
 		done
@@ -355,25 +366,8 @@ elif [[ "$1" == "webapp" ]]; then
 			fi
 		fi
 
-		bind_path_results+=("$bind_path_db:${zdb_folder}/assets/db/${run_name}")
-		# link the results directory into the assets/directory of the webapp
-		to_remove=""
-		for bd in ${bind_path_results[@]}; do
-			target=$(echo $bd | cut -d':' -f 2)
-			base=$(echo $bd | cut -d':' -f 1)
-			basedir=$(dirname $target)
-			if [ -e "$target" ]; then
-				rm -rf $target
-			fi
-			to_remove="$to_remove $target"
-			mkdir -p $basedir
-			ln -s $base $target
-		done
-
 		conda run --live-stream -p $conda_prefix ${zdb_folder}/start_webapp ${options}
 
-		# cleanup links
-		rm -rf ${to_remove}
 	else
 		if [ ! -d "${singularity_dir}" ]; then
 			mkdir -p ${singularity_dir}
@@ -397,10 +391,13 @@ elif [[ "$1" == "webapp" ]]; then
 			bind_singularity="$bind_singularity,$index"
 		done
 
-		bind_singularity="$bind_singularity,$(dirname $bind_path_db):${zdb_folder}/assets/db/"
+		# The mount point must exist in order for singularity to mount the file
+		touch ${zdb_folder}/served_assets/db/${run_name}
 		singularity run -c --bind ${bind_singularity} \
 			${singularity_dir}/${zdb_container}.sif ${zdb_folder}/start_webapp ${options}
 	fi
+	# Clean-up...
+	rm -rf $zdb_folder/served_assets
 elif [[ "$1" == "run" ]]; then
 	shift
 

--- a/webapp/settings/settings.py
+++ b/webapp/settings/settings.py
@@ -20,7 +20,7 @@ DEBUG = int(os.environ.get("DEBUG", 0))
 RUN_NAME = os.environ["RUN_NAME"]
 hosts = os.environ.get("ALLOWED_HOSTS", "localhost")
 
-PREFIX = "assets"
+PREFIX = "served_assets"
 
 BIODB_DB_PATH = PREFIX + "/db/" + RUN_NAME
 SEARCH_INDEX = PREFIX + "/search_index/" + RUN_NAME
@@ -75,9 +75,17 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
 STATIC_URL = '/assets/'
-STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, "assets"),
-)
+
+# We always want to server files in served_assets. When using the dev server,
+# files in STATICFILES_DIRS are served so we need to set that to served_assets.
+# Otherwise files get collected from STATICFILES_DIR to STATIC_ROOT.
+ASSET_ROOT = os.path.join(BASE_DIR, PREFIX)
+
+if os.environ.get("ZDB_DEVSERVER") == "true":
+    STATICFILES_DIRS = (ASSET_ROOT,)
+else:
+    STATIC_ROOT = ASSET_ROOT
+    STATICFILES_DIRS = (os.path.join(BASE_DIR, "assets"),)
 
 
 APPEND_SLASH = True  # Ajoute un slash en fin d'URL

--- a/webapp/settings/testing_settings.py
+++ b/webapp/settings/testing_settings.py
@@ -29,3 +29,5 @@ from settings.settings import *  # noqa
 BIODB_DB_PATH = results_dir + "/db/" + run_name
 SEARCH_INDEX = results_dir + "/search_index/" + run_name
 BLAST_DB_PATH = results_dir + "/blast_DB/" + run_name
+ASSET_ROOT = os.path.join(testing_dir, "webapp", "served_assets")
+STATICFILES_DIRS = (ASSET_ROOT,)

--- a/webapp/start_webapp
+++ b/webapp/start_webapp
@@ -95,7 +95,7 @@ export PORT="$custom_port"
 export RUN_NAME="$custom_run_name"
 export DEBUG="$debugging"
 export ALLOWED_HOSTS="${hosts// /,}"
-
+export ZDB_DEVSERVER="$use_dev_server"
 
 # go to the chlamdb folder
 scriptpath=`realpath $0`
@@ -104,10 +104,14 @@ cd $zdb_dir
 
 echo "Starting web server. The application will be accessible @${hosts} on port ${custom_port}"
 if [ "$use_dev_server" = true ]; then
+	# symlink zdb static files into served_assets folder
+	ln -s ${zdb_dir}/assets/* ${zdb_dir}/served_assets/
 	python manage.py runserver --nothreading 0.0.0.0:$custom_port
 else
+	# collect static files into served_assets folder
+	python manage.py collectstatic --noinput
 	gunicorn -c /usr/local/gunicorn/gunicorn.py
-	sed "s/PORT/${custom_port}/" /usr/local/nginx/nginx.config | sed --expression "s@ASSETS_PATH@${zdb_dir}\/assets@" > /usr/local/nginx/nginx_curr.config
+	sed "s/PORT/${custom_port}/" /usr/local/nginx/nginx.config | sed --expression "s@ASSETS_PATH@${zdb_dir}\/served_assets@" > /usr/local/nginx/nginx_curr.config
 
 	nginx -p /usr/local/nginx -c /usr/local/nginx/nginx_curr.config
 
@@ -124,6 +128,21 @@ else
 
 	echo "Brutally stopping Xvfb"
 	kill -TERM $xvfb_pid
+
+	# Remove static files that were collected by collect static.
+	# This is only necessary for docker which creates these files with
+	# root, so that they cannot be easily deleted afterwards
+	rm -rf $zdb_dir/served_assets/admin
+	rm -rf $zdb_dir/served_assets/autocomplete_light
+	rm -rf $zdb_dir/served_assets/bibliography
+	rm -rf $zdb_dir/served_assets/css
+	rm -rf $zdb_dir/served_assets/images
+	rm -rf $zdb_dir/served_assets/img
+	rm -rf $zdb_dir/served_assets/js
+	rm -rf $zdb_dir/served_assets/sass
+	rm -rf $zdb_dir/served_assets/vendor
+	rm -rf $zdb_dir/served_assets/webfonts
+
 fi
 
 unset DISPLAY
@@ -131,3 +150,4 @@ unset PORT
 unset RUN_NAME
 unset ALLOWED_HOSTS
 unset DEBUG
+unset ZDB_DEVSERVER

--- a/webapp/views/custom_plots.py
+++ b/webapp/views/custom_plots.py
@@ -98,7 +98,7 @@ class CusomPlotsView(View):
                 col = SimpleColorColumn.fromSeries(count, header=label, color_gradient=True)
                 e_tree.add_column(col)
         self.tree_path = "/temp/custom_tree.svg"
-        path = settings.BASE_DIR + "/assets" + self.tree_path
+        path = settings.ASSET_ROOT + self.tree_path
         e_tree.render(path, dpi=500)
         return e_tree
 

--- a/webapp/views/fam.py
+++ b/webapp/views/fam.py
@@ -123,7 +123,7 @@ class FamBaseView(View):
             self.db, getattr(hit_counts, self.object_column),
             self.format_entry(entry_id), orthogroups)
         asset_path = f"/temp/fam_tree_{entry_id}.svg"
-        path = settings.BASE_DIR + "/assets" + asset_path
+        path = settings.ASSET_ROOT + asset_path
         e_tree.render(path, dpi=500)
 
         info = {self.colname_to_header(key): infos[key]

--- a/webapp/views/gwas.py
+++ b/webapp/views/gwas.py
@@ -96,7 +96,7 @@ class GWASBaseView(View):
 
         e_tree = self.prepare_tree(phenotype, hits, results)
         self.tree_path = "/temp/gwas_tree.svg"
-        path = settings.BASE_DIR + "/assets" + self.tree_path
+        path = settings.ASSET_ROOT + self.tree_path
         e_tree.render(path, dpi=500)
 
         context = self.get_context(

--- a/webapp/views/locus.py
+++ b/webapp/views/locus.py
@@ -124,7 +124,7 @@ def tab_og_conservation_tree(db, group, compare_to=None):
 
     dpi = 1200
     asset_path = f"/temp/og_conservation{group}.svg"
-    path = settings.BASE_DIR + '/assets/' + asset_path
+    path = settings.ASSET_ROOT + asset_path
     e_tree.render(path, dpi=dpi)
     return {"asset_path": asset_path}
 
@@ -232,7 +232,7 @@ def tab_og_phylogeny(db, og_id, compare_to=None):
     e_tree.rename_leaves(locus_to_genome, leaf_name_type=str)
 
     asset_path = f"/temp/og_phylogeny{og_id}.svg"
-    path = settings.BASE_DIR + '/assets/' + asset_path
+    path = settings.ASSET_ROOT + asset_path
     e_tree.render(path, dpi=1200)
 
     algn_file = f"/alignments/{og_filename}"
@@ -447,7 +447,7 @@ def tab_og_best_hits(db, orthogroup, locus=None):
                       0, "branch-right")
 
     asset_path = f"/temp/og_best_hit_phylogeny_{orthogroup}.svg"
-    path = settings.BASE_DIR + '/assets/' + asset_path
+    path = settings.ASSET_ROOT + asset_path
     ts = TreeStyle()
     ts.show_leaf_name = False
     ete_tree.render(path, tree_style=ts, dpi=1200)

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -62,7 +62,7 @@ def help(request):
 
 
 def about(request):
-    path = settings.BASE_DIR + '/assets/bibliography/references.bib'
+    path = settings.ASSET_ROOT + '/bibliography/references.bib'
     with open(path) as bibtex_file:
         bib_database = bibtexparser.load(bibtex_file)
 
@@ -380,7 +380,7 @@ class CogPhyloHeatmap(CogViewMixin, View):
             e_tree.add_column(col)
 
         freq = frequency
-        path = settings.BASE_DIR + f"/assets/temp/COG_tree_{freq}.svg"
+        path = settings.ASSET_ROOT + f"/temp/COG_tree_{freq}.svg"
         asset_path = f"/temp/COG_tree_{freq}.svg"
         e_tree.render(path, dpi=600)
         context = self.get_context(envoi=True, freq=freq, asset_path=asset_path)
@@ -496,7 +496,7 @@ def KEGG_module_map(request, module_name):
 
     big = len(mat.columns) >= 40
     dpi = 800 if big else 1200
-    path = settings.BASE_DIR + '/assets/temp/KEGG_tree_%s.svg' % module_name
+    path = settings.ASSET_ROOT + '/temp/KEGG_tree_%s.svg' % module_name
     asset_path = '/temp/KEGG_tree_%s.svg' % module_name
     e_tree.render(path, dpi=dpi)
     envoi = True
@@ -615,7 +615,7 @@ def KEGG_mapp_ko(request, map_name=None, taxon_id=None):
             entry = (format_ko(ko_id, as_url=True), descr, in_this_genome, ttl)
         data.append(entry)
     e_tree = gen_pathway_profile(db, ko_list)
-    path = settings.BASE_DIR + f"/assets/temp/{map_name}.svg"
+    path = settings.ASSET_ROOT + f"/temp/{map_name}.svg"
     asset_path = f"/temp/{map_name}.svg"
     e_tree.render(path, dpi=800)
     ctx = {"pathway_num": kos.iloc[0].pathway,
@@ -1010,7 +1010,7 @@ def gen_blast_heatmap(db, blast_res, blast_type, no_query_name=False):
         e_tree.add_column(col)
 
     base_file_name = time.strftime("blast_%d_%m_%y_%H_%M.svg", time.gmtime())
-    path = settings.BASE_DIR + f"/assets/temp/{base_file_name}"
+    path = settings.ASSET_ROOT + f"/temp/{base_file_name}"
     asset_path = f"/temp/{base_file_name}"
     e_tree.render(path, dpi=600)
     return asset_path
@@ -1076,7 +1076,7 @@ def blast(request):
             asset_path = gen_blast_heatmap(db, blast_stdout,
                                            blast_type, form.no_query_name)
         rand_id = id_generator(6)
-        blast_file_l = settings.BASE_DIR + '/assets/temp/%s.xml' % rand_id
+        blast_file_l = settings.ASSET_ROOT + '/temp/%s.xml' % rand_id
         f = open(blast_file_l, 'w')
         f.write(blast_stdout)
         f.close()
@@ -1679,7 +1679,7 @@ def kegg_module_subcat(request):
         new_col = KOAndCompleteness(values, n_missing, header)
         e_tree.add_column(new_col)
     e_tree.rename_leaves(leaf_to_name.description.to_dict())
-    path = settings.BASE_DIR + '/assets/temp/metabo_tree.svg'
+    path = settings.ASSET_ROOT + '/temp/metabo_tree.svg'
     asset_path = '/temp/metabo_tree.svg'
     e_tree.render(path, dpi=500, w=800)
     envoi = True
@@ -1746,7 +1746,7 @@ def kegg_module(request):
         new_col = KOAndCompleteness(values, n_missing, header)
         e_tree.add_column(new_col)
     e_tree.rename_leaves(leaf_to_name.description.to_dict())
-    path = settings.BASE_DIR + '/assets/temp/metabo_tree.svg'
+    path = settings.ASSET_ROOT + '/temp/metabo_tree.svg'
     asset_path = '/temp/metabo_tree.svg'
     e_tree.render(path, dpi=500, w=800)
 
@@ -1814,7 +1814,7 @@ def phylogeny(request):
     genomes_data = get_genomes_data(db)
 
     asset_path = "/temp/species_tree.svg"
-    path = settings.BASE_DIR + '/assets/temp/species_tree.svg'
+    path = settings.ASSET_ROOT + '/temp/species_tree.svg'
 
     core = db.get_n_orthogroups(only_core=True)
 


### PR DESCRIPTION
The dal and dal_select2 apps come with static files which need to be served. This is done automatically when running the dev_server but not when using nginx and gunicorn. In that case we need to use the collectstatic command to gather all the necessary static files into one folder and then serve that folder.
We also improve cleaning-up of the files when the webapp gets shut-down, which is mainly an issue with docker as folders and files get created by root, leading to issues when running with conda or singularity after running with docker.

_Describe the changes and add screenshots when pertinent as visual help._

## Checklist
- [x] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

