### PR TITLE
Display Venn diagram as Edwards for 6 genomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Changed
 
+- Display Venn diagram as Edwards for 6 genomes, as numbers were missing in the classic representation. ([#132](https://github.com/metagenlab/zDB/pull/132)) (Niklaus Johner)
 - Add contig accession and range to genomic regions in plot_region. ([#131](https://github.com/metagenlab/zDB/pull/131)) (Niklaus Johner)
 - Improve error handling for missing input genomes and reference databases. ([#130](https://github.com/metagenlab/zDB/pull/130)) (Niklaus Johner)
 

--- a/webapp/templates/chlamdb/venn_representation_template.html
+++ b/webapp/templates/chlamdb/venn_representation_template.html
@@ -30,6 +30,7 @@ $(document).ready(function() {
     $('#venn_diagram').jvenn({
         series: {{ series|safe }},
         displayStat: true,
+        displayMode: {{ series|safe }}.length == 6 ? 'edwards':'classic',
         fnClickCallback: function() {
             let dataSet = this.list
                 .filter(it => it in data_dict)


### PR DESCRIPTION
 Not all numbers are displayed in the classic representation for the venn diagram with 6 genomes. Adding all numbers makes the diagram unreadable (see screenshot below). Instead we now display it as Edwards. This is a bit of a cheap fix, but the only other option would be to replace the library generating the venn diagrams. We should maybe do that at some point as the current library is really bad, with no option to change the size of the figure and such. Everything is hard coded in the javascript library (position and shapes of everything).

**Classic representation with all numbers**
![venn6](https://github.com/user-attachments/assets/b3b8c997-1346-4a41-8730-418b3bab429e)

**Edwards representation**
![venn6_edwards](https://github.com/user-attachments/assets/2ff54351-7ffb-47af-b94f-1832b47a1102)

resolves #132 

## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

