### PR TITLE
Fix kegg forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
+- Fix Kegg based comparative analysis form. ([#123](https://github.com/metagenlab/zDB/pull/123)) (Niklaus Johner)
 - Add missing assets when running webapp with nginx and gunicorn. ([#122](https://github.com/metagenlab/zDB/pull/122)) (Niklaus Johner)
 - Fix checkm conda environment. ([#121](https://github.com/metagenlab/zDB/pull/121)) (Niklaus Johner)
 

--- a/webapp/assets/css/style_FILE_zDB.css
+++ b/webapp/assets/css/style_FILE_zDB.css
@@ -3,18 +3,15 @@
   .serviceBox_met{
     color: #555;
     font-family: 'Poppins', sans-serif;
-    text-align: right;
     padding: 10px 10px 10px 20px;
     position: relative;
-    min-height: 500px;
+    min-height: 350px;
     min-width: 200px;
     border-radius: 25px;
     background-color: #e0e0e0e1;
     margin-top:20px;
    
 }
-
-
 
 .serviceBox_met:before,
 .serviceBox_met:after{
@@ -39,21 +36,21 @@
    
 }
 
-
 .serviceBox_met .service-icon{
     color: rgb(255, 255, 255);
     background-color:#1f2e20 ;
     font-size: 50px;
-    text-align: center;
+    text-align: right;
     line-height: 100px;
     height: 100px;
     width: 100px;
-    margin: 0 0 30px;
+    margin: 0 0 4px;
     border-radius: 50%;
     border: 4px solid rgb(54, 134, 54);
     box-shadow: 0 0 10px rgba(0,0,0,0.5);
     display: inline-block;
     position: relative;
+    margin-left: calc(100% - 104px);
 
 }
 .serviceBox_met .service-icon:before{
@@ -71,7 +68,6 @@
     
 }
 
-
 .serviceBox_met .service-icon_2{
     color: rgb(255, 255, 255);
     background-color: #1f2e20 ;
@@ -81,13 +77,15 @@
     line-height: 100px;
     height: 100px;
     width: 100px;
-    margin: 0 0 30px;
+    margin: 0 0 4px;
     border-radius: 50%;
     border: 4px solid rgb(141, 0, 19);
     box-shadow: 0 0 10px rgba(0,0,0,0.5);
     display: inline-block;
     position: relative;
+    margin-left: calc(100% - 104px);
 }
+
 .serviceBox_met .service-icon_2:before{
     content: '';
     border: 2px solid #333;
@@ -103,9 +101,9 @@
 }
 
 .serviceBox_met .title{
-    
     text-transform: uppercase;
     text-align: left;
+    margin-top: 0px;
    
 }
 .serviceBox_met .description{

--- a/webapp/templates/chlamdb/kegg.html
+++ b/webapp/templates/chlamdb/kegg.html
@@ -3,110 +3,101 @@
 
 <html>
 <head>
-{% load static %}
-{% get_static_prefix as STATIC_PREFIX %}
-{% include "chlamdb/header.html" %}
-{% load crispy_forms_tags %}
-
+  {% load static %}
+  {% get_static_prefix as STATIC_PREFIX %}
+  {% include "chlamdb/header.html" %}
+  {% load crispy_forms_tags %}
 </head>
 
 <body>
   <div class="container-fluid" id="main_container">
     <div class="row">
       <div id="wrapper">
-          <div id="page-content-wrapper">
-            <div class="row">
-              <div class="col-lg-12">
-                 {% include "chlamdb/menu.html" %}
+        <div id="page-content-wrapper">
+          <div class="row">
+            <div class="col-lg-12">
+              {% include "chlamdb/menu.html" %}
 
-                 <div class="row" style="padding-top:20px">
+              <div class="row" style="padding-top:20px">
 
-                    <div class="col-lg-5 col-md-6 col-sm-12" >
-                    <div class="serviceBox_met"  >
-                        <div class="service-icon_2">
-                          <span><img src="{% static '/img/icons8-dna-64.png' %}"/></span>
-                        </div>
-                        <h3 class="title">Genome centered modules</h3>
-                        <p class="description"> List Kegg modules or Kegg modules in a genome of interest</p>
-                        <div class= "col-md-4 col-sm-6">
-                            {% csrf_token %}
-                            {% crispy form_genome_modules %}
-                        </div>
+                <div class="col-lg-5 col-md-6 col-sm-12" >
+                  <div class="serviceBox_met"  >
+                    <div class="service-icon_2">
+                      <span><img src="{% static '/img/icons8-dna-64.png' %}"/></span>
                     </div>
+                    <h3 class="title">Genome centered modules</h3>
+                    <p class="description"> List Kegg modules or Kegg modules in a genome of interest</p>
+                    <div class= "col-md-4 col-sm-6">
+                      {% csrf_token %}
+                      {% crispy form_genome_modules %}
                     </div>
-
-                    <div class="col-lg-5 col-md-6 col-sm-12"  >
-                    <div  class="serviceBox_met" >
-                      <div class="service-icon">
-                        <span><img src="{% static '/img/icons8-dna-64.png' %}"/></span>
-                      </div>
-                      <h3 class="title" >Genome centered pathways</h3>
-                      <p class="description"> List Kegg pathways or Kegg pathways in a genome of interest</p>
-                      <div class= "col-md-4 col-sm-6">
-                          {% crispy form_genome %}
-                      </div>
-                    </div>
-                    </div>
-
+                  </div>
                 </div>
+
+                <div class="col-lg-5 col-md-6 col-sm-12"  >
+                  <div  class="serviceBox_met" >
+                    <div class="service-icon">
+                      <span><img src="{% static '/img/icons8-dna-64.png' %}"/></span>
+                    </div>
+                    <h3 class="title" >Genome centered pathways</h3>
+                    <p class="description"> List Kegg pathways or Kegg pathways in a genome of interest</p>
+                    <div class= "col-md-4 col-sm-6">
+                      {% crispy form_genome %}
+                    </div>
+                  </div>
+                </div>
+
+              </div>
        
-                <div class="row">
-
-                  <div class="col-lg-5 col-md-6 col-sm-12" >
-                    <div class="serviceBox_met"  style="min-height: 500px;">
-                        <div class="service-icon_2">
-                          <span><img src="{% static '/img/icons8-module-70.png' %}"/></span>
-                        </div>
-                        <h3 class="title">kEGG Modules centered</h3>
-                        <p class="description"> Discover the distribution of Kegg Modules within the genomes of the database</p>
-                          <div class= "col-md-4 col-sm-6">
-                            {% crispy form_cat %}
-                            <b>or</b>
-                            {% crispy form_subcat %}
-                          </div>
-                      </div>
-                  </div>
-                  <div class="col-lg-5 col-md-6 col-sm-12">
-                   <div  class="serviceBox_met " >
-                      <div class="service-icon">
-                        <span><img src="{% static '/img/icons8-train-track-60.png' %}" /></span>
-                      </div>
-                      <h3 class="title" >kEGG Pathways centered</h3>
-                      <p class="description"> Discover the distribution of Kegg patwhays within the genomes of the database</p>
-                      <div class= "col-lg-5 col-md-6 col-sm-12">
-                          <div class="genome_search">
-                            {% crispy form_pathway %}
-                      </div>
-                   </div>
-                  </div>
-                </div>
-
               <div class="row">
-                    <div class="col-lg-5 col-md-6 col-sm-12" >
 
-                      <div class="serviceBox_met "  >
-                          <div class="service-icon_2">
-                            <span><img src="{% static '/img/icons8-data-sheet-60.png' %}"/></span>
-                          </div>
-                          <h3 class="title">Comparative analysis</h3>
-                          <p class="description"> Discover the distribution of Kegg Modules within the genomes of the database</p>
-                          <div class= "col-md-6 col-sm-6">
-                              {% crispy form_module %}
-                          </div>
-                        </div>
-                      </div>
+                <div class="col-lg-5 col-md-6 col-sm-12" >
+                  <div class="serviceBox_met"  style="min-height: 500px;">
+                    <div class="service-icon_2">
+                      <span><img src="{% static '/img/icons8-module-70.png' %}"/></span>
+                    </div>
+                    <h3 class="title">kEGG Modules centered</h3>
+                    <p class="description"> Discover the distribution of Kegg Modules within the genomes of the database</p>
+                    <div class= "col-md-4 col-sm-6">
+                      {% crispy form_cat %}
+                      <b>or</b>
+                      {% crispy form_subcat %}
+                    </div>
+                  </div>
                 </div>
 
+                <div class="col-lg-5 col-md-6 col-sm-12">
+                  <div  class="serviceBox_met " >
+                    <div class="service-icon">
+                      <span><img src="{% static '/img/icons8-train-track-60.png' %}" /></span>
+                    </div>
+                    <h3 class="title" >kEGG Pathways centered</h3>
+                    <p class="description"> Discover the distribution of Kegg patwhays within the genomes of the database</p>
+                    <div class= "col-lg-5 col-md-6 col-sm-12">
+                      <div class="genome_search">
+                        {% crispy form_pathway %}
+                      </div>
+                    </div>
+                  </div>
+                  <div class="serviceBox_met "  >
+                    <div class="service-icon_2">
+                      <span><img src="{% static '/img/icons8-data-sheet-60.png' %}"/></span>
+                    </div>
+                    <h3 class="title">Comparative analysis</h3>
+                    <p class="description"> Discover the distribution of Kegg Modules within the genomes of the database</p>
+                    <div class= "col-md-6 col-sm-6">
+                      {% crispy form_module %}
+                    </div>
+                  </div>
+                </div>
+
+              </div>
+            </div>
           </div>
         </div>
+      </div>
     </div>
- </div>
-</div>
-</div>
-
-
-
-
+  </div>
 
 <script>
   $(document).ready(function() {
@@ -127,7 +118,7 @@
   ],
   } );
   } );
-$('.dropdown-toggle').dropdown()
+  $('.dropdown-toggle').dropdown()
 </script>
 
 </body>

--- a/webapp/templates/chlamdb/kegg.html
+++ b/webapp/templates/chlamdb/kegg.html
@@ -4,7 +4,6 @@
 <html>
 <head>
 {% load static %}
-{% load static %}
 {% get_static_prefix as STATIC_PREFIX %}
 {% include "chlamdb/header.html" %}
 {% load crispy_forms_tags %}
@@ -29,13 +28,9 @@
                         </div>
                         <h3 class="title">Genome centered modules</h3>
                         <p class="description"> List Kegg modules or Kegg modules in a genome of interest</p>
-                        <br>
-                        <br>
                         <div class= "col-md-4 col-sm-6">
-                          <form action="{% url "kegg_genomes_modules" %}" method="post">{% csrf_token %}
-                            {{ form_genome.as_p }}
-                            <input type="submit" value="Submit" />
-                          </form>
+                            {% csrf_token %}
+                            {% crispy form_genome_modules %}
                         </div>
                     </div>
                     </div>
@@ -47,13 +42,8 @@
                       </div>
                       <h3 class="title" >Genome centered pathways</h3>
                       <p class="description"> List Kegg pathways or Kegg pathways in a genome of interest</p>
-                      <br>
-                      <br>
                       <div class= "col-md-4 col-sm-6">
-                        <form action="{% url "kegg_genomes" %}" method="post">{% csrf_token %}
-                          {{ form_genome.as_p }}
-                          <input type="submit" value="Submit" />
-                        </form>
+                          {% crispy form_genome %}
                       </div>
                     </div>
                     </div>
@@ -63,28 +53,17 @@
                 <div class="row">
 
                   <div class="col-lg-5 col-md-6 col-sm-12" >
-                    <div class="serviceBox_met "  >
+                    <div class="serviceBox_met"  style="min-height: 500px;">
                         <div class="service-icon_2">
                           <span><img src="{% static '/img/icons8-module-70.png' %}"/></span>
                         </div>
                         <h3 class="title">kEGG Modules centered</h3>
                         <p class="description"> Discover the distribution of Kegg Modules within the genomes of the database</p>
-                        <br>
-                        <br>
-                        <div class= "col-lg-5 col-md-6 col-sm-12">
-                          <form action="{% url "kegg_module" %}" method="post">{% csrf_token %}
-                            {{ form_cat.as_p }}
-                            <input type="submit" value="Submit" />
-                          </form>
-                          <br>
-                          <b>or</b>
-                          <br>
-                          <br>
-                          <form action="{% url "kegg_module_subcat" %}" method="post">{% csrf_token %}
-                            {{ form_subcat.as_p }}
-                            <input type="submit" value="Submit" />
-                          </form>
-                        </div>
+                          <div class= "col-md-4 col-sm-6">
+                            {% crispy form_cat %}
+                            <b>or</b>
+                            {% crispy form_subcat %}
+                          </div>
                       </div>
                   </div>
                   <div class="col-lg-5 col-md-6 col-sm-12">
@@ -94,47 +73,30 @@
                       </div>
                       <h3 class="title" >kEGG Pathways centered</h3>
                       <p class="description"> Discover the distribution of Kegg patwhays within the genomes of the database</p>
-                      <br>
-                      <br>
                       <div class= "col-lg-5 col-md-6 col-sm-12">
                           <div class="genome_search">
-                            <form action="{% url "KEGG_mapp_ko" %}" method="post">{% csrf_token %}
-                            {{ form_pathway.as_p }}
-                            <input type="submit" value="Submit" />
-                          </form>
+                            {% crispy form_pathway %}
                       </div>
                    </div>
                   </div>
+                </div>
 
-                 </div>
-              </div>
               <div class="row">
-
                     <div class="col-lg-5 col-md-6 col-sm-12" >
+
                       <div class="serviceBox_met "  >
                           <div class="service-icon_2">
                             <span><img src="{% static '/img/icons8-data-sheet-60.png' %}"/></span>
                           </div>
                           <h3 class="title">Comparative analysis</h3>
                           <p class="description"> Discover the distribution of Kegg Modules within the genomes of the database</p>
-                          <br>
-                          <br>
                           <div class= "col-md-6 col-sm-6">
-                            <form action='{% url "module_comparison" %}' method="post">
-                              {% csrf_token %}
-                              {{ form_module.as_p }}
-                              <input type="submit" value="Submit" />
-                            </form>
+                              {% crispy form_module %}
                           </div>
                         </div>
                       </div>
                 </div>
-                    
 
-
-                    
-                  
-                  
           </div>
         </div>
     </div>

--- a/webapp/templates/chlamdb/kegg.html
+++ b/webapp/templates/chlamdb/kegg.html
@@ -99,28 +99,6 @@
     </div>
   </div>
 
-<script>
-  $(document).ready(function() {
-  $('#kegg_maps').DataTable( {
-  dom: 'Bfrtip',
-  "paging":   true,
-  "ordering": true,
-  "info":     false,
-  buttons: [
-    {
-        extend: 'excel',
-        title: 'kepp_maps'
-    },
-    {
-        extend: 'csv',
-        title: 'kepp_maps'
-    }
-  ],
-  } );
-  } );
-  $('.dropdown-toggle').dropdown()
-</script>
-
 </body>
 {% include "chlamdb/style_menu.html" %}
 </html>

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -1592,23 +1592,21 @@ def kegg(request):
 
     db = DB.load_db(settings.BIODB_DB_PATH, settings.BIODB_CONF)
     module_overview_form = make_module_overview_form(db)
-    form_cat = module_overview_form(request.POST)
     form_cat = module_overview_form()
 
-    single_genome_form = make_single_genome_form(db)
-    form_genome = single_genome_form(request.POST)
+    single_genome_form = make_single_genome_form(db, "kegg_genomes_modules")
+    form_genome_modules = single_genome_form()
+
+    single_genome_form = make_single_genome_form(db, "kegg_genomes")
     form_genome = single_genome_form()
 
     module_overview_form = make_module_overview_form(db, True)
-    form_subcat = module_overview_form(request.POST)
     form_subcat = module_overview_form()
 
-    comp_metabo_form = make_metabo_from(db)
-    form_module = comp_metabo_form(request.POST)
+    comp_metabo_form = make_metabo_from(db, action="module_comparison")
     form_module = comp_metabo_form()
 
     pathway_overview_form = make_pathway_overview_form(db)
-    form_pathway = pathway_overview_form(request.POST)
     form_pathway = pathway_overview_form()
 
     return render(request, 'chlamdb/kegg.html', my_locals(locals()))


### PR DESCRIPTION
Selection with the autocomplete widget was not working for the kegg-based comparative analysis form. We have fixed this by using crispy forms to render the forms on the kegg-based view. We have also improved the overall layout and style of the view as shown in the screenshots below.

**Kegg based view before fix**
![kegg_befor_fix](https://github.com/user-attachments/assets/78b971cc-703a-42f2-b9f0-590bca26b9d0)


**Kegg based view after fix**
![kegg_after_fix](https://github.com/user-attachments/assets/f0a659f6-e09c-4864-93c5-693a0d584ef5)


## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

