### PR TITLE
Support for AMRFinder version 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
+- Fix annotation pipeline for new AMRFinder version 4. ([#141](https://github.com/metagenlab/zDB/pull/141)) (Niklaus Johner)
+
 ### Changed
 
 - Display Venn diagram as Edwards for 6 genomes, as numbers were missing in the classic representation. ([#135](https://github.com/metagenlab/zDB/pull/135)) (Niklaus Johner)

--- a/bin/setup_chlamdb.py
+++ b/bin/setup_chlamdb.py
@@ -315,19 +315,19 @@ def load_cog(params, filelist, db_file, cdd_to_cog, cog_db_dir):
 
 
 def amr_hit_to_db_entry(hit):
-    columns = ["Gene symbol",
-               "Sequence name",
+    columns = ["Element symbol",
+               "Element name",
                "Scope",
-               "Element type",
-               "Element subtype",
+               "Type",
+               "Subtype",
                "Class",
                "Subclass",
-               "% Coverage of reference sequence",
-               "% Identity to reference sequence",
-               "Accession of closest sequence",
-               "Name of closest sequence",
-               "HMM id"]
-    entry = [hsh_from_s(hit["Protein identifier"][len("CRC-"):])]
+               "% Coverage of reference",
+               "% Identity to reference",
+               "Closest reference accession",
+               "Closest reference name",
+               "HMM accession"]
+    entry = [hsh_from_s(hit["Protein id"][len("CRC-"):])]
     entry.extend([hit[column] for column in columns])
     return entry
 

--- a/conda/amrfinderplus.yaml
+++ b/conda/amrfinderplus.yaml
@@ -3,4 +3,4 @@ channels:
     - conda-forge
     - bioconda
 dependencies:
-    -  ncbi-amrfinderplus >= 3.12
+    -  ncbi-amrfinderplus >= 4.0

--- a/nextflow.config
+++ b/nextflow.config
@@ -75,7 +75,7 @@ params.orthofinder_container = "quay.io/biocontainers/orthofinder:2.5.2--0"
 params.diamond_container = "registry.hub.docker.com/buchfink/diamond:version2.0.13"
 params.mafft_container = "quay.io/biocontainers/mafft:7.487--h779adbc_0"
 params.fasttree_container = "quay.io/biocontainers/fasttree:2.1.8--h779adbc_6"
-params.ncbi_amr_container = "registry.hub.docker.com/ncbi/amr:latest"
+params.ncbi_amr_container = "registry.hub.docker.com/ncbi/amr:4.0.3-2024-10-22.1"
 
 
 /////////////////////////////


### PR DESCRIPTION
The output of AMRFinder has changed in release 4, so we need to update our code accordingly. This means that zDB only works with AMRFinder 4 or above. We also pin the container to the latest version of AMRFinder and update the conda environment to make sure to use AMRFinder version 4.

see https://github.com/evolarjun/amr/wiki/New-in-AMRFinderPlus/#amrfinderplus-40 for changes to the AMRFinder output.

## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

