### PR TITLE
Optimize order of regions in plot_region.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ to [Common Changelog](https://common-changelog.org)
 - Display Venn diagram as Edwards for 6 genomes, as numbers were missing in the classic representation. ([#135](https://github.com/metagenlab/zDB/pull/135)) (Niklaus Johner)
 - Add contig accession and range to genomic regions in plot_region. ([#134](https://github.com/metagenlab/zDB/pull/134)) (Niklaus Johner)
 - Improve error handling for missing input genomes and reference databases. ([#130](https://github.com/metagenlab/zDB/pull/130)) (Niklaus Johner)
+- Optimize order of regions in plot_region. ([#137](https://github.com/metagenlab/zDB/pull/137)) (Niklaus Johner)
+
 
 ### Added
 

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -414,7 +414,7 @@ def locusx_genomic_region(db, seqid, window):
                              "start_pos"]].groupby("seqfeature_id")
         start = grouped["start_pos"].min()
         end = grouped["end_pos"].max()
-        strands = df_seqids[["seqfeature_id", "strand"]].drop_duplicates(
+        strands = df_seqids[["seqfeature_id", "strand", "bioentry_id"]].drop_duplicates(
             "seqfeature_id")
         df_seqids = start.to_frame().join(end).join(
             strands.set_index("seqfeature_id"))


### PR DESCRIPTION
We automatically determine the best order to display the regions in the plot_region view, maximizing the number and order of common orthogroups between consecutive regions. Note that we use a local optimum, taking a path of maximum score between neighbouring regions, not over the full path (although we take the best path among such paths obtained for all starting regions).

As an example see the two screenshots of the same genomic region, with the ordered optimized or not. Note that with the optimization of the order of display of the regions, it is clear in that case that there are 2 orientations for the genes in the region. The homology between certain regions is also much clearer, as prior to optimization a region which does not conserve the OGs is placed in the in the second row.

We also fix a bug in the view for circular contigs which had been introduced in https://github.com/metagenlab/zDB/pull/134

**Without order optimization**
![plot_region_no_optimization](https://github.com/user-attachments/assets/474f5621-898b-42fc-8eab-7509dcc7ae34)

**With order optimization**
![plot_region_optimized_order](https://github.com/user-attachments/assets/62c4f572-f584-4bcc-9ed8-42ccee203f19)





## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

