### PR TITLE
Add command line parameter to set CSRF_TRUSTED_ORIGINS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Added
 
+- Add command line parameter to set CSRF_TRUSTED_ORIGINS. ([#145](https://github.com/metagenlab/zDB/pull/145)) (Niklaus Johner)
 
 ## 1.3.4 - 2024-11-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 Versions are of the form MAJOR.MINOR.PATCH and this changelog tries to conform
 to [Common Changelog](https://common-changelog.org)
 
+## Unreleased
+
+### Fixed
+
+### Changed
+
+### Added
+
+
 ## 1.3.4 - 2024-11-06
 
 ### Fixed

--- a/bin/zdb
+++ b/bin/zdb
@@ -191,6 +191,7 @@ elif [[ "$1" == "webapp" ]]; then
 	docker=false
 	conda=false
 	allowed_host=""
+	trusted_origins=""
 	dir=$(pwd)
 
 	zdb_folder="${NEXTFLOW_DIR}/webapp/"
@@ -206,6 +207,10 @@ elif [[ "$1" == "webapp" ]]; then
 				;;
 			--allowed_host=*)
 				allowed_host="${i#*=}"
+				shift
+				;;
+			--trusted_origins=*)
+				trusted_origins="${i#*=}"
 				shift
 				;;
 			--name=*)
@@ -251,6 +256,10 @@ elif [[ "$1" == "webapp" ]]; then
 				echo "                      to guess with the hostname command. This is basically" 
 			    echo "	                    the URL or IP adress you will using to access the web page."
 				echo ""
+				echo "--trusted_origins=ORIGINS: coma separated list that will be passed as argument"
+				echo "                      	 to django's CSRF_TRUSTED_ORIGINS. This needs to include"
+				echo "                      	 the scheme, e.g. https://example.com"
+				echo ""
 				echo "By default, the web application will be run in a singularity container."
 				echo "This can be changed with either one of the two following options:"
 				echo "--docker: the web application will be run in a docker instead of "
@@ -292,6 +301,10 @@ elif [[ "$1" == "webapp" ]]; then
 
 	if [ ! -z "${allowed_host}" ]; then
 		allowed_host="--hosts=${allowed_host}"
+	fi
+
+	if [ ! -z "${trusted_origins}" ]; then
+		trusted_origins="--trusted_origins=${trusted_origins}"
 	fi
 
 	dev_server=""
@@ -342,7 +355,7 @@ elif [[ "$1" == "webapp" ]]; then
 	done
 	mkdir -p $zdb_folder/served_assets/temp
 
-	options="--run_name=${run_name} --port=${port} ${debugging_mode} ${allowed_host} ${dev_server}"
+	options="--run_name=${run_name} --port=${port} ${debugging_mode} ${allowed_host} ${trusted_origins} ${dev_server}"
 	if [[ "$docker" = true ]]; then
 		full_docker_name="registry.hub.docker.com/metagenlab/${zdb_container}"
 		docker pull ${full_docker_name}

--- a/webapp/settings/settings.py
+++ b/webapp/settings/settings.py
@@ -19,6 +19,7 @@ SECRET_KEY = secrets.token_urlsafe()
 DEBUG = int(os.environ.get("DEBUG", 0))
 RUN_NAME = os.environ["RUN_NAME"]
 hosts = os.environ.get("ALLOWED_HOSTS", "localhost")
+trusted_origins = os.environ.get("CSRF_TRUSTED_ORIGINS")
 
 PREFIX = "served_assets"
 
@@ -27,6 +28,8 @@ SEARCH_INDEX = PREFIX + "/search_index/" + RUN_NAME
 BLAST_DB_PATH = PREFIX + "/blast_DB/" + RUN_NAME
 
 ALLOWED_HOSTS = hosts.split(",")
+if trusted_origins:
+    CSRF_TRUSTED_ORIGINS = trusted_origins.split(",")
 
 BIODB_CONF = {
     "zdb.db_type": "sqlite",

--- a/webapp/start_webapp
+++ b/webapp/start_webapp
@@ -7,6 +7,7 @@ custom_run_name=""
 default_port="8080"
 default_run_name="latest"
 hosts=""
+origins=""
 use_dev_server=false
 
 
@@ -22,6 +23,10 @@ for i in "$@"; do
 			;;
 		--hosts=*)
 			hosts="${i#*=}"
+			shift
+			;;
+		--trusted_origins=*)
+			origins="${i#*=}"
 			shift
 			;;
 		--use_dev_server)
@@ -95,6 +100,7 @@ export PORT="$custom_port"
 export RUN_NAME="$custom_run_name"
 export DEBUG="$debugging"
 export ALLOWED_HOSTS="${hosts// /,}"
+export CSRF_TRUSTED_ORIGINS="${origins// /,}"
 export ZDB_DEVSERVER="$use_dev_server"
 
 # go to the chlamdb folder
@@ -149,5 +155,6 @@ unset DISPLAY
 unset PORT
 unset RUN_NAME
 unset ALLOWED_HOSTS
+unset CSRF_TRUSTED_ORIGINS
 unset DEBUG
 unset ZDB_DEVSERVER


### PR DESCRIPTION
It seems that the CSRF protection has changed in django 4.0 and it is now necessary to set the trusted origins in certain situations. See
https://docs.djangoproject.com/en/5.1/releases/4.0/#csrf-trusted-origins-changes

We notably need to set the `CSRF_TRUSTED_ORIGINS` for our demo zdb.metagenlab.ch.

## Checklist
- [x] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

