### PR TITLE
Fix SQL queries for libsqlite 3.49.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
+- Fix SQL queries for libsqlite 3.49.1. ([#151](https://github.com/metagenlab/zDB/pull/151)) (Niklaus Johner)
+
 ### Changed
 
 - Cite zDB paper on home page and about pages. ([#147](https://github.com/metagenlab/zDB/pull/147)) (Niklaus Johner)

--- a/bin/annotations.py
+++ b/bin/annotations.py
@@ -1,20 +1,22 @@
 import os
 import re
-from collections import defaultdict, namedtuple
+from collections import defaultdict
+from collections import namedtuple
 
 import pandas as pd
-from Bio import AlignIO, SeqIO
+from Bio import AlignIO
+from Bio import SeqIO
 from Bio.Align import MultipleSeqAlignment
 from Bio.SeqUtils import CheckSum
 
 
 def chunks(lst, n):
     for i in range(0, len(lst), n):
-        yield lst[i:i + n]
+        yield lst[i : i + n]
 
 
 def orthogroups_to_fasta(genomes_list):
-    fasta_list = genomes_list.split(' ')
+    fasta_list = genomes_list.split(" ")
 
     sequence_data = {}
     for fasta_file in fasta_list:
@@ -24,7 +26,7 @@ def orthogroups_to_fasta(genomes_list):
     with open("Orthogroups.txt") as f:
         all_grp = [i for i in f]
         for n, line in enumerate(all_grp):
-            groups = line.rstrip().split(' ')
+            groups = line.rstrip().split(" ")
             group_name = groups[0][:-1]
             groups = groups[1:]
             if len(groups) > 1:
@@ -43,35 +45,40 @@ def check_reference_databases(params):
     if params.get("cog"):
         if not os.path.isdir(os.path.join(db_dir, "cog")):
             raise MissingReferenceDatabase(
-                'COG database could not be found. '
-                'Please set it up with "zdb setup --cog"')
+                "COG database could not be found. "
+                'Please set it up with "zdb setup --cog"'
+            )
     if params.get("ko"):
         if not os.path.isdir(os.path.join(db_dir, "kegg")):
             raise MissingReferenceDatabase(
-                'KEGG database could not be found. '
-                'Please set it up with "zdb setup --ko"')
+                "KEGG database could not be found. "
+                'Please set it up with "zdb setup --ko"'
+            )
     if params.get("pfam"):
         if not os.path.isdir(os.path.join(db_dir, "pfam")):
             raise MissingReferenceDatabase(
-                'Pfam database could not be found. '
-                'Please set it up with "zdb setup --pfam"')
+                "Pfam database could not be found. "
+                'Please set it up with "zdb setup --pfam"'
+            )
     if params.get("swissprot"):
         if not os.path.isdir(os.path.join(db_dir, "uniprot", "swissprot")):
             raise MissingReferenceDatabase(
-                'Swissprot database could not be found. '
-                'Please set it up with "zdb setup --swissprot"')
+                "Swissprot database could not be found. "
+                'Please set it up with "zdb setup --swissprot"'
+            )
     if params.get("vfdb"):
         if not os.path.isdir(os.path.join(db_dir, "vfdb")):
             raise MissingReferenceDatabase(
-                'VFDB database could not be found. '
-                'Please set it up with "zdb setup --vfdb"')
+                "VFDB database could not be found. "
+                'Please set it up with "zdb setup --vfdb"'
+            )
 
 
 class InvalidInput(Exception):
     pass
 
 
-class InputHandler():
+class InputHandler:
     """
     This class is in charge of parsing the input csv, checking
     and if necessary revising the GBK files.
@@ -136,20 +143,19 @@ class InputHandler():
             return True
         raise InvalidInput(
             f'Invalid entry "{value}" in group column. Should be one of '
-            '"yes", "true", "x", "1", "no", "false", "0" or empty')
+            '"yes", "true", "x", "1", "no", "false", "0" or empty'
+        )
 
     @classmethod
     def parse_csv(cls, csv_file):
-        csv = pd.read_csv(csv_file, dtype=str,
-                          skipinitialspace=True).fillna('')
+        csv = pd.read_csv(csv_file, dtype=str, skipinitialspace=True).fillna("")
         entries = []
         names = set()
 
         group_names = {}
         for colname in csv.columns:
             if not cls.is_header_allowed(colname):
-                raise InvalidInput(
-                    f'Invalid column header "{colname}" in input file.')
+                raise InvalidInput(f'Invalid column header "{colname}" in input file.')
             if cls.header_is_group(colname):
                 group_names[colname] = cls.header_to_group_label(colname)
 
@@ -160,7 +166,8 @@ class InputHandler():
             if name:
                 if name in names:
                     raise InvalidInput(
-                        f'Name "{name}" appears twice in the input file.')
+                        f'Name "{name}" appears twice in the input file.'
+                    )
                 names.add(name)
 
             # only get the filename, as nextflow will symlink it
@@ -169,11 +176,13 @@ class InputHandler():
             if not os.path.isfile(filename):
                 raise InvalidInput(
                     f'File "{filename}" cannot be accessed. Please check '
-                    f'that {entry.file} exists and is accessible.')
+                    f"that {entry.file} exists and is accessible."
+                )
 
             if filename in filenames:
                 raise InvalidInput(
-                    f'File "{filename}" appears twice in the input file.')
+                    f'File "{filename}" appears twice in the input file.'
+                )
             filenames.add(filename)
 
             groups = []
@@ -222,8 +231,9 @@ class InputHandler():
                     common_name = entry.name
 
                 if sci_name is None:
-                    raise Exception(f"No scientific name for record {record.id} "
-                                    f"in {gbk_file}.")
+                    raise Exception(
+                        f"No scientific name for record {record.id} in {gbk_file}."
+                    )
 
                 if record.name in self.contigs:
                     needs_revision = True
@@ -243,7 +253,9 @@ class InputHandler():
                     if self.organisms[sci_name] > 1:
                         needs_revision = True
                 elif curr_organism != sci_name:
-                    raise Exception(f"Two different organisms in {gbk_file}: {curr_organism}/{sci_name}")
+                    raise Exception(
+                        f"Two different organisms in {gbk_file}: {curr_organism}/{sci_name}"
+                    )
 
                 # necessary, as BioSQL will use whatever matches in the
                 # common or scientific names to assign taxid. So if the common name
@@ -269,7 +281,8 @@ class InputHandler():
 
             if n_cds == 0:
                 raise Exception(
-                    f"No CDS in {gbk_file}, has it been correctly annotated?")
+                    f"No CDS in {gbk_file}, has it been correctly annotated?"
+                )
 
             if needs_revision:
                 gbk_to_revise.append(gbk_file)
@@ -279,7 +292,8 @@ class InputHandler():
         for filename, name in custom_names.items():
             if self.organisms[name] > 1:
                 raise Exception(
-                    f"The custom name {name} is already used in another file")
+                    f"The custom name {name} is already used in another file"
+                )
 
         # at one point, will have to rewrite this to avoid
         # re-parsing the genbank files that failed the check
@@ -304,7 +318,8 @@ class InputHandler():
                 # when writing the same record. It instead recognizes the "accession" entry.
                 if "accessions" not in record.annotations:
                     record.annotations["accession"] = [
-                        self.gen_new_locus_tag(self.accessions)]
+                        self.gen_new_locus_tag(self.accessions)
+                    ]
                 elif self.accessions[record.annotations["accessions"][0]] > 1:
                     new_acc = self.gen_new_locus_tag(self.accessions)
                     if "accession" not in record.annotations:
@@ -325,10 +340,12 @@ class InputHandler():
                     curr_locus = feature.qualifiers.get("locus_tag", None)
                     if curr_locus is None:
                         feature.qualifiers["locus_tag"] = self.gen_new_locus_tag(
-                            self.locuses)
+                            self.locuses
+                        )
                     elif self.locuses[curr_locus[0]] > 1:
                         feature.qualifiers["locus_tag"] = self.gen_new_locus_tag(
-                            self.locuses)
+                            self.locuses
+                        )
                         self.locuses[curr_locus[0]] -= 1
                 records.append(record)
             SeqIO.write(records, "filtered/" + failed_gbk, "genbank")
@@ -338,19 +355,21 @@ class InputHandler():
 
 
 def convert_gbk_to_fasta(gbf_file, edited_gbf, output_fmt="faa", keep_pseudo=False):
-    records = SeqIO.parse(gbf_file, 'genbank')
-    edited_records = open(edited_gbf, 'w')
+    records = SeqIO.parse(gbf_file, "genbank")
+    edited_records = open(edited_gbf, "w")
 
     for record in records:
         for feature in record.features:
-            if feature.type == 'CDS':
-                if not keep_pseudo and ('pseudo' in feature.qualifiers
-                                        or 'pseudogene' in feature.qualifiers):
+            if feature.type == "CDS":
+                if not keep_pseudo and (
+                    "pseudo" in feature.qualifiers or "pseudogene" in feature.qualifiers
+                ):
                     continue
 
                 if "locus_tag" not in feature.qualifiers:
                     raise Exception(
-                        f"Feature without locus tag in record {record.name}")
+                        f"Feature without locus tag in record {record.name}"
+                    )
 
                 locus_tag = feature.qualifiers["locus_tag"][0]
                 if output_fmt == "faa":
@@ -360,21 +379,25 @@ def convert_gbk_to_fasta(gbf_file, edited_gbf, output_fmt="faa", keep_pseudo=Fal
                 elif output_fmt == "fna":
                     data = feature.location.extract(record).seq
                 else:
-                    raise Exception(f"Unsupported option: {output_fmt}, must be either faa or fna")
+                    raise Exception(
+                        f"Unsupported option: {output_fmt}, must be either faa or fna"
+                    )
 
-                edited_records.write(">%s %s\n%s\n" % (locus_tag,
-                                                       record.description, data))
+                edited_records.write(
+                    ">%s %s\n%s\n" % (locus_tag, record.description, data)
+                )
     edited_records.close()
 
 
 def convert_gbk_to_fna(gbf_file, fna_contigs):
     # from BioPython, object of class SeqRecord
-    records = SeqIO.parse(gbf_file, 'genbank')
-    edited_records = open(fna_contigs, 'w')
+    records = SeqIO.parse(gbf_file, "genbank")
+    edited_records = open(fna_contigs, "w")
 
     for record in records:
-        edited_records.write(">%s %s\n%s\n" %
-                             (record.name, record.description, record.seq))
+        edited_records.write(
+            ">%s %s\n%s\n" % (record.name, record.description, record.seq)
+        )
     edited_records.close()
 
 
@@ -382,11 +405,11 @@ def convert_gbk_to_fna(gbf_file, fna_contigs):
 def get_nr_sequences(fasta_file, genomes_list):
     locus2genome = {}
     for fasta in genomes_list:
-        genome = os.path.basename(fasta).split('.')[0]
+        genome = os.path.basename(fasta).split(".")[0]
         for seq in SeqIO.parse(fasta, "fasta"):
             locus2genome[seq.name] = genome
-    nr_fasta = open('nr.faa', 'w')
-    nr_mapping = open('nr_mapping.tab', 'w')
+    nr_fasta = open("nr.faa", "w")
+    nr_mapping = open("nr_mapping.tab", "w")
 
     hsh_checksum_list = {}
 
@@ -394,13 +417,12 @@ def get_nr_sequences(fasta_file, genomes_list):
     updated_records = []
 
     for record in records:
-
         # NOTE: the case is important for crc64, need to check whether it
         # is necessary to make all entries lower/upper case to ensure consistency.
         checksum = CheckSum.crc64(record.seq)
-        nr_mapping.write("%s\t%s\t%s\n" % (record.id,
-                                           checksum,
-                                           locus2genome[record.id]))
+        nr_mapping.write(
+            "%s\t%s\t%s\n" % (record.id, checksum, locus2genome[record.id])
+        )
         if checksum not in hsh_checksum_list:
             hsh_checksum_list[checksum] = [record]
             record.id = checksum
@@ -439,20 +461,18 @@ def get_nr_sequences(fasta_file, genomes_list):
 # ortholog present in all samples)
 #
 # Orthofinder output file : Orthogroup_ID: locus1 locus2... locusN
-def orthofinder2core_groups(fasta_list,
-                            mcl_file,
-                            n_missing=0):
+def orthofinder2core_groups(fasta_list, mcl_file, n_missing=0):
     orthogroup2locus_list = {}
-    with open(mcl_file, 'r') as f:
+    with open(mcl_file, "r") as f:
         for line in f:
-            groups = line.rstrip().split(' ')
+            groups = line.rstrip().split(" ")
             group_id = groups[0][:-1]  # remove lagging ':'
             groups = groups[1:]
             orthogroup2locus_list[group_id] = groups
 
     locus2genome = {}
     for fasta in fasta_list:
-        tokens = os.path.basename(fasta).split('.')
+        tokens = os.path.basename(fasta).split(".")
         # the filename may contain additional "." that are to be included
         genome = ".".join(tokens[:-1])
         for seq in SeqIO.parse(fasta, "fasta"):
@@ -481,8 +501,9 @@ def orthofinder2core_groups(fasta_list,
 
 
 def get_core_orthogroups(genomes_list, int_core_missing):
-    core_groups, orthogroup2locus_list, locus2genome = orthofinder2core_groups(genomes_list,
-                                                                               'Orthogroups.txt', int_core_missing)
+    core_groups, orthogroup2locus_list, locus2genome = orthofinder2core_groups(
+        genomes_list, "Orthogroups.txt", int_core_missing
+    )
 
     og_resume_file = open("orthogroups_summary_info.tsv", "w")
     core_groups_set = set(core_groups)
@@ -498,12 +519,12 @@ def get_core_orthogroups(genomes_list, int_core_missing):
 
     if len(core_groups) <= 0:
         raise Exception(
-            "No core orthogroups, maybe try to rerun the pipeline with num_missing to a higher value")
+            "No core orthogroups, maybe try to rerun the pipeline with num_missing to a higher value"
+        )
 
     for group_id in core_groups:
-        sequence_data = SeqIO.to_dict(
-            SeqIO.parse(group_id + "_mafft.faa", "fasta"))
-        dest = group_id + '_taxon_ids.faa'
+        sequence_data = SeqIO.to_dict(SeqIO.parse(group_id + "_mafft.faa", "fasta"))
+        dest = group_id + "_taxon_ids.faa"
         new_fasta = []
         for locus in orthogroup2locus_list[group_id]:
             tmp_seq = sequence_data[locus]
@@ -512,7 +533,7 @@ def get_core_orthogroups(genomes_list, int_core_missing):
             tmp_seq.description = locus2genome[locus]
             new_fasta.append(tmp_seq)
 
-        out_handle = open(dest, 'w')
+        out_handle = open(dest, "w")
         SeqIO.write(new_fasta, out_handle, "fasta")
         out_handle.close()
 
@@ -539,8 +560,7 @@ def calculate_og_identities(input_fasta, output_file):
                 per_identity = 100 * (identical / float(alignment_length))
             else:
                 per_identity = 0
-            values.append((locus_tag_1, locus_tag_2,
-                          per_identity, alignment_length))
+            values.append((locus_tag_1, locus_tag_2, per_identity, alignment_length))
     output_fh = open(output_file, "w")
     for lt1, lt2, ident, le in values:
         print(lt1, lt2, ident, le, sep=",", file=output_fh)
@@ -548,7 +568,7 @@ def calculate_og_identities(input_fasta, output_file):
 
 
 def concatenate_core_orthogroups(fasta_files):
-    out_name = 'msa.faa'
+    out_name = "msa.faa"
 
     taxons = []
     all_seq_data = {}

--- a/bin/download_ref_db.py
+++ b/bin/download_ref_db.py
@@ -24,8 +24,11 @@ def download_refseq(download_dir, n_retry=10):
     # letters to make sure it ends with faa.gz, instead of using regular
     # expression
     nr_re = re.compile(r"complete.nonredundant_protein.(\d)*.protein.faa.gz")
-    nr_filelist = [i for i in ftp.nlst() if re.match(nr_re, i) is not None
-                   and i not in existing_files]
+    nr_filelist = [
+        i
+        for i in ftp.nlst()
+        if re.match(nr_re, i) is not None and i not in existing_files
+    ]
 
     for f in nr_filelist:
         failed = 0
@@ -43,18 +46,34 @@ def download_refseq(download_dir, n_retry=10):
                 failed += 1
                 if failed == n_retry:
                     os.remove(f)
-                    raise Exception("Failed to download " + f + ". You may retry \
-                            to run the script to complete the download.")
+                    raise Exception(
+                        "Failed to download "
+                        + f
+                        + ". You may retry \
+                            to run the script to complete the download."
+                    )
         existing_files.add(f)
 
 
-parser = argparse.ArgumentParser(description="""Downloads the databases necessary
-        for the annotation pipeline""")
+parser = argparse.ArgumentParser(
+    description="""Downloads the databases necessary
+        for the annotation pipeline"""
+)
 
-parser.add_argument("--download_ko", nargs="?", const="databases/ko/", default=False,
-                    help="download ko file definition, necessary to do this before --load-kegg")
-parser.add_argument("--download_refseq", nargs="?", const="databases/refseq/", default=False,
-                    help="download ko file definition, necessary to do this before --load-kegg")
+parser.add_argument(
+    "--download_ko",
+    nargs="?",
+    const="databases/ko/",
+    default=False,
+    help="download ko file definition, necessary to do this before --load-kegg",
+)
+parser.add_argument(
+    "--download_refseq",
+    nargs="?",
+    const="databases/refseq/",
+    default=False,
+    help="download ko file definition, necessary to do this before --load-kegg",
+)
 
 
 args = vars(parser.parse_args())

--- a/testing/pipelines/base.py
+++ b/testing/pipelines/base.py
@@ -6,7 +6,6 @@ import nextflow
 
 
 class BaseTestCase(TestCase):
-
     def assertItemsEqual(self, actual, expected):
         self.assertEqual(sorted(actual), sorted(expected))
 
@@ -16,7 +15,6 @@ class BaseTestCase(TestCase):
 
 
 class BasePipelineTestCase(BaseTestCase):
-
     nf_filename = None
     ref_db_dir = None
 
@@ -34,21 +32,14 @@ class BasePipelineTestCase(BaseTestCase):
             "base_db": self.ref_db_dir,
             "singularity_dir": self.singularity_dir.name,
         }
-        self.nf_args = {
-            "run_path": "./testing/pipelines"}
+        self.nf_args = {"run_path": "./testing/pipelines"}
 
     def execute_pipeline(self):
-        return nextflow.run(self.nf_file_path,
-                            params=self.nf_params,
-                            **self.nf_args)
+        return nextflow.run(self.nf_file_path, params=self.nf_params, **self.nf_args)
 
     def assert_success(self, execution):
-        self.assertEqual(execution.status, "OK",
-                         "Pipeline execution failed")
-        self.assertEqual(execution.return_code, "0",
-                         "Pipeline execution failed")
+        self.assertEqual(execution.status, "OK", "Pipeline execution failed")
+        self.assertEqual(execution.return_code, "0", "Pipeline execution failed")
         for proc in execution.process_executions:
-            self.assertIn(proc.return_code, ["0", ""],
-                          "Process execution failed")
-            self.assertIn(proc.status, ["COMPLETED", "-"],
-                          "Process execution failed")
+            self.assertIn(proc.return_code, ["0", ""], "Process execution failed")
+            self.assertIn(proc.status, ["COMPLETED", "-"], "Process execution failed")

--- a/testing/pipelines/test_annotation_pipeline.py
+++ b/testing/pipelines/test_annotation_pipeline.py
@@ -1,62 +1,63 @@
 import os
 
-from sqlalchemy import MetaData, create_engine
+from sqlalchemy import MetaData
+from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
+
 from testing.pipelines.base import BasePipelineTestCase
 
 base_tables = [
-    'biodatabase',
-    'biodb_config',
-    'bioentry',
-    'bioentry_dbxref',
-    'bioentry_path',
-    'bioentry_qualifier_value',
-    'bioentry_reference',
-    'bioentry_relationship',
-    'biosequence',
-    'cog_functions',
-    'cog_names',
-    'comment',
-    'dbxref',
-    'dbxref_qualifier_value',
-    'filenames',
-    'gene_phylogeny',
-    'genome_summary',
-    'groups',
-    'ko_class',
-    'ko_def',
-    'ko_module_def',
-    'ko_pathway_def',
-    'ko_to_module',
-    'ko_to_pathway',
-    'location',
-    'location_qualifier_value',
-    'og_hits',
-    'ontology',
-    'orthology_identity',
-    'reference',
-    'reference_phylogeny',
-    'seqfeature',
-    'seqfeature_dbxref',
-    'seqfeature_path',
-    'seqfeature_qualifier_value',
-    'seqfeature_relationship',
-    'sequence_hash_dictionnary',
-    'taxon',
-    'taxon_in_group',
-    'taxon_name',
-    'term',
-    'term_dbxref',
-    'term_path',
-    'term_relationship',
-    'term_relationship_term',
-    'term_synonym',
-    'versions'
+    "biodatabase",
+    "biodb_config",
+    "bioentry",
+    "bioentry_dbxref",
+    "bioentry_path",
+    "bioentry_qualifier_value",
+    "bioentry_reference",
+    "bioentry_relationship",
+    "biosequence",
+    "cog_functions",
+    "cog_names",
+    "comment",
+    "dbxref",
+    "dbxref_qualifier_value",
+    "filenames",
+    "gene_phylogeny",
+    "genome_summary",
+    "groups",
+    "ko_class",
+    "ko_def",
+    "ko_module_def",
+    "ko_pathway_def",
+    "ko_to_module",
+    "ko_to_pathway",
+    "location",
+    "location_qualifier_value",
+    "og_hits",
+    "ontology",
+    "orthology_identity",
+    "reference",
+    "reference_phylogeny",
+    "seqfeature",
+    "seqfeature_dbxref",
+    "seqfeature_path",
+    "seqfeature_qualifier_value",
+    "seqfeature_relationship",
+    "sequence_hash_dictionnary",
+    "taxon",
+    "taxon_in_group",
+    "taxon_name",
+    "term",
+    "term_dbxref",
+    "term_path",
+    "term_relationship",
+    "term_relationship_term",
+    "term_synonym",
+    "versions",
 ]
 
 
 class TestAnnotationPipeline(BasePipelineTestCase):
-
     nf_filename = "annotation_pipeline.nf"
 
     @property
@@ -70,7 +71,8 @@ class TestAnnotationPipeline(BasePipelineTestCase):
     def load_db(self, execution):
         self.metadata_obj = MetaData()
         self.engine = create_engine(
-            "sqlite:////" + os.path.join(self.db_dir, execution.identifier))
+            "sqlite:////" + os.path.join(self.db_dir, execution.identifier)
+        )
         self.session = Session(self.engine)
         self.metadata_obj.reflect(bind=self.engine)
 
@@ -80,7 +82,8 @@ class TestAnnotationPipeline(BasePipelineTestCase):
     def setUp(self):
         super(TestAnnotationPipeline, self).setUp()
         self.nf_params["input"] = os.path.join(
-            self.test_dir, "assets", "test_input.csv")
+            self.test_dir, "assets", "test_input.csv"
+        )
 
     def assert_created_files(self, proc, files):
         created_files = os.listdir(proc.path)
@@ -113,8 +116,9 @@ class TestAnnotationPipeline(BasePipelineTestCase):
         self.load_db(execution)
 
         # Let's check that tables were correctly created and filled
-        self.assertItemsEqual(base_tables + ['cog_hits'],
-                              self.metadata_obj.tables.keys())
+        self.assertItemsEqual(
+            base_tables + ["cog_hits"], self.metadata_obj.tables.keys()
+        )
         self.assert_db_base_table_row_counts()
         self.assertEqual(189, self.query("cog_hits").count())
 
@@ -125,8 +129,10 @@ class TestAnnotationPipeline(BasePipelineTestCase):
         self.load_db(execution)
 
         # Let's check that tables were correctly created and filled
-        self.assertItemsEqual(base_tables + ['module_completeness', 'ko_hits'],
-                              self.metadata_obj.tables.keys())
+        self.assertItemsEqual(
+            base_tables + ["module_completeness", "ko_hits"],
+            self.metadata_obj.tables.keys(),
+        )
         self.assert_db_base_table_row_counts()
         self.assertEqual(3, self.query("module_completeness").count())
         self.assertEqual(137, self.query("ko_hits").count())
@@ -138,8 +144,9 @@ class TestAnnotationPipeline(BasePipelineTestCase):
         self.load_db(execution)
 
         # Let's check that tables were correctly created and filled
-        self.assertItemsEqual(base_tables + ['pfam_hits', 'pfam_table'],
-                              self.metadata_obj.tables.keys())
+        self.assertItemsEqual(
+            base_tables + ["pfam_hits", "pfam_table"], self.metadata_obj.tables.keys()
+        )
         self.assert_db_base_table_row_counts()
         self.assertEqual(324, self.query("pfam_hits").count())
         self.assertEqual(237, self.query("pfam_table").count())
@@ -152,8 +159,9 @@ class TestAnnotationPipeline(BasePipelineTestCase):
 
         # Let's check that tables were correctly created and filled
         self.assertItemsEqual(
-            base_tables + ['swissprot_defs', 'swissprot_hits'],
-            self.metadata_obj.tables.keys())
+            base_tables + ["swissprot_defs", "swissprot_hits"],
+            self.metadata_obj.tables.keys(),
+        )
         self.assert_db_base_table_row_counts()
         # The exact number of hits depends on the version of the ref db
         self.assertTrue(self.query("swissprot_defs").count() > 19400)
@@ -167,8 +175,8 @@ class TestAnnotationPipeline(BasePipelineTestCase):
 
         # Let's check that tables were correctly created and filled
         self.assertItemsEqual(
-            base_tables + ['amr_hits'],
-            self.metadata_obj.tables.keys())
+            base_tables + ["amr_hits"], self.metadata_obj.tables.keys()
+        )
         self.assert_db_base_table_row_counts()
         self.assertEqual(2, self.query("amr_hits").count())
 
@@ -180,8 +188,8 @@ class TestAnnotationPipeline(BasePipelineTestCase):
 
         # Let's check that tables were correctly created and filled
         self.assertItemsEqual(
-            base_tables + ['vf_hits', 'vf_defs'],
-            self.metadata_obj.tables.keys())
+            base_tables + ["vf_hits", "vf_defs"], self.metadata_obj.tables.keys()
+        )
         self.assert_db_base_table_row_counts()
         self.assertEqual(36, self.query("vf_hits").count())
         self.assertEqual(35, self.query("vf_defs").count())
@@ -202,19 +210,20 @@ class TestAnnotationPipeline(BasePipelineTestCase):
 
         # Let's check that tables were correctly created and filled
         added_tables = [
-            'ko_hits',
-            'pfam_table',
-            'pfam_hits',
-            'cog_hits',
-            'swissprot_hits',
-            'swissprot_defs',
-            'module_completeness',
-            'amr_hits',
-            'vf_defs',
-            'vf_hits',
+            "ko_hits",
+            "pfam_table",
+            "pfam_hits",
+            "cog_hits",
+            "swissprot_hits",
+            "swissprot_defs",
+            "module_completeness",
+            "amr_hits",
+            "vf_defs",
+            "vf_hits",
         ]
-        self.assertItemsEqual(base_tables + added_tables,
-                              self.metadata_obj.tables.keys())
+        self.assertItemsEqual(
+            base_tables + added_tables, self.metadata_obj.tables.keys()
+        )
         self.assert_db_base_table_row_counts()
         self.assertEqual(189, self.query("cog_hits").count())
         self.assertEqual(3, self.query("module_completeness").count())
@@ -228,5 +237,14 @@ class TestAnnotationPipeline(BasePipelineTestCase):
         self.assertEqual(35, self.query("vf_defs").count())
 
         self.assertItemsEqual(
-            ["Pfam", "SwissProt", "Ko", "CDD", "AMRFinderSoftware", "AMRFinderDB", "VFDB"],
-            [row[0] for row in self.query("versions").all()])
+            [
+                "Pfam",
+                "SwissProt",
+                "Ko",
+                "CDD",
+                "AMRFinderSoftware",
+                "AMRFinderDB",
+                "VFDB",
+            ],
+            [row[0] for row in self.query("versions").all()],
+        )

--- a/testing/pipelines/test_annotation_pipeline.py
+++ b/testing/pipelines/test_annotation_pipeline.py
@@ -120,7 +120,7 @@ class TestAnnotationPipeline(BasePipelineTestCase):
             base_tables + ["cog_hits"], self.metadata_obj.tables.keys()
         )
         self.assert_db_base_table_row_counts()
-        self.assertEqual(189, self.query("cog_hits").count())
+        self.assertEqual(196, self.query("cog_hits").count())
 
     def test_ko_hits(self):
         self.nf_params["ko"] = "true"
@@ -149,7 +149,7 @@ class TestAnnotationPipeline(BasePipelineTestCase):
         )
         self.assert_db_base_table_row_counts()
         self.assertEqual(324, self.query("pfam_hits").count())
-        self.assertEqual(237, self.query("pfam_table").count())
+        self.assertEqual(236, self.query("pfam_table").count())
 
     def test_swissprot_hits(self):
         self.nf_params["blast_swissprot"] = "true"
@@ -225,11 +225,11 @@ class TestAnnotationPipeline(BasePipelineTestCase):
             base_tables + added_tables, self.metadata_obj.tables.keys()
         )
         self.assert_db_base_table_row_counts()
-        self.assertEqual(189, self.query("cog_hits").count())
+        self.assertEqual(196, self.query("cog_hits").count())
         self.assertEqual(3, self.query("module_completeness").count())
         self.assertEqual(137, self.query("ko_hits").count())
         self.assertEqual(324, self.query("pfam_hits").count())
-        self.assertEqual(237, self.query("pfam_table").count())
+        self.assertEqual(236, self.query("pfam_table").count())
         self.assertTrue(self.query("swissprot_defs").count() > 19400)
         self.assertTrue(self.query("swissprot_hits").count() > 29400)
         self.assertEqual(2, self.query("amr_hits").count())

--- a/testing/pipelines/test_annotations_functional.py
+++ b/testing/pipelines/test_annotations_functional.py
@@ -4,14 +4,17 @@ from io import StringIO
 
 from testing.pipelines.base import BaseTestCase
 
-sys.path.append(os.path.join(os.path.dirname(os.path.dirname(
-    os.path.dirname(os.path.abspath(__file__)))), "bin"))
+sys.path.append(
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "bin",
+    )
+)
 
 from annotations import InputHandler, InvalidInput  # noqa
 
 
 class TestInputHandler(BaseTestCase):
-
     def setUp(self):
         self._cwd = os.getcwd()
         os.chdir(os.path.join(self.test_dir, "assets"))
@@ -32,71 +35,93 @@ class TestInputHandler(BaseTestCase):
         input_file = "test_input.csv"
         handler = InputHandler(input_file)
         self.assert_names(handler, [None, None, None])
-        self.assert_files(handler, ['R6724_16313_small.gbk',
-                                    'R6726_16314_small.gbk',
-                                    'R6728_16315_small.gbk'])
+        self.assert_files(
+            handler,
+            ["R6724_16313_small.gbk", "R6726_16314_small.gbk", "R6728_16315_small.gbk"],
+        )
 
     def test_handles_name_column(self):
-        input_file = StringIO("name, file\nfoo,R6724_16313_small.gbk\nbar, R6726_16314_small.gbk")
+        input_file = StringIO(
+            "name, file\nfoo,R6724_16313_small.gbk\nbar, R6726_16314_small.gbk"
+        )
         handler = InputHandler(input_file)
         self.assertEqual(2, len(handler.csv_entries))
         self.assert_names(handler, ["foo", "bar"])
-        self.assert_files(handler, ['R6724_16313_small.gbk', 'R6726_16314_small.gbk'])
+        self.assert_files(handler, ["R6724_16313_small.gbk", "R6726_16314_small.gbk"])
 
     def test_handles_incomplete_name_column(self):
-        input_file = StringIO("name,file\n,R6724_16313_small.gbk\nbar,R6726_16314_small.gbk")
+        input_file = StringIO(
+            "name,file\n,R6724_16313_small.gbk\nbar,R6726_16314_small.gbk"
+        )
         handler = InputHandler(input_file)
         self.assertEqual(2, len(handler.csv_entries))
         self.assert_names(handler, [None, "bar"])
-        self.assert_files(handler, ['R6724_16313_small.gbk', 'R6726_16314_small.gbk'])
+        self.assert_files(handler, ["R6724_16313_small.gbk", "R6726_16314_small.gbk"])
 
     def test_handles_group_columns(self):
-        input_file = StringIO("name,file,group:first one,group:second_group\n"
-                              "foo,R6724_16313_small.gbk,1,\n"
-                              "bar,R6726_16314_small.gbk,false,True\n")
+        input_file = StringIO(
+            "name,file,group:first one,group:second_group\n"
+            "foo,R6724_16313_small.gbk,1,\n"
+            "bar,R6726_16314_small.gbk,false,True\n"
+        )
         handler = InputHandler(input_file)
         self.assertEqual(2, len(handler.csv_entries))
         self.assert_names(handler, ["foo", "bar"])
-        self.assert_files(handler, ['R6724_16313_small.gbk', 'R6726_16314_small.gbk'])
+        self.assert_files(handler, ["R6724_16313_small.gbk", "R6726_16314_small.gbk"])
         self.assert_groups(handler, [["first one"], ["second_group"]])
 
     def test_raises_for_missing_file(self):
         input_file = StringIO("file\nfoo.gbk\nR6724_16313_small.gbk")
         with self.assertRaises(InvalidInput) as exc:
             InputHandler(input_file)
-        self.assertEqual('File "foo.gbk" cannot be accessed. Please check that'
-                         ' foo.gbk exists and is accessible.',
-                         str(exc.exception))
+        self.assertEqual(
+            'File "foo.gbk" cannot be accessed. Please check that'
+            " foo.gbk exists and is accessible.",
+            str(exc.exception),
+        )
 
     def test_raises_for_dupplicate_filename(self):
         input_file = StringIO("file\nR6724_16313_small.gbk\nR6724_16313_small.gbk")
         with self.assertRaises(InvalidInput) as exc:
             InputHandler(input_file)
-        self.assertEqual('File "R6724_16313_small.gbk" appears twice in the input file.',
-                         str(exc.exception))
+        self.assertEqual(
+            'File "R6724_16313_small.gbk" appears twice in the input file.',
+            str(exc.exception),
+        )
 
     def test_raises_for_dupplicate_name(self):
-        input_file = StringIO("file,name\nR6724_16313_small.gbk,foo\nR6726_16314_small.gbk,foo")
+        input_file = StringIO(
+            "file,name\nR6724_16313_small.gbk,foo\nR6726_16314_small.gbk,foo"
+        )
         with self.assertRaises(InvalidInput) as exc:
             InputHandler(input_file)
-        self.assertEqual('Name "foo" appears twice in the input file.',
-                         str(exc.exception))
+        self.assertEqual(
+            'Name "foo" appears twice in the input file.', str(exc.exception)
+        )
 
     def test_raises_for_invalid_column_header(self):
-        input_file = StringIO("filee,name\nR6724_16313_small.gbk,foo\nR6726_16314_small.gbk,foo")
+        input_file = StringIO(
+            "filee,name\nR6724_16313_small.gbk,foo\nR6726_16314_small.gbk,foo"
+        )
         with self.assertRaises(InvalidInput) as exc:
             InputHandler(input_file)
-        self.assertEqual('Invalid column header "filee" in input file.',
-                         str(exc.exception))
+        self.assertEqual(
+            'Invalid column header "filee" in input file.', str(exc.exception)
+        )
 
     def test_is_header_allowed(self):
-        allowed_headers = ["file", "name", "group:foo", "group:foo bar",
-                           "group:foo_bar", "group:foo1"]
+        allowed_headers = [
+            "file",
+            "name",
+            "group:foo",
+            "group:foo bar",
+            "group:foo_bar",
+            "group:foo1",
+        ]
         for header in allowed_headers:
             self.assertTrue(InputHandler.is_header_allowed(header))
 
-        disallowed_headers = ["filee", "names", "group foo", "group-foo",
-                              "foo:bar"]
+        disallowed_headers = ["filee", "names", "group foo", "group-foo", "foo:bar"]
         for header in disallowed_headers:
             self.assertFalse(InputHandler.is_header_allowed(header))
 
@@ -110,4 +135,5 @@ class TestInputHandler(BaseTestCase):
         self.assertEqual(
             'Invalid entry "maybe" in group column. Should be one of '
             '"yes", "true", "x", "1", "no", "false", "0" or empty',
-            str(exc.exception))
+            str(exc.exception),
+        )

--- a/testing/pipelines/test_db_setup.py
+++ b/testing/pipelines/test_db_setup.py
@@ -6,7 +6,6 @@ from testing.pipelines.base import BasePipelineTestCase
 
 
 class TestDBSetupPipeline(BasePipelineTestCase):
-
     nf_filename = "db_setup.nf"
     _ref_db_dir = None
 
@@ -32,20 +31,27 @@ class TestDBSetupPipeline(BasePipelineTestCase):
         self.assert_success(execution)
         self.assertEqual(
             [proc.name for proc in execution.process_executions],
-            ["setup_pfam_db:download_pfam_db", "setup_pfam_db:prepare_hmm"])
+            ["setup_pfam_db:download_pfam_db", "setup_pfam_db:prepare_hmm"],
+        )
 
         download_process = execution.process_executions[0]
         self.assert_created_files(download_process, [])
 
         setup_process = execution.process_executions[1]
-        expected_files = ["Pfam-A.hmm", "Pfam-A.hmm.dat", "Pfam-A.hmm.h3f",
-                          "Pfam-A.hmm.h3i", "Pfam-A.hmm.h3m", "Pfam-A.hmm.h3p",
-                          'Pfam.version']
+        expected_files = [
+            "Pfam-A.hmm",
+            "Pfam-A.hmm.dat",
+            "Pfam-A.hmm.h3f",
+            "Pfam-A.hmm.h3i",
+            "Pfam-A.hmm.h3m",
+            "Pfam-A.hmm.h3p",
+            "Pfam.version",
+        ]
         # Files are moved to db directory
         self.assert_created_files(setup_process, [])
         self.assertItemsEqual(
-            expected_files,
-            os.listdir(os.path.join(self.ref_db_dir, "pfam")))
+            expected_files, os.listdir(os.path.join(self.ref_db_dir, "pfam"))
+        )
 
     def test_creating_cog_db(self):
         self.nf_params["cog"] = "true"
@@ -54,35 +60,48 @@ class TestDBSetupPipeline(BasePipelineTestCase):
 
         self.assertEqual(
             [proc.name for proc in execution.process_executions],
-            ["setup_cogg_db:download_cog_cdd", "setup_cogg_db:setup_cog_cdd"])
+            ["setup_cogg_db:download_cog_cdd", "setup_cogg_db:setup_cog_cdd"],
+        )
 
         download_process = execution.process_executions[0]
         self.assertIn("Cog.pn", os.listdir(download_process.path))
         smp_files = glob.glob(os.path.join(download_process.path, "COG*.smp"))
         self.assertTrue(len(smp_files) > 1000)
 
-        expected_files = ["cdd_to_cog", "cog_db.aux", "cog_db.freq",
-                          "cog_db.loo", "cog_db.phr", "cog_db.pin",
-                          "cog_db.psi", "cog_db.psq", "cog_db.rps",
-                          "cog_db.psd", "cdd.info"]
+        expected_files = [
+            "cdd_to_cog",
+            "cog_db.aux",
+            "cog_db.freq",
+            "cog_db.loo",
+            "cog_db.phr",
+            "cog_db.pin",
+            "cog_db.psi",
+            "cog_db.psq",
+            "cog_db.rps",
+            "cog_db.psd",
+            "cdd.info",
+        ]
         # Files are moved to db directory
         self.assertItemsEqual(
-            expected_files,
-            os.listdir(os.path.join(self.ref_db_dir, "cog")))
+            expected_files, os.listdir(os.path.join(self.ref_db_dir, "cog"))
+        )
 
     def test_creating_ko_db(self):
         self.nf_params["ko"] = "true"
         execution = self.execute_pipeline()
         self.assert_success(execution)
 
-        self.assertEqual([proc.name for proc in execution.process_executions],
-                         ["setup_ko_db:download_ko_profiles"])
+        self.assertEqual(
+            [proc.name for proc in execution.process_executions],
+            ["setup_ko_db:download_ko_profiles"],
+        )
 
         # Files are moved to db directory
         db_dir = os.path.join(self.ref_db_dir, "kegg")
         self.assertTrue(os.path.isfile(os.path.join(db_dir, "ko_list")))
-        self.assertTrue(os.path.isfile(
-            os.path.join(db_dir, "profiles", "prokaryote.hal")))
+        self.assertTrue(
+            os.path.isfile(os.path.join(db_dir, "profiles", "prokaryote.hal"))
+        )
         hmm_files = glob.glob(os.path.join(db_dir, "profiles", "*.hmm"))
         self.assertTrue(len(hmm_files) > 20000)
         self.assertTrue(os.path.isfile(os.path.join(db_dir, "version.txt")))
@@ -91,40 +110,51 @@ class TestDBSetupPipeline(BasePipelineTestCase):
         self.nf_params["blast_swissprot"] = "true"
         execution = self.execute_pipeline()
         self.assert_success(execution)
-        self.assertEqual([proc.name for proc in execution.process_executions],
-                         ["setup_swissprot_db:download_swissprot",
-                          "setup_swissprot_db:prepare_swissprot"])
+        self.assertEqual(
+            [proc.name for proc in execution.process_executions],
+            [
+                "setup_swissprot_db:download_swissprot",
+                "setup_swissprot_db:prepare_swissprot",
+            ],
+        )
 
         download_process = execution.process_executions[0]
         self.assert_created_files(download_process, ["swissprot.fasta"])
 
         # Files are moved to db directory
-        expected_files = ['swissprot.fasta.phr',
-                          'swissprot.fasta',
-                          'swissprot.fasta.pin',
-                          'swissprot.fasta.psq',
-                          'relnotes.txt']
+        expected_files = [
+            "swissprot.fasta.phr",
+            "swissprot.fasta",
+            "swissprot.fasta.pin",
+            "swissprot.fasta.psq",
+            "relnotes.txt",
+        ]
 
         self.assertItemsEqual(
             expected_files,
-            os.listdir(os.path.join(self.ref_db_dir, "uniprot", "swissprot")))
+            os.listdir(os.path.join(self.ref_db_dir, "uniprot", "swissprot")),
+        )
 
     def test_creating_vf_db(self):
         self.nf_params["vfdb"] = "true"
         execution = self.execute_pipeline()
         self.assert_success(execution)
 
-        self.assertEqual([proc.name for proc in execution.process_executions],
-                         ["setup_vfdb:download_vfdb", "setup_vfdb:prepare_vfdb"])
+        self.assertEqual(
+            [proc.name for proc in execution.process_executions],
+            ["setup_vfdb:download_vfdb", "setup_vfdb:prepare_vfdb"],
+        )
 
         # Files are moved to zdb_ref/vfdb
-        expected_files = ['vfdb.fasta',
-                          'VFs.xls',
-                          'vfdb.fasta.phr',
-                          'vfdb.fasta.pin',
-                          'vfdb.fasta.psq']
+        expected_files = [
+            "vfdb.fasta",
+            "VFs.xls",
+            "vfdb.fasta.phr",
+            "vfdb.fasta.pin",
+            "vfdb.fasta.psq",
+        ]
         self.assert_created_files(execution.process_executions[0], [])
         self.assert_created_files(execution.process_executions[1], [])
         self.assertItemsEqual(
-            expected_files,
-            os.listdir(os.path.join(self.ref_db_dir, "vfdb")))
+            expected_files, os.listdir(os.path.join(self.ref_db_dir, "vfdb"))
+        )

--- a/testing/webapp/test_download_sequences.py
+++ b/testing/webapp/test_download_sequences.py
@@ -5,34 +5,38 @@ from django.test import SimpleTestCase
 
 
 class TestDownloadSequencesView(SimpleTestCase):
-
-    prot_seq = 'METTKPSFQDVLEFVRLYRRKNKLQREIQDVEKKIRDNQKRVLLLDNLSDYIKPGMSVEAIQGIIASMKSDYEDRVDDYIIKNAELSKERRDISKKLKVMGEAKVEG'
+    prot_seq = "METTKPSFQDVLEFVRLYRRKNKLQREIQDVEKKIRDNQKRVLLLDNLSDYIKPGMSVEAIQGIIASMKSDYEDRVDDYIIKNAELSKERRDISKKLKVMGEAKVEG"
 
     def test_get_is_forbidden(self):
         resp = self.client.get("/download_sequences")
-        self.assertEqual(405,  resp.status_code)
-        self.assertEqual('Method Not Allowed', resp.reason_phrase)
+        self.assertEqual(405, resp.status_code)
+        self.assertEqual("Method Not Allowed", resp.reason_phrase)
 
     def test_download_prot_sequence(self):
-        resp = self.client.post("/download_sequences",
-                                {"loci": ["CHUV_00025"]},
-                                content_type="application/json")
+        resp = self.client.post(
+            "/download_sequences",
+            {"loci": ["CHUV_00025"]},
+            content_type="application/json",
+        )
         seq = SeqIO.read(StringIO(resp.content.decode("utf8")), "fasta")
         self.assertEqual("CHUV_00025", seq.id)
         self.assertEqual(self.prot_seq, str(seq.seq))
 
     def test_download_prot_sequences(self):
-        resp = self.client.post("/download_sequences",
-                                {"loci": ["CHUV_00025", "CHUV_00010"]},
-                                content_type="application/json")
+        resp = self.client.post(
+            "/download_sequences",
+            {"loci": ["CHUV_00025", "CHUV_00010"]},
+            content_type="application/json",
+        )
         sequences = SeqIO.parse(StringIO(resp.content.decode("utf8")), "fasta")
-        self.assertEqual(["CHUV_00025", "CHUV_00010"],
-                         [seq.id for seq in sequences])
+        self.assertEqual(["CHUV_00025", "CHUV_00010"], [seq.id for seq in sequences])
 
     def test_download_dna_sequence(self):
-        resp = self.client.post("/download_sequences",
-                                {"loci": ["CHUV_00025"], "dna": True},
-                                content_type="application/json")
+        resp = self.client.post(
+            "/download_sequences",
+            {"loci": ["CHUV_00025"], "dna": True},
+            content_type="application/json",
+        )
         seq = SeqIO.read(StringIO(resp.content.decode("utf8")), "fasta")
         self.assertEqual("CHUV_00025", seq.id)
         # Drop last character of sequence after translation as it's a *

--- a/testing/webapp/test_groups.py
+++ b/testing/webapp/test_groups.py
@@ -4,50 +4,56 @@ from lib.db_utils import DB
 
 
 class TestGroupsViews(SimpleTestCase):
-
     def test_groups_overview(self):
         resp = self.client.get("/groups/")
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/groups_overview.html')
+        self.assertTemplateUsed(resp, "chlamdb/groups_overview.html")
 
         groups = [
-            '<a href=/groups/positive>positive</a>',
-            '<a href=/groups/negative>negative</a>',
-            '<a href=/groups/all>all</a>']
+            "<a href=/groups/positive>positive</a>",
+            "<a href=/groups/negative>negative</a>",
+            "<a href=/groups/all>all</a>",
+        ]
         self.assertEqual(groups, resp.context["groups"])
         for group in groups:
             self.assertContains(resp, group)
 
-        self.assertContains(resp, 'Add new group')
+        self.assertContains(resp, "Add new group")
 
     def test_add_and_delete_group_view(self):
         resp = self.client.get("/groups/add/")
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/group_add.html')
-        self.assertEqual(list(resp.context.get("form").fields.keys()),
-                         ['group_name', 'genomes'])
+        self.assertTemplateUsed(resp, "chlamdb/group_add.html")
+        self.assertEqual(
+            list(resp.context.get("form").fields.keys()), ["group_name", "genomes"]
+        )
 
         db = DB.load_db_from_name(settings.BIODB_DB_PATH)
         data = {"group_name": "test_group", "genomes": ["group:negative", "1"]}
         resp = self.client.post("/groups/add/", data=data)
         self.assertEqual(302, resp.status_code)
-        self.assertEqual('/groups/test_group', resp.url)
+        self.assertEqual("/groups/test_group", resp.url)
         self.assertTrue(db.get_group("test_group"))
 
         resp = self.client.post("/groups/test_group/delete/")
         self.assertEqual(302, resp.status_code)
-        self.assertEqual('/groups/', resp.url)
+        self.assertEqual("/groups/", resp.url)
         self.assertFalse(db.get_group("test_group"))
 
     def test_group_details_view(self):
         resp = self.client.get("/groups/positive")
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/group_details.html')
+        self.assertTemplateUsed(resp, "chlamdb/group_details.html")
         genomes = [
             '<a href="/extract_contigs/1">Klebsiella pneumoniae R6724_16313</a>',
-            '<a href="/extract_contigs/2">Klebsiella pneumoniae R6726_16314</a>']
+            '<a href="/extract_contigs/2">Klebsiella pneumoniae R6726_16314</a>',
+        ]
         self.assertEqual(
-            [row.accession for i, row in resp.context["genome_table"]["table_data"].iterrows()],
-            genomes)
+            [
+                row.accession
+                for i, row in resp.context["genome_table"]["table_data"].iterrows()
+            ],
+            genomes,
+        )
         for genome in genomes:
             self.assertContains(resp, genome, html=True)

--- a/testing/webapp/test_utils.py
+++ b/testing/webapp/test_utils.py
@@ -2,22 +2,28 @@ from django.conf import settings
 from django.test import SimpleTestCase
 from lib.db_utils import DB
 
-from webapp.views.utils import AccessionFieldHandler, EntryIdParser
+from webapp.views.utils import AccessionFieldHandler
+from webapp.views.utils import EntryIdParser
 
 
 class TestAccessionFieldHandler(SimpleTestCase):
+    taxons = [
+        ("1", "Klebsiella pneumoniae R6724_16313"),
+        ("2", "Klebsiella pneumoniae R6726_16314"),
+        ("3", "Klebsiella pneumoniae R6728_16315"),
+    ]
 
-    taxons = [('1', 'Klebsiella pneumoniae R6724_16313'),
-              ('2', 'Klebsiella pneumoniae R6726_16314'),
-              ('3', 'Klebsiella pneumoniae R6728_16315')]
+    plasmids = [
+        ("plasmid:1", "Klebsiella pneumoniae R6724_16313 plasmid"),
+        ("plasmid:2", "Klebsiella pneumoniae R6726_16314 plasmid"),
+        ("plasmid:3", "Klebsiella pneumoniae R6728_16315 plasmid"),
+    ]
 
-    plasmids = [('plasmid:1', 'Klebsiella pneumoniae R6724_16313 plasmid'),
-                ('plasmid:2', 'Klebsiella pneumoniae R6726_16314 plasmid'),
-                ('plasmid:3', 'Klebsiella pneumoniae R6728_16315 plasmid')]
-
-    groups = [('group:all', 'all'),
-              ('group:negative', 'negative'),
-              ('group:positive', 'positive')]
+    groups = [
+        ("group:all", "all"),
+        ("group:negative", "negative"),
+        ("group:positive", "positive"),
+    ]
 
     def setUp(self):
         self.handler = AccessionFieldHandler()
@@ -30,113 +36,120 @@ class TestAccessionFieldHandler(SimpleTestCase):
 
     def add_plasmid_for_taxids(self, taxids):
         plasmid_term_id = self.db.server.adaptor.execute_one(
-            "SELECT term_id FROM term WHERE name='plasmid'")[0]
+            "SELECT term_id FROM term WHERE name='plasmid'"
+        )[0]
         for taxid in taxids:
             self.db.server.adaptor.execute(
                 f"UPDATE bioentry_qualifier_value SET value=1 "
-                f"WHERE bioentry_id={taxid} AND term_id={plasmid_term_id};")
+                f"WHERE bioentry_id={taxid} AND term_id={plasmid_term_id};"
+            )
 
     def assertItemsEqual(self, expected, choices):
         self.assertEqual(sorted(expected), sorted(choices))
 
     def test_get_choices_handles_plasmids(self):
-        self.assertItemsEqual(
-            self.taxons + self.groups,
-            self.handler.get_choices())
+        self.assertItemsEqual(self.taxons + self.groups, self.handler.get_choices())
 
         self.add_plasmid_for_taxids([1, 3])
         self.assertItemsEqual(
-            self.taxons + self.groups + self.plasmids[::2],
-            self.handler.get_choices())
+            self.taxons + self.groups + self.plasmids[::2], self.handler.get_choices()
+        )
 
         self.assertItemsEqual(
-            self.taxons + self.groups,
-            self.handler.get_choices(with_plasmids=False))
+            self.taxons + self.groups, self.handler.get_choices(with_plasmids=False)
+        )
 
     def test_get_choices_handles_groups(self):
-        self.assertItemsEqual(
-            self.taxons + self.groups,
-            self.handler.get_choices())
+        self.assertItemsEqual(self.taxons + self.groups, self.handler.get_choices())
 
     def test_get_choices_handles_taxid_exclusion(self):
         exclude = [el[0] for el in self.taxons[1:]]
         self.assertItemsEqual(
-            [self.taxons[0]],
-            self.handler.get_choices(exclude=exclude))
+            [self.taxons[0]], self.handler.get_choices(exclude=exclude)
+        )
 
         self.add_plasmid_for_taxids([1, 2, 3])
-        self.assertItemsEqual(self.taxons + self.groups + self.plasmids,
-                              self.handler.get_choices())
+        self.assertItemsEqual(
+            self.taxons + self.groups + self.plasmids, self.handler.get_choices()
+        )
 
         exclude = [self.taxons[-1][0]]
-        self.assertItemsEqual(self.taxons[:-1] + [self.groups[2]] + self.plasmids,
-                              self.handler.get_choices(exclude=exclude))
+        self.assertItemsEqual(
+            self.taxons[:-1] + [self.groups[2]] + self.plasmids,
+            self.handler.get_choices(exclude=exclude),
+        )
 
-        self.assertItemsEqual(self.taxons[:-1] + [self.groups[2]],
-                              self.handler.get_choices(exclude=exclude,
-                                                       with_plasmids=False))
+        self.assertItemsEqual(
+            self.taxons[:-1] + [self.groups[2]],
+            self.handler.get_choices(exclude=exclude, with_plasmids=False),
+        )
 
     def test_get_choices_handles_plasmid_exclusion(self):
         self.add_plasmid_for_taxids([1, 2, 3])
 
         exclude = [self.plasmids[-1][0]]
-        self.assertItemsEqual(self.taxons + self.groups + self.plasmids[:-1],
-                              self.handler.get_choices(exclude=exclude))
+        self.assertItemsEqual(
+            self.taxons + self.groups + self.plasmids[:-1],
+            self.handler.get_choices(exclude=exclude),
+        )
 
         exclude = [el[0] for el in self.plasmids]
-        self.assertItemsEqual(self.taxons + self.groups,
-                              self.handler.get_choices(exclude=exclude))
+        self.assertItemsEqual(
+            self.taxons + self.groups, self.handler.get_choices(exclude=exclude)
+        )
 
     def test_get_choices_handles_group_exclusion(self):
         exclude = [self.groups[1][0]]
-        self.assertItemsEqual(self.taxons[:-1] + [self.groups[2]],
-                              self.handler.get_choices(exclude=exclude))
+        self.assertItemsEqual(
+            self.taxons[:-1] + [self.groups[2]],
+            self.handler.get_choices(exclude=exclude),
+        )
 
         exclude.append(self.groups[2][0])
-        self.assertItemsEqual([],
-                              self.handler.get_choices(exclude=exclude))
+        self.assertItemsEqual([], self.handler.get_choices(exclude=exclude))
 
     def test_get_choices_handles_exclude_taxids_in_groups(self):
         exclude = [self.groups[1][0]]
         self.assertItemsEqual(
             self.taxons[:-1] + self.groups,
-            self.handler.get_choices(exclude_taxids_in_groups=exclude))
+            self.handler.get_choices(exclude_taxids_in_groups=exclude),
+        )
 
         exclude.append(self.groups[2][0])
         self.assertItemsEqual(
-            self.groups,
-            self.handler.get_choices(exclude_taxids_in_groups=exclude))
+            self.groups, self.handler.get_choices(exclude_taxids_in_groups=exclude)
+        )
 
     def test_extract_choices_returns_none_when_include_plasmids_is_false(self):
         self.assertEqual(
-            ([1, 3], None),
-            self.handler.extract_choices(["1", "3"], False))
+            ([1, 3], None), self.handler.extract_choices(["1", "3"], False)
+        )
 
-        self.assertEqual(
-            ([1, 3], []),
-            self.handler.extract_choices(["1", "3"], True))
+        self.assertEqual(([1, 3], []), self.handler.extract_choices(["1", "3"], True))
 
     def test_extract_choices_handles_plasmids(self):
         self.assertEqual(
             ([2], [1, 3]),
-            self.handler.extract_choices(["plasmid:1", "2", "plasmid:3"], True))
+            self.handler.extract_choices(["plasmid:1", "2", "plasmid:3"], True),
+        )
 
         self.assertEqual(
             ([2], None),
-            self.handler.extract_choices(["plasmid:1", "2", "plasmid:3"], False))
+            self.handler.extract_choices(["plasmid:1", "2", "plasmid:3"], False),
+        )
 
     def test_extract_choices_handles_groups(self):
         self.assertEqual(
-            ([3], []),
-            self.handler.extract_choices(["group:negative"], True))
+            ([3], []), self.handler.extract_choices(["group:negative"], True)
+        )
 
         self.assertEqual(
             ([2, 3], [1]),
-            self.handler.extract_choices(["plasmid:1", "2", "group:negative"], True))
+            self.handler.extract_choices(["plasmid:1", "2", "group:negative"], True),
+        )
 
 
 class TestEntryIdParser(SimpleTestCase):
-
     def setUp(self):
         biodb_path = settings.BIODB_DB_PATH
         self.db = DB.load_db_from_name(biodb_path)
@@ -147,35 +160,33 @@ class TestEntryIdParser(SimpleTestCase):
 
     def test_handles_orthogroups(self):
         self.assertEqual(
-            ('orthogroup', 1),
-            self.entry_id_parser.id_to_object_type("group_1"))
+            ("orthogroup", 1), self.entry_id_parser.id_to_object_type("group_1")
+        )
 
     def test_handles_orthogroup_0(self):
         self.assertEqual(
-            ('orthogroup', 0),
-            self.entry_id_parser.id_to_object_type("group_0"))
+            ("orthogroup", 0), self.entry_id_parser.id_to_object_type("group_0")
+        )
 
     def test_handles_cog(self):
         self.assertEqual(
-            ('cog', 1234),
-            self.entry_id_parser.id_to_object_type("COG1234"))
+            ("cog", 1234), self.entry_id_parser.id_to_object_type("COG1234")
+        )
 
     def test_handles_pfam(self):
         self.assertEqual(
-            ('pfam', 10423),
-            self.entry_id_parser.id_to_object_type("PF10423"))
+            ("pfam", 10423), self.entry_id_parser.id_to_object_type("PF10423")
+        )
 
     def test_handles_ko(self):
-        self.assertEqual(
-            ('ko', 1241),
-            self.entry_id_parser.id_to_object_type("K01241"))
+        self.assertEqual(("ko", 1241), self.entry_id_parser.id_to_object_type("K01241"))
 
     def test_handles_vf(self):
         self.assertEqual(
-            ('vf', "VFG048797"),
-            self.entry_id_parser.id_to_object_type("VFG048797"))
+            ("vf", "VFG048797"), self.entry_id_parser.id_to_object_type("VFG048797")
+        )
 
     def test_handles_amr(self):
         self.assertEqual(
-            ('amr', "ybtP"),
-            self.entry_id_parser.id_to_object_type("ybtP"))
+            ("amr", "ybtP"), self.entry_id_parser.id_to_object_type("ybtP")
+        )

--- a/testing/webapp/test_views.py
+++ b/testing/webapp/test_views.py
@@ -11,111 +11,110 @@ from django.urls import resolve
 from webapp.settings import testing_settings
 
 dump_html = False
-html_dumps_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                              "html_dumps")
+html_dumps_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "html_dumps")
 
 untested_patterns = {
-    r'^download_sequences$',
-    '^favicon\\.ico$',
-    r'^groups/([a-zA-Z0-9_\.\(\)\-\'\s]+)/delete/$',
-    '^module_cat_info/([a-zA-Z0-9_\\.]+)/([a-zA-Z0-9_\\.\\+-]+)$',
-    '^plot_region/$',
-    '^robots.txt$',
-    '^search_bar$',
-    '^search_bar/([a-zA-Z0-9_\\.\\-]+)/([a-zA-Z0-9_\\.\\-]+)',
-    '^search_suggest/.*$',
+    r"^download_sequences$",
+    "^favicon\\.ico$",
+    r"^groups/([a-zA-Z0-9_\.\(\)\-\'\s]+)/delete/$",
+    "^module_cat_info/([a-zA-Z0-9_\\.]+)/([a-zA-Z0-9_\\.\\+-]+)$",
+    "^plot_region/$",
+    "^robots.txt$",
+    "^search_bar$",
+    "^search_bar/([a-zA-Z0-9_\\.\\-]+)/([a-zA-Z0-9_\\.\\-]+)",
+    "^search_suggest/.*$",
 }
 
 urls = [
-    '/about',
-    '/amr_comparison',
-    '/autocomplete_n_missing/',
-    '/autocomplete_taxid/',
-    '/blast/',
-    '/circos/',
-    '/circos_main/',
-    '/cog_barchart/',
-    '/cog_comparison',
-    '/cog_phylo_heatmap/False',
-    '/cog_phylo_heatmap/True',
-    '/cog_venn_subset/L?h=1&h=2',
-    '/custom_plots/',
-    '/entry_list_amr',
-    '/entry_list_cog',
-    '/entry_list_ko',
-    '/entry_list_pfam',
-    '/entry_list_vf',
-    '/extract_amr/',
-    '/extract_cog/',
-    '/extract_contigs/1',
-    '/extract_ko/',
-    '/extract_orthogroup/',
-    '/extract_pfam/',
-    '/extract_vf/',
-    '/fam_amr/ybtP',
-    '/fam_cog/COG0775',
-    '/fam_ko/K01241',
-    '/fam_pfam/PF10423',
-    '/fam_vf/VFG048797',
-    '/FAQ',
-    '/genomes',
-    '/get_cog/3/L?h=1&h=2&h=3',
-    '/groups/',
-    '/groups/add/',
-    '/groups/positive',
-    '/gwas_amr/',
-    '/gwas_cog/',
-    '/gwas_ko/',
-    '/gwas_orthogroup/',
-    '/gwas_pfam/',
-    '/gwas_vf/',
-    '/help',
-    '/home/',
-    '/index_comp/cog',
-    '/index_comp/ko',
-    '/index_comp/orthogroup',
-    '/index_comp/pfam',
-    '/index_comp/vf',
-    '/invalid/url',
-    '/kegg/',
-    '/kegg_genomes/',
-    '/kegg_genomes_modules/',
-    '/KEGG_mapp_ko',
-    '/KEGG_mapp_ko/map00230/1',
-    '/KEGG_mapp_ko/map01100',
-    '/kegg_module/',
-    '/KEGG_module_map/M00035',
-    '/kegg_module_subcat',
-    '/ko_barchart/',
-    '/ko_comparison',
-    '/ko_venn_subset/Cofactor+and+vitamin+metabolism?h=1&h=2',
-    '/locusx',
-    '/locusx/CHUV_00025',
-    '/locusx/CHUV_00025/True',
-    '/module_comparison/',
-    '/orthogroup/group_85',
-    '/orthogroup_comparison',
-    '/pan_genome/amr',
-    '/pan_genome/cog',
-    '/pan_genome/ko',
-    '/pan_genome/orthogroup',
-    '/pan_genome/pfam',
-    '/pan_genome/vf',
-    '/pfam_comparison',
-    '/phylogeny',
-    '/plot_heatmap/cog',
-    '/plot_heatmap/ko',
-    '/plot_heatmap/orthogroup',
-    '/plot_heatmap/pfam',
-    '/plot_heatmap/amr',
-    '/plot_heatmap/vf',
-    '/venn_amr/',
-    '/venn_cog/',
-    '/venn_ko/',
-    '/venn_orthogroup/',
-    '/venn_pfam/',
-    '/venn_vf/',
-    '/vf_comparison/',
+    "/about",
+    "/amr_comparison",
+    "/autocomplete_n_missing/",
+    "/autocomplete_taxid/",
+    "/blast/",
+    "/circos/",
+    "/circos_main/",
+    "/cog_barchart/",
+    "/cog_comparison",
+    "/cog_phylo_heatmap/False",
+    "/cog_phylo_heatmap/True",
+    "/cog_venn_subset/L?h=1&h=2",
+    "/custom_plots/",
+    "/entry_list_amr",
+    "/entry_list_cog",
+    "/entry_list_ko",
+    "/entry_list_pfam",
+    "/entry_list_vf",
+    "/extract_amr/",
+    "/extract_cog/",
+    "/extract_contigs/1",
+    "/extract_ko/",
+    "/extract_orthogroup/",
+    "/extract_pfam/",
+    "/extract_vf/",
+    "/fam_amr/ybtP",
+    "/fam_cog/COG0775",
+    "/fam_ko/K01241",
+    "/fam_pfam/PF10423",
+    "/fam_vf/VFG048797",
+    "/FAQ",
+    "/genomes",
+    "/get_cog/3/L?h=1&h=2&h=3",
+    "/groups/",
+    "/groups/add/",
+    "/groups/positive",
+    "/gwas_amr/",
+    "/gwas_cog/",
+    "/gwas_ko/",
+    "/gwas_orthogroup/",
+    "/gwas_pfam/",
+    "/gwas_vf/",
+    "/help",
+    "/home/",
+    "/index_comp/cog",
+    "/index_comp/ko",
+    "/index_comp/orthogroup",
+    "/index_comp/pfam",
+    "/index_comp/vf",
+    "/invalid/url",
+    "/kegg/",
+    "/kegg_genomes/",
+    "/kegg_genomes_modules/",
+    "/KEGG_mapp_ko",
+    "/KEGG_mapp_ko/map00230/1",
+    "/KEGG_mapp_ko/map01100",
+    "/kegg_module/",
+    "/KEGG_module_map/M00035",
+    "/kegg_module_subcat",
+    "/ko_barchart/",
+    "/ko_comparison",
+    "/ko_venn_subset/Cofactor+and+vitamin+metabolism?h=1&h=2",
+    "/locusx",
+    "/locusx/CHUV_00025",
+    "/locusx/CHUV_00025/True",
+    "/module_comparison/",
+    "/orthogroup/group_85",
+    "/orthogroup_comparison",
+    "/pan_genome/amr",
+    "/pan_genome/cog",
+    "/pan_genome/ko",
+    "/pan_genome/orthogroup",
+    "/pan_genome/pfam",
+    "/pan_genome/vf",
+    "/pfam_comparison",
+    "/phylogeny",
+    "/plot_heatmap/cog",
+    "/plot_heatmap/ko",
+    "/plot_heatmap/orthogroup",
+    "/plot_heatmap/pfam",
+    "/plot_heatmap/amr",
+    "/plot_heatmap/vf",
+    "/venn_amr/",
+    "/venn_cog/",
+    "/venn_ko/",
+    "/venn_orthogroup/",
+    "/venn_pfam/",
+    "/venn_vf/",
+    "/vf_comparison/",
 ]
 
 
@@ -129,7 +128,10 @@ def maybe_dump_html(resp, fname_postfix=""):
         fname += ".html"
 
         # Replace csrf token
-        match = re.search(b'<input type="hidden" name="csrfmiddlewaretoken" value="(.*?)"', resp.content)
+        match = re.search(
+            b'<input type="hidden" name="csrfmiddlewaretoken" value="(.*?)"',
+            resp.content,
+        )
         if match:
             resp.content = resp.content.replace(match.groups()[0], b"XXXXX")
 
@@ -138,7 +140,6 @@ def maybe_dump_html(resp, fname_postfix=""):
 
 
 class ViewTestCase(SimpleTestCase):
-
     def setUp(self):
         self.asset_root = testing_settings.ASSET_ROOT
         os.makedirs(os.path.join(self.asset_root, "temp"))
@@ -150,14 +151,13 @@ class ViewTestCase(SimpleTestCase):
 
 
 class TestViewsAreHealthy(ViewTestCase):
-
     def test_no_broken_views(self):
         for url in urls:
             try:
                 resp = self.client.get(url)
             except Exception as exc:
                 print(f"{url} is broken")
-                raise(exc)
+                raise (exc)
             self.assertEqual(200, resp.status_code, f"{url} is broken")
 
     def test_all_urlpatterns_are_tested(self):
@@ -170,12 +170,13 @@ class TestViewsAreHealthy(ViewTestCase):
         self.assertFalse(
             all_patterns - covered_patterns,
             "Some patterns are not covered in the tests: please add them to "
-            "untested_patterns or urls")
+            "untested_patterns or urls",
+        )
 
     def test_all_views_render_valid_html_or_json(self):
         for url in urls:
             resp = self.client.get(url)
-            if resp.get("Content-Type") == 'application/json':
+            if resp.get("Content-Type") == "application/json":
                 try:
                     resp.json()
                 except Exception as exc:
@@ -192,18 +193,19 @@ class TestViewsAreHealthy(ViewTestCase):
             maybe_dump_html(resp)
 
     def test_all_comparison_views_render_navigation(self):
-
-        comp_pattern = "/extract_[^s]+/|/[^m].+_comparison|/venn_|"\
-                       "/plot_heatmap|/pan_genome|/entry_list"
+        comp_pattern = (
+            "/extract_[^s]+/|/[^m].+_comparison|/venn_|"
+            "/plot_heatmap|/pan_genome|/entry_list"
+        )
         for url in urls:
             if re.match(comp_pattern, url):
                 resp = self.client.get(url)
-                self.assertContains(resp, "<nav>",
-                                    msg_prefix=f"{url} does not contain navigation")
+                self.assertContains(
+                    resp, "<nav>", msg_prefix=f"{url} does not contain navigation"
+                )
 
 
 class TestViewsContent(ViewTestCase):
-
     def assertNoPlot(self, resp):
         self.assertNotIn("envoi", resp.context.keys())
         self.assertNotContains(resp, '<div class="panel panel-success"')
@@ -215,45 +217,82 @@ class TestViewsContent(ViewTestCase):
         self.assertContains(resp, "Help to interpret the results")
 
     def assertTitle(self, resp, title):
-        self.assertContains(
-            resp, f'<p class="home-title">{title}</p>', html=True)
+        self.assertContains(resp, f'<p class="home-title">{title}</p>', html=True)
 
     def test_home_page(self):
         resp = self.client.get("/home")
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/home.html')
+        self.assertTemplateUsed(resp, "chlamdb/home.html")
         self.assertEqual(3, resp.context["number_of_files"])
         self.assertContains(resp, "A comparative genomics database", html=True)
         self.assertContains(resp, '<a href="/genomes" ><b>Genomes</b></a>', html=True)
-        self.assertContains(resp, '<a href="/phylogeny"><b>Phylogeny</b></a>', html=True)
-        self.assertContains(resp, '<a class="link_boxes" href="/blast/"><span class="link"></span> Blast </a>', html=True)
-        self.assertContains(resp, '<a class="link_boxes" href="/index_comp/orthogroup"><span class="link"></span>Orthologous groups</a>', html=True)
-        self.assertContains(resp, '<a class="link_boxes" href="/index_comp/cog"><span class="link"></span>COG entries</a>', html=True)
-        self.assertContains(resp, '<a class="link_boxes" href="/index_comp/ko"><span class="link"></span>Kegg Orthologs</a>', html=True)
-        self.assertContains(resp, '<a class="link_boxes" href="/index_comp/pfam"><span class="link"></span>Pfam domains</a>', html=True)
-        self.assertContains(resp, '<a class="link_boxes" href="/circos/"><span class="link"></span>Plot region</a>', html=True)
-        self.assertContains(resp, '<a class="link_boxes" href="/circos/"><span class="link"></span>Circos</a>', html=True)
-        self.assertContains(resp, '<a class="link_boxes" href="/kegg/"><span class="link"></span>Kegg based</a>', html=True)
+        self.assertContains(
+            resp, '<a href="/phylogeny"><b>Phylogeny</b></a>', html=True
+        )
+        self.assertContains(
+            resp,
+            '<a class="link_boxes" href="/blast/"><span class="link"></span> Blast </a>',
+            html=True,
+        )
+        self.assertContains(
+            resp,
+            '<a class="link_boxes" href="/index_comp/orthogroup"><span class="link"></span>Orthologous groups</a>',
+            html=True,
+        )
+        self.assertContains(
+            resp,
+            '<a class="link_boxes" href="/index_comp/cog"><span class="link"></span>COG entries</a>',
+            html=True,
+        )
+        self.assertContains(
+            resp,
+            '<a class="link_boxes" href="/index_comp/ko"><span class="link"></span>Kegg Orthologs</a>',
+            html=True,
+        )
+        self.assertContains(
+            resp,
+            '<a class="link_boxes" href="/index_comp/pfam"><span class="link"></span>Pfam domains</a>',
+            html=True,
+        )
+        self.assertContains(
+            resp,
+            '<a class="link_boxes" href="/circos/"><span class="link"></span>Plot region</a>',
+            html=True,
+        )
+        self.assertContains(
+            resp,
+            '<a class="link_boxes" href="/circos/"><span class="link"></span>Circos</a>',
+            html=True,
+        )
+        self.assertContains(
+            resp,
+            '<a class="link_boxes" href="/kegg/"><span class="link"></span>Kegg based</a>',
+            html=True,
+        )
 
     def test_cog_barchart(self):
         resp = self.client.get("/cog_barchart/")
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/cog_barplot.html')
+        self.assertTemplateUsed(resp, "chlamdb/cog_barplot.html")
         self.assertTitle(resp, "Comparisons: Clusters of Orthologous groups (COGs)")
         self.assertNoPlot(resp)
-        self.assertContains(resp, "Barcharts of COG entries categories in selected genomes")
+        self.assertContains(
+            resp, "Barcharts of COG entries categories in selected genomes"
+        )
 
         resp = self.client.post("/cog_barchart/", data={"targets": ["1", "2"]})
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/cog_barplot.html')
+        self.assertTemplateUsed(resp, "chlamdb/cog_barplot.html")
         self.assertTitle(resp, "Comparisons: Clusters of Orthologous groups (COGs)")
         self.assertPlot(resp)
-        self.assertContains(resp, "Barcharts of COG entries categories in selected genomes")
+        self.assertContains(
+            resp, "Barcharts of COG entries categories in selected genomes"
+        )
 
     def test_blast(self):
         resp = self.client.get("/blast/")
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/blast.html')
+        self.assertTemplateUsed(resp, "chlamdb/blast.html")
         self.assertTitle(resp, "Homology search: Blast")
         self.assertNotIn("envoi", resp.context.keys())
         self.assertNotContains(resp, "Help to interpret the results")
@@ -264,11 +303,11 @@ class TestViewsContent(ViewTestCase):
             "blast_input": "ATCGCCACGGTGGTGCAGGCGCAGAAAGCGGGCAAAACGCTCAGCGTCG",
             "blast": "blastn_ffn",
             "max_number_of_hits": 10,
-            "target": "all"
+            "target": "all",
         }
         resp = self.client.post("/blast/", data=data)
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/blast.html')
+        self.assertTemplateUsed(resp, "chlamdb/blast.html")
         self.assertTitle(resp, "Homology search: Blast")
         self.assertIn("envoi", resp.context.keys())
         self.assertContains(resp, "Help to interpret the results")
@@ -278,7 +317,7 @@ class TestViewsContent(ViewTestCase):
     def test_custom_plots(self):
         resp = self.client.get("/custom_plots/")
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/custom_plots.html')
+        self.assertTemplateUsed(resp, "chlamdb/custom_plots.html")
         self.assertTitle(resp, "Custom plots")
         self.assertNotIn("show_results", resp.context.keys())
         self.assertNotContains(resp, '<a href=#phylogenetic_tree data-toggle="tab">')
@@ -289,15 +328,14 @@ class TestViewsContent(ViewTestCase):
         }
         resp = self.client.post("/custom_plots/", data=data)
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/custom_plots.html')
+        self.assertTemplateUsed(resp, "chlamdb/custom_plots.html")
         self.assertTitle(resp, "Custom plots")
         self.assertIn("show_results", resp.context.keys())
         self.assertContains(resp, '<a href=#phylogenetic_tree data-toggle="tab">')
         self.assertContains(resp, '<a href=#custom_plot_table data-toggle="tab">')
 
 
-class ComparisonViewsTestMixin():
-
+class ComparisonViewsTestMixin:
     selection_html = """
         <option value="1" selected="">Klebsiella pneumoniae R6724_16313</option>
         <option value="2" selected="">Klebsiella pneumoniae R6726_16314</option>
@@ -310,8 +348,7 @@ class ComparisonViewsTestMixin():
     gwas_table_html = '<table id="gwas_table"'
 
     def assertPageTitle(self, resp, title):
-        self.assertContains(
-            resp, f'<p class="home-title">{title}</p>', html=True)
+        self.assertContains(resp, f'<p class="home-title">{title}</p>', html=True)
 
     def assertNav(self, resp):
         self.assertContains(resp, "<nav>")
@@ -329,12 +366,12 @@ class ComparisonViewsTestMixin():
 
     def assertNoVennDiagram(self, resp):
         self.assertFalse(resp.context.get("show_results", False))
-        self.assertTemplateNotUsed('chlamdb/venn_representation_template.html')
+        self.assertTemplateNotUsed("chlamdb/venn_representation_template.html")
         self.assertNotContains(resp, self.venn_html)
 
     def assertVennDiagram(self, resp):
         self.assertTrue(resp.context.get("show_results", False))
-        self.assertTemplateUsed('chlamdb/venn_representation_template.html')
+        self.assertTemplateUsed("chlamdb/venn_representation_template.html")
         self.assertContains(resp, self.venn_html)
 
     def assertNoHeatmap(self, resp):
@@ -392,21 +429,26 @@ class ComparisonViewsTestMixin():
     @property
     def gwas_form_data(self):
         phenotype = SimpleUploadedFile(
-            "phenotype.csv", b"1,1\n2,1\n3,0", content_type="text/csv")
-        return {"max_number_of_hits": "all",
-                "bonferroni_cutoff": 0.99,
-                "phenotype_file": phenotype}
+            "phenotype.csv", b"1,1\n2,1\n3,0", content_type="text/csv"
+        )
+        return {
+            "max_number_of_hits": "all",
+            "bonferroni_cutoff": 0.99,
+            "phenotype_file": phenotype,
+        }
 
     @property
     def gwas_groups_form_data(self):
-        return {"max_number_of_hits": "all",
-                "bonferroni_cutoff": 0.99,
-                "groups": ["positive"]}
+        return {
+            "max_number_of_hits": "all",
+            "bonferroni_cutoff": 0.99,
+            "groups": ["positive"],
+        }
 
     def test_comparison_index_view(self):
         resp = self.client.get(f"/index_comp/{self.view_type}")
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/index_comp.html')
+        self.assertTemplateUsed(resp, "chlamdb/index_comp.html")
         self.assertPageTitle(resp, self.page_title)
         # Check that all links work
         links = re.findall('location.href="(.*?)";', str(resp.content))
@@ -414,23 +456,23 @@ class ComparisonViewsTestMixin():
             resp = self.client.get(link)
             self.assertEqual(200, resp.status_code)
             # Make sure we landed on the desired view
-            self.assertEqual(link.lstrip("/").split("/")[0],
-                             resp.resolver_match.view_name)
+            self.assertEqual(
+                link.lstrip("/").split("/")[0], resp.resolver_match.view_name
+            )
             self.assertPageTitle(resp, self.page_title)
 
     def test_tabular_comparison_view(self):
         resp = self.client.get(self.tab_comp_view)
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/tabular_comparison.html')
+        self.assertTemplateUsed(resp, "chlamdb/tabular_comparison.html")
         self.assertPageTitle(resp, self.page_title)
         self.assertNoCompTable(resp)
         self.assertNav(resp)
 
         for tab_comp_form_data in self.tab_comp_form_data_list:
-            resp = self.client.post(self.tab_comp_view,
-                                    data=tab_comp_form_data)
+            resp = self.client.post(self.tab_comp_view, data=tab_comp_form_data)
             self.assertEqual(200, resp.status_code)
-            self.assertTemplateUsed(resp, 'chlamdb/tabular_comparison.html')
+            self.assertTemplateUsed(resp, "chlamdb/tabular_comparison.html")
             self.assertPageTitle(resp, self.page_title)
             self.assertSelection(resp)
             self.assertCompTable(resp)
@@ -441,15 +483,14 @@ class ComparisonViewsTestMixin():
     def test_venn_view(self):
         resp = self.client.get(self.venn_view)
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/venn_generic.html')
+        self.assertTemplateUsed(resp, "chlamdb/venn_generic.html")
         self.assertPageTitle(resp, self.page_title)
         self.assertNoVennDiagram(resp)
         self.assertNav(resp)
 
-        resp = self.client.post(self.venn_view,
-                                data=self.venn_form_data)
+        resp = self.client.post(self.venn_view, data=self.venn_form_data)
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/venn_generic.html')
+        self.assertTemplateUsed(resp, "chlamdb/venn_generic.html")
         self.assertPageTitle(resp, self.page_title)
         self.assertSelection(resp)
         self.assertVennDiagram(resp)
@@ -460,15 +501,14 @@ class ComparisonViewsTestMixin():
     def test_plot_heatmap_view(self):
         resp = self.client.get(self.heatmap_view)
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/plot_heatmap.html')
+        self.assertTemplateUsed(resp, "chlamdb/plot_heatmap.html")
         self.assertPageTitle(resp, self.page_title)
         self.assertNoHeatmap(resp)
         self.assertNav(resp)
 
-        resp = self.client.post(self.heatmap_view,
-                                data=self.heatmap_form_data)
+        resp = self.client.post(self.heatmap_view, data=self.heatmap_form_data)
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/plot_heatmap.html')
+        self.assertTemplateUsed(resp, "chlamdb/plot_heatmap.html")
         self.assertPageTitle(resp, self.page_title)
         self.assertSelection(resp)
         self.assertHeatmap(resp)
@@ -479,15 +519,16 @@ class ComparisonViewsTestMixin():
     def test_pan_genome_view(self):
         resp = self.client.get(f"/pan_genome/{self.view_type}")
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/pan_genome.html')
+        self.assertTemplateUsed(resp, "chlamdb/pan_genome.html")
         self.assertEqual(self.view_type, resp.context["object_type"])
         self.assertPageTitle(resp, self.page_title)
         self.assertNoRarefactionPlot(resp)
 
-        resp = self.client.post(f"/pan_genome/{self.view_type}",
-                                data={"targets": ["1", "2"]})
+        resp = self.client.post(
+            f"/pan_genome/{self.view_type}", data={"targets": ["1", "2"]}
+        )
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/pan_genome.html')
+        self.assertTemplateUsed(resp, "chlamdb/pan_genome.html")
         self.assertEqual(self.view_type, resp.context["object_type"])
         self.assertPageTitle(resp, self.page_title)
         self.assertRarefactionPlot(resp)
@@ -497,39 +538,36 @@ class ComparisonViewsTestMixin():
     def test_gwas_view(self):
         resp = self.client.get(self.gwas_view)
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/gwas.html')
+        self.assertTemplateUsed(resp, "chlamdb/gwas.html")
         self.assertPageTitle(resp, self.page_title)
         self.assertNoGwasTable(resp)
         self.assertNav(resp)
         self.assertNotContains(resp, 'id="error"')
 
-        resp = self.client.post(self.gwas_view,
-                                data=self.gwas_form_data)
+        resp = self.client.post(self.gwas_view, data=self.gwas_form_data)
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/gwas.html')
+        self.assertTemplateUsed(resp, "chlamdb/gwas.html")
         self.assertPageTitle(resp, self.page_title)
         # No results because there is no hit.
         self.assertNoGwasTable(resp)
         self.assertNav(resp)
         self.assertContains(resp, 'id="error"')
-        self.assertContains(resp, 'No significant association')
+        self.assertContains(resp, "No significant association")
 
-        resp = self.client.post(self.gwas_view,
-                                data=self.gwas_groups_form_data)
+        resp = self.client.post(self.gwas_view, data=self.gwas_groups_form_data)
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/gwas.html')
+        self.assertTemplateUsed(resp, "chlamdb/gwas.html")
         self.assertPageTitle(resp, self.page_title)
         # No results because there is no hit.
         self.assertNoGwasTable(resp)
         self.assertNav(resp)
         self.assertContains(resp, 'id="error"')
-        self.assertContains(resp, 'No significant association')
+        self.assertContains(resp, "No significant association")
 
         maybe_dump_html(resp, "with_results")
 
 
 class TestPfamViews(ViewTestCase, ComparisonViewsTestMixin):
-
     view_type = "pfam"
     page_title = "Comparisons: PFAM domains"
 
@@ -537,15 +575,16 @@ class TestPfamViews(ViewTestCase, ComparisonViewsTestMixin):
 
 
 class TestKOViews(ViewTestCase, ComparisonViewsTestMixin):
-
     view_type = "ko"
     page_title = "Comparisons: Kegg Orthologs (KO)"
 
     def test_venn_subset_view(self):
-        subset_view = f"/{self.view_type}_venn_subset/Cofactor+and+vitamin+metabolism?h=1&h=2"
+        subset_view = (
+            f"/{self.view_type}_venn_subset/Cofactor+and+vitamin+metabolism?h=1&h=2"
+        )
         resp = self.client.get(subset_view)
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/venn_generic.html')
+        self.assertTemplateUsed(resp, "chlamdb/venn_generic.html")
         self.assertPageTitle(resp, self.page_title)
         self.assertVennDiagram(resp)
         self.assertNav(resp)
@@ -554,7 +593,6 @@ class TestKOViews(ViewTestCase, ComparisonViewsTestMixin):
 
 
 class TestCOGViews(ViewTestCase, ComparisonViewsTestMixin):
-
     view_type = "cog"
     page_title = "Comparisons: Clusters of Orthologous groups (COGs)"
 
@@ -562,7 +600,7 @@ class TestCOGViews(ViewTestCase, ComparisonViewsTestMixin):
         subset_view = f"/{self.view_type}_venn_subset/L?h=1&h=2"
         resp = self.client.get(subset_view)
         self.assertEqual(200, resp.status_code)
-        self.assertTemplateUsed(resp, 'chlamdb/venn_generic.html')
+        self.assertTemplateUsed(resp, "chlamdb/venn_generic.html")
         self.assertPageTitle(resp, self.page_title)
         self.assertVennDiagram(resp)
         self.assertNav(resp)
@@ -571,7 +609,6 @@ class TestCOGViews(ViewTestCase, ComparisonViewsTestMixin):
 
 
 class TestAMRViews(ViewTestCase, ComparisonViewsTestMixin):
-
     view_type = "amr"
     page_title = "Comparisons: Antimicrobial Resistance"
 
@@ -580,9 +617,11 @@ class TestAMRViews(ViewTestCase, ComparisonViewsTestMixin):
         """Tests for class and subclass are not worth much as none
         of the AMRs in the DB have a class or subclass...
         """
-        return [{"targets": ["1", "2"], "comp_type": "gene"},
-                {"targets": ["1", "2"], "comp_type": "class"},
-                {"targets": ["1", "2"], "comp_type": "subclass"}]
+        return [
+            {"targets": ["1", "2"], "comp_type": "gene"},
+            {"targets": ["1", "2"], "comp_type": "class"},
+            {"targets": ["1", "2"], "comp_type": "subclass"},
+        ]
 
     @skip("Heatmap plot fails because the test data does not provide enough hits")
     def test_plot_heatmap_view(self):
@@ -590,19 +629,19 @@ class TestAMRViews(ViewTestCase, ComparisonViewsTestMixin):
 
 
 class TestVFViews(ViewTestCase, ComparisonViewsTestMixin):
-
     view_type = "vf"
     page_title = "Comparisons: Virulence Factors"
 
     @property
     def tab_comp_form_data_list(self):
-        return [{"targets": ["1", "2"], "comp_type": "vf_gene_id"},
-                {"targets": ["1", "2"], "comp_type": "vfid"},
-                {"targets": ["1", "2"], "comp_type": "category"},]
+        return [
+            {"targets": ["1", "2"], "comp_type": "vf_gene_id"},
+            {"targets": ["1", "2"], "comp_type": "vfid"},
+            {"targets": ["1", "2"], "comp_type": "category"},
+        ]
 
 
 class TestOrthogroupViews(ViewTestCase, ComparisonViewsTestMixin):
-
     view_type = "orthogroup"
     page_title = "Comparisons: orthologous groups"
 

--- a/webapp/chlamdb/circosjs.py
+++ b/webapp/chlamdb/circosjs.py
@@ -1,26 +1,21 @@
-
-class CircosJs():
-    '''
+class CircosJs:
+    """
     Generate javascript code for circos plots
 
     - self.add_heatmap: add a new heatmap
     - self.get_js_code: return complete js code as string
-    '''
-    
-    
-    
-    def __init__(self,
-                 figure_div_id="heatmapChart"):
-        
+    """
+
+    def __init__(self, figure_div_id="heatmapChart"):
         self.contigs_data = []
-        self.heatmap_tracks = '{'
-        self.highlight_tracks = '{'
-        self.lineplot_tracks = '{'
-        self.histogram_tracks = '{'
+        self.heatmap_tracks = "{"
+        self.highlight_tracks = "{"
+        self.lineplot_tracks = "{"
+        self.histogram_tracks = "{"
         self.last_inner_radius = None
         self.last_outer_radius = 1.01
 
-        self.js_template = ''' 
+        self.js_template = """ 
         
         var width = 900;
 
@@ -89,9 +84,9 @@ class CircosJs():
 
         myCircos.render();
   
-        '''
-        
-        self.template_heatmap = '''
+        """
+
+        self.template_heatmap = """
         var heatmap_data_lst = %s ;
 
         var i = 0;
@@ -105,9 +100,9 @@ class CircosJs():
 
             myCircos.heatmap(key, data, conf);
         }
-        '''
-        
-        self.template_highlight = '''
+        """
+
+        self.template_highlight = """
         var highlight_data_lst = %s ;
 
         var i = 0;
@@ -121,9 +116,9 @@ class CircosJs():
             myCircos.highlight(key, data, conf);
         }
         
-        '''
-        
-        self.template_lineplot = '''
+        """
+
+        self.template_lineplot = """
         var lineplot_data_lst = %s ;
 
         var i = 0;
@@ -135,9 +130,9 @@ class CircosJs():
             myCircos.line(key, data, conf);
         }
         
-        '''
+        """
 
-        self.template_histogram = '''
+        self.template_histogram = """
         var histogram_data_lst = %s ;
 
         var i = 0;
@@ -149,194 +144,278 @@ class CircosJs():
             myCircos.histogram(key, data, conf);
         }
         
-        '''
+        """
 
-        self.heatmap_configuration_template = '{outerRadius: %s, innerRadius: %s, min: 0, max: 100, color: %s, logScale: false}'
-        
-        self.histogram_configuration_template = '{outerRadius: %s, innerRadius: %s, color: %s, logScale: false}'
-        
+        self.heatmap_configuration_template = "{outerRadius: %s, innerRadius: %s, min: 0, max: 100, color: %s, logScale: false}"
+
+        self.histogram_configuration_template = (
+            "{outerRadius: %s, innerRadius: %s, color: %s, logScale: false}"
+        )
+
         self.lineplot_configuration_template = '{outerRadius: %s, innerRadius: %s, color: "%s", logScale: false, fillColor: "%s", fill: true, direction: "out"}'
-    
 
     def add_contigs_data(self, df_bioentry):
-      '''
-      Input df with the following columns:
-      - length
-      - accession
-      
-      The index is used as id
-      '''     
-      i = 0
-      for bioentry, row in df_bioentry.iterrows():
-          if i % 2 == 0:
-              self.contigs_data.append({"len": row.length, "color": "#8dd3c7", "label": row.accession, "id": bioentry})
-          else:
-              self.contigs_data.append({"len": row.length, "color": "#fb8072", "label": row.accession, "id": bioentry})
-          i+=1
-      
-    
-    def add_gene_track(self, df, label, highlight_list = ["OJCDPLGI_00091", "OJCDPLGI_00096"], sep=0, radius_diff=0.04):
-      '''
-      Input df columns:
-      - bioentry_id
-      - start_pos
-      - end_pos
-      - locus_ref
-      '''
-    
-      highlight_data = [{"block_id": str(row.bioentry_id), "start":row.start_pos, "end": row.end_pos, "color": row.color, "locus_tag": row.locus_ref, "gene": f"{row.gene}", "product": f'{row.gene_product}'} if row.locus_ref not in highlight_list else  {"block_id": str(row.bioentry_id), "start":row.start_pos, "end": row.end_pos, "color": "magenta", "locus_tag": row.locus_ref,  "gene": f"{row.gene}", "product": f'{row.gene_product}'} for n, row in df.iterrows()]
-      
-      if not self.last_inner_radius:
-        outer_radius = 0.98
-        inner_radius = 0.98 - radius_diff
-        #conf["color"] = color
-      else:
-        outer_radius = self.last_inner_radius - sep
-        inner_radius  = self.last_inner_radius - sep - radius_diff
-        #conf["color"] = color
-      
-      self.last_inner_radius = inner_radius
+        """
+        Input df with the following columns:
+        - length
+        - accession
 
-      conf = self.heatmap_configuration_template % (outer_radius, inner_radius, 'function (d) {return d.color}') # 
+        The index is used as id
+        """
+        i = 0
+        for bioentry, row in df_bioentry.iterrows():
+            if i % 2 == 0:
+                self.contigs_data.append(
+                    {
+                        "len": row.length,
+                        "color": "#8dd3c7",
+                        "label": row.accession,
+                        "id": bioentry,
+                    }
+                )
+            else:
+                self.contigs_data.append(
+                    {
+                        "len": row.length,
+                        "color": "#fb8072",
+                        "label": row.accession,
+                        "id": bioentry,
+                    }
+                )
+            i += 1
 
-      self.highlight_tracks += f'"{label}": [%s,%s],' % (highlight_data, conf)
-    
-    
+    def add_gene_track(
+        self,
+        df,
+        label,
+        highlight_list=["OJCDPLGI_00091", "OJCDPLGI_00096"],
+        sep=0,
+        radius_diff=0.04,
+    ):
+        """
+        Input df columns:
+        - bioentry_id
+        - start_pos
+        - end_pos
+        - locus_ref
+        """
+
+        highlight_data = [
+            {
+                "block_id": str(row.bioentry_id),
+                "start": row.start_pos,
+                "end": row.end_pos,
+                "color": row.color,
+                "locus_tag": row.locus_ref,
+                "gene": f"{row.gene}",
+                "product": f"{row.gene_product}",
+            }
+            if row.locus_ref not in highlight_list
+            else {
+                "block_id": str(row.bioentry_id),
+                "start": row.start_pos,
+                "end": row.end_pos,
+                "color": "magenta",
+                "locus_tag": row.locus_ref,
+                "gene": f"{row.gene}",
+                "product": f"{row.gene_product}",
+            }
+            for n, row in df.iterrows()
+        ]
+
+        if not self.last_inner_radius:
+            outer_radius = 0.98
+            inner_radius = 0.98 - radius_diff
+            # conf["color"] = color
+        else:
+            outer_radius = self.last_inner_radius - sep
+            inner_radius = self.last_inner_radius - sep - radius_diff
+            # conf["color"] = color
+
+        self.last_inner_radius = inner_radius
+
+        conf = self.heatmap_configuration_template % (
+            outer_radius,
+            inner_radius,
+            "function (d) {return d.color}",
+        )  #
+
+        self.highlight_tracks += f'"{label}": [%s,%s],' % (highlight_data, conf)
+
     def add_heatmap_track(self, df, label, color="comp", sep=0, radius_diff=0.06):
-        '''
+        """
         Input df columns:
         - bioentry_id
         - start_pos
         - end_pos
         - identity
         - locus_tag
-        
+
         Locus without homologs in the target genome should have a locus_tag with a value of None
-        '''
-        heatmap_data = [{"block_id": row.bioentry_id, "start":row.start_pos, "end": row.end_pos, "value": row.identity, "locus_tag": row.locus_tag} if row.locus_tag is not None else {"block_id": row.bioentry_id, "start":row.start_pos, "end": row.end_pos, "value": "false"} for n, row in df.iterrows()]
-          
+        """
+        heatmap_data = [
+            {
+                "block_id": row.bioentry_id,
+                "start": row.start_pos,
+                "end": row.end_pos,
+                "value": row.identity,
+                "locus_tag": row.locus_tag,
+            }
+            if row.locus_tag is not None
+            else {
+                "block_id": row.bioentry_id,
+                "start": row.start_pos,
+                "end": row.end_pos,
+                "value": "false",
+            }
+            for n, row in df.iterrows()
+        ]
+
         if not self.last_inner_radius:
             outer_radius = 0.98
             inner_radius = 0.98 - radius_diff
-            #conf["color"] = color
+            # conf["color"] = color
         else:
             outer_radius = self.last_inner_radius - sep
-            inner_radius  = self.last_inner_radius - sep - radius_diff
-            #conf["color"] = color
-          
+            inner_radius = self.last_inner_radius - sep - radius_diff
+            # conf["color"] = color
+
         self.last_inner_radius = inner_radius
 
-        if color == 'comp':
-              col = '''function(datum, index) {var color_scale = chroma.scale('YlOrRd').domain([30,100]); if (datum.value == "false") {return "lightblue"} else {var col = color_scale((datum.value)).hex();return col}}'''
+        if color == "comp":
+            col = """function(datum, index) {var color_scale = chroma.scale('YlOrRd').domain([30,100]); if (datum.value == "false") {return "lightblue"} else {var col = color_scale((datum.value)).hex();return col}}"""
         else:
-              col = color
+            col = color
 
         conf = self.heatmap_configuration_template % (outer_radius, inner_radius, col)
-              
-        self.heatmap_tracks += f'"{label}": [%s,%s],' % (heatmap_data, conf)
-    
 
-    def add_line_track(self, bioentry_df, label, fillcolor="red", sep=0, radius_diff=0.06, windows=500):
-        '''
+        self.heatmap_tracks += f'"{label}": [%s,%s],' % (heatmap_data, conf)
+
+    def add_line_track(
+        self, bioentry_df, label, fillcolor="red", sep=0, radius_diff=0.06, windows=500
+    ):
+        """
         Minimal Input df columns:
         - bioentry_id
         - seq
-        '''
+        """
         from Bio.SeqUtils import gc_fraction
-        
-        ordered_seqs = [bioentry.seq for n,bioentry in bioentry_df.iterrows()]
-        concat_seq = ''.join(ordered_seqs)
+
+        ordered_seqs = [bioentry.seq for n, bioentry in bioentry_df.iterrows()]
+        concat_seq = "".join(ordered_seqs)
         average_gc = gc_fraction(concat_seq)
-        
+
         linedata_data = []
         for index, bientry in bioentry_df.iterrows():
             for i in range(0, len(bientry.seq), windows):
                 start = i
                 stop = i + windows
-                gc = gc_fraction(bientry.seq[start:stop]) #- average_gc
+                gc = gc_fraction(bientry.seq[start:stop])  # - average_gc
                 if stop > len(bientry.seq):
                     stop = len(bientry.seq)
                 if stop - start < 500:
                     break
-                #print("gc-diff", gc)
-                linedata_data.append({"block_id": str(index), "position": start, "value": gc}) 
-                linedata_data.append({"block_id": str(index), "position": stop, "value": gc}) 
-          
+                # print("gc-diff", gc)
+                linedata_data.append(
+                    {"block_id": str(index), "position": start, "value": gc}
+                )
+                linedata_data.append(
+                    {"block_id": str(index), "position": stop, "value": gc}
+                )
+
         if not self.last_inner_radius:
             outer_radius = 0.98
             inner_radius = 0.98 - radius_diff
-            #conf["color"] = color
+            # conf["color"] = color
         else:
             outer_radius = self.last_inner_radius - sep
-            inner_radius  = self.last_inner_radius - sep - radius_diff
-            #conf["color"] = color
-          
+            inner_radius = self.last_inner_radius - sep - radius_diff
+            # conf["color"] = color
+
         self.last_inner_radius = inner_radius
 
-        conf = self.lineplot_configuration_template % (outer_radius, inner_radius, fillcolor, fillcolor)
-              
+        conf = self.lineplot_configuration_template % (
+            outer_radius,
+            inner_radius,
+            fillcolor,
+            fillcolor,
+        )
+
         self.lineplot_tracks += f'"{label}": [%s,%s],' % (linedata_data, conf)
- 
- 
-    def add_histogram_track(self, df, label, fillcolor="blue", sep=0, radius_diff=0.06, outer=False):
-        '''
+
+    def add_histogram_track(
+        self, df, label, fillcolor="blue", sep=0, radius_diff=0.06, outer=False
+    ):
+        """
         Minimal Input df columns:
         - bioentry_id
-        - start_pos 
-        - end_pos 
+        - start_pos
+        - end_pos
         - value
-        '''
-        histogram_data = [{"block_id": f'{row.bioentry_id}', "start":row.start_pos, "end": row.end_pos, "value": row.value} for n, row in df.iterrows()]
-        
+        """
+        histogram_data = [
+            {
+                "block_id": f"{row.bioentry_id}",
+                "start": row.start_pos,
+                "end": row.end_pos,
+                "value": row.value,
+            }
+            for n, row in df.iterrows()
+        ]
+
         if not outer:
             if not self.last_inner_radius:
                 outer_radius = 0.98
                 inner_radius = 0.98 - radius_diff
-                #conf["color"] = color
+                # conf["color"] = color
             else:
                 outer_radius = self.last_inner_radius - sep
-                inner_radius  = self.last_inner_radius - sep - radius_diff
-                #conf["color"] = color
+                inner_radius = self.last_inner_radius - sep - radius_diff
+                # conf["color"] = color
             self.last_inner_radius = inner_radius
         else:
             inner_radius = self.last_outer_radius + sep
-            outer_radius  = self.last_outer_radius + sep + radius_diff
+            outer_radius = self.last_outer_radius + sep + radius_diff
             self.last_outer_radius = outer_radius
-          
-        
 
-        col = '''function(datum, index) {console.log(datum); if (datum.value < 6) {return "red"} else {return "lightblue"}}'''
+        col = """function(datum, index) {console.log(datum); if (datum.value < 6) {return "red"} else {return "lightblue"}}"""
         print(col)
 
         conf = self.histogram_configuration_template % (outer_radius, inner_radius, col)
-              
+
         self.histogram_tracks += f'"{label}": [%s,%s],' % (histogram_data, conf)
-    
-    
-    def get_js_code(self,):
-        
-        if len(self.heatmap_tracks)> 1:
-            heat =  self.heatmap_tracks[0:-1] + '}'
+
+    def get_js_code(
+        self,
+    ):
+        if len(self.heatmap_tracks) > 1:
+            heat = self.heatmap_tracks[0:-1] + "}"
             heatmap_code = self.template_heatmap % heat
         else:
-            heatmap_code = ''
-            
-        if len(self.highlight_tracks) > 1:           
-            high = self.highlight_tracks[0:-1] + '}'
+            heatmap_code = ""
+
+        if len(self.highlight_tracks) > 1:
+            high = self.highlight_tracks[0:-1] + "}"
             highlight_code = self.template_highlight % high
         else:
-            highlight_code = ''
-        
+            highlight_code = ""
+
         if len(self.lineplot_tracks) > 1:
-            line = self.lineplot_tracks[0:-1] + '}'
+            line = self.lineplot_tracks[0:-1] + "}"
             lineplot_code = self.template_lineplot % line
         else:
-            lineplot_code = ''
-            
+            lineplot_code = ""
+
         if len(self.histogram_tracks) > 1:
-            histogram = self.histogram_tracks[0:-1] + '}'
+            histogram = self.histogram_tracks[0:-1] + "}"
             histogram_code = self.template_histogram % histogram
         else:
-            histogram_code = ''
-        
-        return self.js_template % (self.contigs_data, heatmap_code, highlight_code, lineplot_code, histogram_code)
+            histogram_code = ""
+
+        return self.js_template % (
+            self.contigs_data,
+            heatmap_code,
+            highlight_code,
+            lineplot_code,
+            histogram_code,
+        )

--- a/webapp/chlamdb/middleware.py
+++ b/webapp/chlamdb/middleware.py
@@ -1,9 +1,8 @@
 class MyMiddleware:
-
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
         response = self.get_response(request)
-        response['X-My-Header'] = "Chlamydiae Genome Database"
+        response["X-My-Header"] = "Chlamydiae Genome Database"
         return response

--- a/webapp/chlamdb/urls.py
+++ b/webapp/chlamdb/urls.py
@@ -1,96 +1,259 @@
-
 from django.urls import re_path
 from django.views.generic import TemplateView
 from django.views.generic.base import RedirectView
-from views import (autocomplete, custom_plots, entry_lists, fam, groups, gwas,
-                   hits_extraction, locus, tabular_comparison, venn, views)
+from views import autocomplete
+from views import custom_plots
+from views import entry_lists
+from views import fam
+from views import groups
+from views import gwas
+from views import hits_extraction
+from views import locus
+from views import tabular_comparison
+from views import venn
+from views import views
 
-favicon_view = RedirectView.as_view(url='/assets/favicon.ico', permanent=True)
+favicon_view = RedirectView.as_view(url="/assets/favicon.ico", permanent=True)
 
 
 urlpatterns = [
-    re_path(r'^vf_comparison', tabular_comparison.VfComparisonView.as_view(), name="vf_comparison"),  # noqa
-    re_path(r'^venn_vf/$', venn.VennVfView.as_view(), name="venn_vf"),
-    re_path(r'^venn_pfam/$', venn.VennPfamView.as_view(), name="venn_pfam"),
-    re_path(r'^venn_orthogroup/$', venn.VennOrthogroupView.as_view(), name="venn_orthogroup"),  # noqa
-    re_path(r'^venn_ko/$', venn.VennKoView.as_view(), name="venn_ko"),
-    re_path(r'^venn_cog/$', venn.VennCogView.as_view(), name="venn_cog"),
-    re_path(r'^venn_amr/$', venn.VennAmrView.as_view(), name="venn_amr"),
-    re_path(r'^search_suggest/.*$', views.search_suggest, name="search_suggest"),  # noqa
-    re_path(r'^search_bar/([a-zA-Z0-9_\.\-]+)/([a-zA-Z0-9_\.\-]+)', views.search_bar, name="search_bar"),  # noqa
-    re_path(r'^search_bar$', views.search_bar, name="search_bar"),
-    re_path(r'^plot_region/$', views.plot_region, name="plot_region"),
-    re_path(r'^plot_heatmap/([a-zA-Z0-9_\-]+)', views.PlotHeatmap.as_view(), name="plot_heatmap"),  # noqa
-    re_path(r'^phylogeny', views.phylogeny, name='phylogeny'),
-    re_path(r'^pfam_comparison', tabular_comparison.PfamComparisonView.as_view(), name="pfam_comparison"),  # noqa
-    re_path(r'^pan_genome/([a-zA-Z0-9_]+)', views.PanGenome.as_view(), name="pan_genome"),  # noqa
-    re_path(r'^orthogroup_comparison', tabular_comparison.OrthogroupComparisonView.as_view(), name="orthogroup_comparison"),  # noqa
-    re_path(r'^orthogroup/([a-zA-Z0-9_\.\-]+)', locus.Orthogroup.as_view(), name="orthogroup"),  # noqa
-    re_path(r'^module_comparison/$', views.module_comparison, name="module_comparison"),  # noqa
-    re_path(r'^module_cat_info/([a-zA-Z0-9_\.]+)/([a-zA-Z0-9_\.\+-]+)$', views.module_cat_info, name="module_cat_info"),  # noqa
-    re_path(r'^locusx/([a-zA-Z0-9_\.\-]+)/([a-zA-Z0-9_\.\-]+)', locus.LocusX.as_view(), name="locusx"),  # noqa
-    re_path(r'^locusx/([a-zA-Z0-9_\.\-]+)', locus.LocusX.as_view(), name="locusx"),
-    re_path(r'^locusx$', locus.LocusX.as_view(), name="locusx"),
-    re_path(r'^ko_venn_subset/([a-zA-Z0-9_\.\+-]+)$', venn.VennKoSubsetView.as_view(), name="ko_venn_subset"),  # noqa
-    re_path(r'^ko_comparison', tabular_comparison.KoComparisonView.as_view(), name="ko_comparison"),  # noqa
-    re_path(r'^ko_barchart/$', views.KoBarchart.as_view(), name="ko_barchart"),
-    re_path(r'^kegg_module_subcat$', views.kegg_module_subcat, name="kegg_module_subcat"),  # noqa
-    re_path(r'^KEGG_module_map/([a-zA-Z0-9_\.]+)$', views.KEGG_module_map, name="KEGG_module_map"),  # noqa
-    re_path(r'^kegg_module/$', views.kegg_module, name="kegg_module"),
-    re_path(r'^KEGG_mapp_ko/([a-zA-Z0-9_\.]+)/([0-9]+)$', views.KEGG_mapp_ko, name="KEGG_mapp_ko"),  # noqa
-    re_path(r'^KEGG_mapp_ko/([a-zA-Z0-9_\.]+)$', views.KEGG_mapp_ko, name="KEGG_mapp_ko"),  # noqa
-    re_path(r'^KEGG_mapp_ko$', views.KEGG_mapp_ko, name="KEGG_mapp_ko"),
-    re_path(r'^kegg_genomes_modules/$', views.kegg_genomes_modules, name="kegg_genomes_modules"),  # noqa
-    re_path(r'^kegg_genomes/$', views.kegg_genomes, name="kegg_genomes"),
-    re_path(r'^kegg/$', views.kegg, name="kegg"),
-    re_path(r'^index_comp/([a-zA-Z0-9_\.\-]+)', views.ComparisonIndexView.as_view(), name="index_comp"),  # noqa
-    re_path(r'^home/$', views.home, name="home"),
-    re_path(r'^help', views.help, name="help"),
-    re_path(r'^gwas_vf/', gwas.VfGwasView.as_view(), name="gwas_vf"),
-    re_path(r'^gwas_pfam/', gwas.PfamGwasView.as_view(), name="gwas_pfam"),
-    re_path(r'^gwas_orthogroup/', gwas.OrthogroupGwasView.as_view(), name="gwas_orthogroup"),  # noqa
-    re_path(r'^gwas_ko/', gwas.KoGwasView.as_view(), name="gwas_ko"),
-    re_path(r'^gwas_cog/', gwas.CogGwasView.as_view(), name="gwas_cog"),
-    re_path(r'^gwas_amr/', gwas.AmrGwasView.as_view(), name="gwas_amr"),
-    re_path(r'^groups/add/$', groups.GroupAdd.as_view(), name=groups.GroupAdd.view_name),  # noqa
-    re_path(r'^groups/([a-zA-Z0-9_\.\(\)\-\'\s]+)/delete/$', groups.GroupDelete.as_view(), name=groups.GroupDelete.view_name),  # noqa
-    re_path(r'^groups/([a-zA-Z0-9_\.\(\)\-\'\s]+)', groups.GroupDetails.as_view(), name=groups.GroupDetails.view_name),  # noqa
-    re_path(r'^groups/$', groups.GroupsOverview.as_view(), name=groups.GroupsOverview.view_name),   # noqa
-    re_path(r'^get_cog/([a-zA-Z0-9_\.]+)/([a-zA-Z0-9_\.\%]+)$', views.get_cog, name="get_cog"),  # noqa
-    re_path(r'^genomes', views.Genomes.as_view(), name=views.Genomes.view_name),
-    re_path(r'^favicon\.ico$', favicon_view),
-    re_path(r'^FAQ', views.faq, name='FAQ'),
-    re_path(r'^fam_vf/(VFG[0-9]+)$', fam.FamVfView.as_view(), name="fam_vf"),
-    re_path(r'^fam_pfam/(PF[0-9]+)$', fam.FamPfamView.as_view(), name="fam_pfam"),
-    re_path(r'^fam_ko/(K[0-9]+)$', fam.FamKoView.as_view(), name="fam_ko"),
-    re_path(r'^fam_cog/(COG[0-9]+)$', fam.FamCogView.as_view(), name="fam_cog"),  # noqa
-    re_path(r'^fam_amr/([a-zA-Z0-9_\.\(\)\-\']+)$', fam.FamAmrView.as_view(), name="fam_amr"),  # noqa
-    re_path(r'^extract_vf/$', hits_extraction.ExtractVfView.as_view(), name="extract_vf"),  # noqa
-    re_path(r'^extract_pfam/$', hits_extraction.ExtractPfamView.as_view(), name="extract_pfam"),  # noqa
-    re_path(r'^extract_orthogroup/$', hits_extraction.ExtractOrthogroupView.as_view(), name="extract_orthogroup"),  # noqa
-    re_path(r'^extract_ko/$', hits_extraction.ExtractKoView.as_view(), name="extract_ko"),  # noqa
-    re_path(r'^extract_contigs/([0-9]+)', views.ExtractContigs.as_view(), name='extract_contigs'),  # noqa
-    re_path(r'^extract_cog/$', hits_extraction.ExtractCogView.as_view(), name="extract_cog"),  # noqa
-    re_path(r'^extract_amr/$', hits_extraction.ExtractAmrView.as_view(), name="extract_amr"),  # noqa
-    re_path(r'^entry_list_vf$', entry_lists.VfEntryListView.as_view(), name="entry_list_vf"),  # noqa
-    re_path(r'^entry_list_pfam$', entry_lists.PfamEntryListView.as_view(), name="entry_list_pfam"),  # noqa
-    re_path(r'^entry_list_ko$', entry_lists.KoEntryListView.as_view(), name="entry_list_ko"),  # noqa
-    re_path(r'^entry_list_cog$', entry_lists.CogEntryListView.as_view(), name="entry_list_cog"),  # noqa
-    re_path(r'^entry_list_amr$', entry_lists.AmrEntryListView.as_view(), name="entry_list_amr"),  # noqa
-    re_path(r'^download_sequences$', locus.DownloadSequences.as_view(), name="download_sequences"),  # noqa
-    re_path(r'^custom_plots/$', custom_plots.CusomPlotsView.as_view(), name="custom_plots"),  # noqa
-    re_path(r'^cog_venn_subset/([A-Z])$', venn.VennCogSubsetView.as_view(), name="cog_venn_subset"),  # noqa
-    re_path(r'^cog_phylo_heatmap/([a-zA-Z0-9_\-]+)', views.CogPhyloHeatmap.as_view(), name="cog_phylo_heatmap"),  # noqa
-    re_path(r'^cog_comparison', tabular_comparison.CogComparisonView.as_view(), name="cog_comparison"),  # noqa
-    re_path(r'^cog_barchart/$', views.CogBarchart.as_view(), name="cog_barchart"),
-    re_path(r'^circos_main/$', views.circos_main, name="circos_main"),
-    re_path(r'^circos/$', views.circos, name="circos"),
-    re_path(r'^blast/$', views.blast, name="blast"),
-    re_path(r'^autocomplete_taxid/$', autocomplete.AutocompleteTaxid.as_view(), name="autocomplete_taxid"),  # noqa
-    re_path(r'^autocomplete_n_missing/$', autocomplete.AutocompleteNMissing.as_view(), name="autocomplete_n_missing"),  # noqa
-    re_path(r'^amr_comparison', tabular_comparison.AmrComparisonView.as_view(), name="amr_comparison"),  # noqa
-    re_path(r'^about$', views.about, name="about"),
-    re_path(r'^.*$', views.home, name="home"),
-    re_path('^robots.txt$', TemplateView.as_view(template_name='robots.txt', content_type='text/plain')),  # noqa
+    re_path(
+        r"^vf_comparison",
+        tabular_comparison.VfComparisonView.as_view(),
+        name="vf_comparison",
+    ),  # noqa
+    re_path(r"^venn_vf/$", venn.VennVfView.as_view(), name="venn_vf"),
+    re_path(r"^venn_pfam/$", venn.VennPfamView.as_view(), name="venn_pfam"),
+    re_path(
+        r"^venn_orthogroup/$", venn.VennOrthogroupView.as_view(), name="venn_orthogroup"
+    ),  # noqa
+    re_path(r"^venn_ko/$", venn.VennKoView.as_view(), name="venn_ko"),
+    re_path(r"^venn_cog/$", venn.VennCogView.as_view(), name="venn_cog"),
+    re_path(r"^venn_amr/$", venn.VennAmrView.as_view(), name="venn_amr"),
+    re_path(r"^search_suggest/.*$", views.search_suggest, name="search_suggest"),  # noqa
+    re_path(
+        r"^search_bar/([a-zA-Z0-9_\.\-]+)/([a-zA-Z0-9_\.\-]+)",
+        views.search_bar,
+        name="search_bar",
+    ),  # noqa
+    re_path(r"^search_bar$", views.search_bar, name="search_bar"),
+    re_path(r"^plot_region/$", views.plot_region, name="plot_region"),
+    re_path(
+        r"^plot_heatmap/([a-zA-Z0-9_\-]+)",
+        views.PlotHeatmap.as_view(),
+        name="plot_heatmap",
+    ),  # noqa
+    re_path(r"^phylogeny", views.phylogeny, name="phylogeny"),
+    re_path(
+        r"^pfam_comparison",
+        tabular_comparison.PfamComparisonView.as_view(),
+        name="pfam_comparison",
+    ),  # noqa
+    re_path(
+        r"^pan_genome/([a-zA-Z0-9_]+)", views.PanGenome.as_view(), name="pan_genome"
+    ),  # noqa
+    re_path(
+        r"^orthogroup_comparison",
+        tabular_comparison.OrthogroupComparisonView.as_view(),
+        name="orthogroup_comparison",
+    ),  # noqa
+    re_path(
+        r"^orthogroup/([a-zA-Z0-9_\.\-]+)",
+        locus.Orthogroup.as_view(),
+        name="orthogroup",
+    ),  # noqa
+    re_path(r"^module_comparison/$", views.module_comparison, name="module_comparison"),  # noqa
+    re_path(
+        r"^module_cat_info/([a-zA-Z0-9_\.]+)/([a-zA-Z0-9_\.\+-]+)$",
+        views.module_cat_info,
+        name="module_cat_info",
+    ),  # noqa
+    re_path(
+        r"^locusx/([a-zA-Z0-9_\.\-]+)/([a-zA-Z0-9_\.\-]+)",
+        locus.LocusX.as_view(),
+        name="locusx",
+    ),  # noqa
+    re_path(r"^locusx/([a-zA-Z0-9_\.\-]+)", locus.LocusX.as_view(), name="locusx"),
+    re_path(r"^locusx$", locus.LocusX.as_view(), name="locusx"),
+    re_path(
+        r"^ko_venn_subset/([a-zA-Z0-9_\.\+-]+)$",
+        venn.VennKoSubsetView.as_view(),
+        name="ko_venn_subset",
+    ),  # noqa
+    re_path(
+        r"^ko_comparison",
+        tabular_comparison.KoComparisonView.as_view(),
+        name="ko_comparison",
+    ),  # noqa
+    re_path(r"^ko_barchart/$", views.KoBarchart.as_view(), name="ko_barchart"),
+    re_path(
+        r"^kegg_module_subcat$", views.kegg_module_subcat, name="kegg_module_subcat"
+    ),  # noqa
+    re_path(
+        r"^KEGG_module_map/([a-zA-Z0-9_\.]+)$",
+        views.KEGG_module_map,
+        name="KEGG_module_map",
+    ),  # noqa
+    re_path(r"^kegg_module/$", views.kegg_module, name="kegg_module"),
+    re_path(
+        r"^KEGG_mapp_ko/([a-zA-Z0-9_\.]+)/([0-9]+)$",
+        views.KEGG_mapp_ko,
+        name="KEGG_mapp_ko",
+    ),  # noqa
+    re_path(
+        r"^KEGG_mapp_ko/([a-zA-Z0-9_\.]+)$", views.KEGG_mapp_ko, name="KEGG_mapp_ko"
+    ),  # noqa
+    re_path(r"^KEGG_mapp_ko$", views.KEGG_mapp_ko, name="KEGG_mapp_ko"),
+    re_path(
+        r"^kegg_genomes_modules/$",
+        views.kegg_genomes_modules,
+        name="kegg_genomes_modules",
+    ),  # noqa
+    re_path(r"^kegg_genomes/$", views.kegg_genomes, name="kegg_genomes"),
+    re_path(r"^kegg/$", views.kegg, name="kegg"),
+    re_path(
+        r"^index_comp/([a-zA-Z0-9_\.\-]+)",
+        views.ComparisonIndexView.as_view(),
+        name="index_comp",
+    ),  # noqa
+    re_path(r"^home/$", views.home, name="home"),
+    re_path(r"^help", views.help, name="help"),
+    re_path(r"^gwas_vf/", gwas.VfGwasView.as_view(), name="gwas_vf"),
+    re_path(r"^gwas_pfam/", gwas.PfamGwasView.as_view(), name="gwas_pfam"),
+    re_path(
+        r"^gwas_orthogroup/", gwas.OrthogroupGwasView.as_view(), name="gwas_orthogroup"
+    ),  # noqa
+    re_path(r"^gwas_ko/", gwas.KoGwasView.as_view(), name="gwas_ko"),
+    re_path(r"^gwas_cog/", gwas.CogGwasView.as_view(), name="gwas_cog"),
+    re_path(r"^gwas_amr/", gwas.AmrGwasView.as_view(), name="gwas_amr"),
+    re_path(
+        r"^groups/add/$", groups.GroupAdd.as_view(), name=groups.GroupAdd.view_name
+    ),  # noqa
+    re_path(
+        r"^groups/([a-zA-Z0-9_\.\(\)\-\'\s]+)/delete/$",
+        groups.GroupDelete.as_view(),
+        name=groups.GroupDelete.view_name,
+    ),  # noqa
+    re_path(
+        r"^groups/([a-zA-Z0-9_\.\(\)\-\'\s]+)",
+        groups.GroupDetails.as_view(),
+        name=groups.GroupDetails.view_name,
+    ),  # noqa
+    re_path(
+        r"^groups/$",
+        groups.GroupsOverview.as_view(),
+        name=groups.GroupsOverview.view_name,
+    ),  # noqa
+    re_path(
+        r"^get_cog/([a-zA-Z0-9_\.]+)/([a-zA-Z0-9_\.\%]+)$",
+        views.get_cog,
+        name="get_cog",
+    ),  # noqa
+    re_path(r"^genomes", views.Genomes.as_view(), name=views.Genomes.view_name),
+    re_path(r"^favicon\.ico$", favicon_view),
+    re_path(r"^FAQ", views.faq, name="FAQ"),
+    re_path(r"^fam_vf/(VFG[0-9]+)$", fam.FamVfView.as_view(), name="fam_vf"),
+    re_path(r"^fam_pfam/(PF[0-9]+)$", fam.FamPfamView.as_view(), name="fam_pfam"),
+    re_path(r"^fam_ko/(K[0-9]+)$", fam.FamKoView.as_view(), name="fam_ko"),
+    re_path(r"^fam_cog/(COG[0-9]+)$", fam.FamCogView.as_view(), name="fam_cog"),  # noqa
+    re_path(
+        r"^fam_amr/([a-zA-Z0-9_\.\(\)\-\']+)$", fam.FamAmrView.as_view(), name="fam_amr"
+    ),  # noqa
+    re_path(
+        r"^extract_vf/$", hits_extraction.ExtractVfView.as_view(), name="extract_vf"
+    ),  # noqa
+    re_path(
+        r"^extract_pfam/$",
+        hits_extraction.ExtractPfamView.as_view(),
+        name="extract_pfam",
+    ),  # noqa
+    re_path(
+        r"^extract_orthogroup/$",
+        hits_extraction.ExtractOrthogroupView.as_view(),
+        name="extract_orthogroup",
+    ),  # noqa
+    re_path(
+        r"^extract_ko/$", hits_extraction.ExtractKoView.as_view(), name="extract_ko"
+    ),  # noqa
+    re_path(
+        r"^extract_contigs/([0-9]+)",
+        views.ExtractContigs.as_view(),
+        name="extract_contigs",
+    ),  # noqa
+    re_path(
+        r"^extract_cog/$", hits_extraction.ExtractCogView.as_view(), name="extract_cog"
+    ),  # noqa
+    re_path(
+        r"^extract_amr/$", hits_extraction.ExtractAmrView.as_view(), name="extract_amr"
+    ),  # noqa
+    re_path(
+        r"^entry_list_vf$", entry_lists.VfEntryListView.as_view(), name="entry_list_vf"
+    ),  # noqa
+    re_path(
+        r"^entry_list_pfam$",
+        entry_lists.PfamEntryListView.as_view(),
+        name="entry_list_pfam",
+    ),  # noqa
+    re_path(
+        r"^entry_list_ko$", entry_lists.KoEntryListView.as_view(), name="entry_list_ko"
+    ),  # noqa
+    re_path(
+        r"^entry_list_cog$",
+        entry_lists.CogEntryListView.as_view(),
+        name="entry_list_cog",
+    ),  # noqa
+    re_path(
+        r"^entry_list_amr$",
+        entry_lists.AmrEntryListView.as_view(),
+        name="entry_list_amr",
+    ),  # noqa
+    re_path(
+        r"^download_sequences$",
+        locus.DownloadSequences.as_view(),
+        name="download_sequences",
+    ),  # noqa
+    re_path(
+        r"^custom_plots/$", custom_plots.CusomPlotsView.as_view(), name="custom_plots"
+    ),  # noqa
+    re_path(
+        r"^cog_venn_subset/([A-Z])$",
+        venn.VennCogSubsetView.as_view(),
+        name="cog_venn_subset",
+    ),  # noqa
+    re_path(
+        r"^cog_phylo_heatmap/([a-zA-Z0-9_\-]+)",
+        views.CogPhyloHeatmap.as_view(),
+        name="cog_phylo_heatmap",
+    ),  # noqa
+    re_path(
+        r"^cog_comparison",
+        tabular_comparison.CogComparisonView.as_view(),
+        name="cog_comparison",
+    ),  # noqa
+    re_path(r"^cog_barchart/$", views.CogBarchart.as_view(), name="cog_barchart"),
+    re_path(r"^circos_main/$", views.circos_main, name="circos_main"),
+    re_path(r"^circos/$", views.circos, name="circos"),
+    re_path(r"^blast/$", views.blast, name="blast"),
+    re_path(
+        r"^autocomplete_taxid/$",
+        autocomplete.AutocompleteTaxid.as_view(),
+        name="autocomplete_taxid",
+    ),  # noqa
+    re_path(
+        r"^autocomplete_n_missing/$",
+        autocomplete.AutocompleteNMissing.as_view(),
+        name="autocomplete_n_missing",
+    ),  # noqa
+    re_path(
+        r"^amr_comparison",
+        tabular_comparison.AmrComparisonView.as_view(),
+        name="amr_comparison",
+    ),  # noqa
+    re_path(r"^about$", views.about, name="about"),
+    re_path(r"^.*$", views.home, name="home"),
+    re_path(
+        "^robots.txt$",
+        TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
+    ),  # noqa
     # re_path(r'^FAQ',TemplateView.as_view(template_name='FAQ.html')),
 ]

--- a/webapp/chlamdb/wsgi.py
+++ b/webapp/chlamdb/wsgi.py
@@ -7,8 +7,10 @@ For more information on this file, see
 https://docs.djangoproject.com/en/1.6/howto/deployment/wsgi/
 """
 
-from django.core.wsgi import get_wsgi_application
 import os
+
+from django.core.wsgi import get_wsgi_application
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings.settings")
 
 application = get_wsgi_application()

--- a/webapp/lib/KO_module.py
+++ b/webapp/lib/KO_module.py
@@ -1,6 +1,6 @@
 # LL(1) parser implementation for the module definition of KEGGs.
 #
-# It ultimately allows, after having parsed a definition, to check 
+# It ultimately allows, after having parsed a definition, to check
 # how many kegg orthologs are missing to have a complete module.
 #
 # For now, it does not support signature modules.
@@ -9,9 +9,10 @@
 # tokens and nodes of the syntax tree.
 # TODO(BM): implement str methods for the other syntax tree nodes
 # TODO(BM): add the details of the grammar that is parsed
-# 
+#
 # Author: bastian.marquis@protonmail.com
 # Date: 05.11.2020
+
 
 class Complex:
     def __init__(self, left, right):
@@ -24,6 +25,7 @@ class Complex:
     def get_n_missing(self, kos):
         return self.right.get_n_missing(kos) + self.left.get_n_missing(kos)
 
+
 class OptionalSubunit(Complex):
     def __init__(self, expr):
         self.expr = expr
@@ -34,6 +36,7 @@ class OptionalSubunit(Complex):
     def get_n_missing(self, kos):
         return 0
 
+
 # May need to put those in a different file
 class KoAnd:
     def __init__(self, list_and):
@@ -42,12 +45,14 @@ class KoAnd:
     def get_n_missing(self, kos):
         return sum(node.get_n_missing(kos) for node in self.list_and)
 
+
 class KoOr:
     def __init__(self, list_or):
         self.list_or = list_or
 
     def get_n_missing(self, kos):
         return min(node.get_n_missing(kos) for node in self.list_or)
+
 
 class KoNode:
     def __init__(self, node_id):
@@ -61,6 +66,7 @@ class KoNode:
             return 0 if kos[self.node_id] > 0 else 1
         return 1
 
+
 class UndefinedKoNode:
     def get_n_missing(self, ko):
         return 0
@@ -69,13 +75,16 @@ class UndefinedKoNode:
 class Token:
     pass
 
+
 class LeftParToken(Token):
     def __str__(self):
         return "LeftPar"
 
+
 class RightParToken(Token):
     def __str__(self):
         return "RightPar"
+
 
 class Ko(Token):
     def __init__(self, ko_id):
@@ -84,21 +93,26 @@ class Ko(Token):
     def __str__(self):
         return f"KO{self.ko_id}"
 
+
 class AndToken(Token):
     def __str__(self):
         return "And"
+
 
 class ComplexToken(Token):
     def __str__(self):
         return "Complex"
 
+
 class OptionalComplexComponent(Token):
     def __str__(self):
         return "OptComplex"
 
+
 class OrToken(Token):
     def __str__(self):
         return "Or"
+
 
 class UndefinedToken(Token):
     def __str__(self):
@@ -123,7 +137,7 @@ class Tokenizer:
             curr_char = self.module_def[self.i]
             if not curr_char.isdigit():
                 raise Exception("Invalid KO")
-            acc = acc*10 + int(curr_char)
+            acc = acc * 10 + int(curr_char)
             self.i += 1
         return Ko(acc)
 
@@ -162,12 +176,13 @@ class Tokenizer:
             elif char == "K":
                 return self.tokenize_ko()
             else:
-                raise Exception(f"Error tokenizing at position {self.i}({self.module_def[self.i]})")
+                raise Exception(
+                    f"Error tokenizing at position {self.i}({self.module_def[self.i]})"
+                )
         raise StopIteration
 
 
 class ModuleParser:
-
     def __init__(self, module_def):
         self.module_def = module_def
         tokenizer = Tokenizer(module_def)
@@ -180,14 +195,17 @@ class ModuleParser:
             return token
         try:
             return next(self.token_iter)
-        except StopIteration as e:
+        except StopIteration:
             return None
 
     def parse_parentheses(self):
         subtree = self.parse()
         next_token = self.next_token()
         if next_token == None or not isinstance(next_token, RightParToken):
-            raise Exception("Unexpected end of expression (unbalanced parentheses) " + str(next_token))
+            raise Exception(
+                "Unexpected end of expression (unbalanced parentheses) "
+                + str(next_token)
+            )
         return subtree
 
     def parse_leaf(self):
@@ -202,7 +220,7 @@ class ModuleParser:
         elif isinstance(n, OptionalComplexComponent):
             return OptionalSubunit([self.parse_leaf()])
         else:
-            raise Exception("Unexpected token: "+str(n))
+            raise Exception("Unexpected token: " + str(n))
 
     def parse_optional(self, left_node):
         right_node = self.parse_complex()
@@ -227,7 +245,7 @@ class ModuleParser:
     def parse(self):
         comp = self.parse_complex()
         n = self.next_token()
-        if n==None:
+        if n == None:
             return comp
         elif isinstance(n, AndToken):
             and_node = KoAnd([comp])

--- a/webapp/lib/colors.py
+++ b/webapp/lib/colors.py
@@ -1,5 +1,3 @@
-
-
 import matplotlib as mpl
 import matplotlib.cm as cm
 
@@ -14,64 +12,64 @@ def to_rgb_str(rgba):
 
     string_vals = []
     for val in rgba[0:3]:
-        if val==0:
+        if val == 0:
             string_vals.append("00")
-        elif val<=15:
-            string_vals.append("0"+hex(val).lstrip("0x"))
+        elif val <= 15:
+            string_vals.append("0" + hex(val).lstrip("0x"))
         else:
             string_vals.append(hex(val).lstrip("0x"))
-    return "#"+"".join(string_vals)
+    return "#" + "".join(string_vals)
 
 
 def get_luminance(rgba):
-    return (0.299*rgba[0]+0.587*rgba[1]+0.114*rgba[2])/255
+    return (0.299 * rgba[0] + 0.587 * rgba[1] + 0.114 * rgba[2]) / 255
 
 
 def get_spaced_colors(n):
-    
-    '''
+    """
     Return n spaces colors color
-    '''
+    """
 
-    max_value = 16581375 #255**3
+    max_value = 16581375  # 255**3
     interval = int(max_value / n)
     colors = [hex(I)[2:].zfill(6) for I in range(0, max_value, interval)]
 
-    return ['#%02x%02x%02x' % (int(i[:2], 16), int(i[2:4], 16), int(i[4:], 16)) for i in colors]
+    return [
+        "#%02x%02x%02x" % (int(i[:2], 16), int(i[2:4], 16), int(i[4:], 16))
+        for i in colors
+    ]
 
 
 def get_categorical_color_scale(value_list):
-
-    '''
+    """
     Given input variable list,
     return a dictionnary of value2color
-    '''
-    
+    """
+
     value2col = dict(zip(value_list, get_spaced_colors(len(value_list))))
-    
+
     return value2col
 
 
-def get_continuous_scale(value_list, 
-                         cm_scale="OrRd"):
-        '''
-        Generate color scale best of a list of value using maplotlib
-        Return the scale and the max value.
-        Example of scales:
-        - OrRd
-        - YlGnBu
-        - PuBu
-        '''
-        
-        cm_scale = getattr(cm, cm_scale)
+def get_continuous_scale(value_list, cm_scale="OrRd"):
+    """
+    Generate color scale best of a list of value using maplotlib
+    Return the scale and the max value.
+    Example of scales:
+    - OrRd
+    - YlGnBu
+    - PuBu
+    """
 
-        if min(value_list) == max(value_list):
-            min_val = 0
-            max_val = 1.5*max(value_list)
-        else:
-            min_val = min(value_list)
-            max_val = max(value_list)
+    cm_scale = getattr(cm, cm_scale)
 
-        norm = mpl.colors.Normalize(vmin=min_val*0.9,vmax=max_val) # *1.1
-        m = cm.ScalarMappable(norm=norm, cmap=cm_scale)
-        return [m, float(max_val)]
+    if min(value_list) == max(value_list):
+        min_val = 0
+        max_val = 1.5 * max(value_list)
+    else:
+        min_val = min(value_list)
+        max_val = max(value_list)
+
+    norm = mpl.colors.Normalize(vmin=min_val * 0.9, vmax=max_val)  # *1.1
+    m = cm.ScalarMappable(norm=norm, cmap=cm_scale)
+    return [m, float(max_val)]

--- a/webapp/lib/db_utils.py
+++ b/webapp/lib/db_utils.py
@@ -18,7 +18,7 @@ from lib.queries import VFQueries
 # to litteral
 # encases the string into quotes
 def quote(v):
-    return f'"{v}"'
+    return f"'{v}'"
 
 
 class NoPhylogenyException(Exception):
@@ -87,9 +87,9 @@ class DB:
                 " INNER JOIN seqfeature_qualifier_value AS acc "
                 "     ON acc.seqfeature_id = fet.seqfeature_id "
                 " INNER JOIN term AS gene_term ON gene_term.term_id = fet.type_term_id "
-                '     AND gene_term.name = "CDS" '
+                "     AND gene_term.name = 'CDS' "
                 " INNER JOIN term AS lc ON lc.term_id = acc.term_id AND "
-                '     lc.name = "locus_tag" '
+                "     lc.name = 'locus_tag' "
                 f" WHERE acc.value IN ({plc})"
             )
         elif look_on == "contig":
@@ -223,10 +223,10 @@ class DB:
             "FROM og_hits AS ortho "
             "INNER JOIN seqfeature_qualifier_value AS seq ON seq.seqfeature_id=ortho.seqid "
             " INNER JOIN term AS seq_term "
-            '   ON seq_term.term_id=seq.term_id AND seq_term.name="translation"'
+            "   ON seq_term.term_id=seq.term_id AND seq_term.name='translation' "
             "INNER JOIN seqfeature_qualifier_value locus ON locus.seqfeature_id=ortho.seqid "
             " INNER JOIN term as locus_term "
-            '   ON locus_term.term_id=locus.term_id AND locus_term.name="locus_tag" '
+            "   ON locus_term.term_id=locus.term_id AND locus_term.name='locus_tag' "
             f"WHERE ortho.orthogroup = {orthogroup};"
         )
         results = self.server.adaptor.execute_and_fetchall(
@@ -491,7 +491,7 @@ class DB:
             self.conn_ncbi_taxonomy = sqlite3.connect(dtb_path)
 
         cursor = self.conn_ncbi_taxonomy.cursor()
-        query_string = ",".join(['"' + a + '"' for a in accession])
+        query_string = ",".join([f"'{a}'" for a in accession])
         query = (
             f"SELECT accession, taxid FROM accession2taxid "
             f"WHERE accession IN ({query_string});"
@@ -960,7 +960,7 @@ class DB:
                 "INNER JOIN bioentry_qualifier_value AS is_plasmid ON "
                 "  is_plasmid.bioentry_id=entry.bioentry_id "
                 "INNER JOIN term AS plasmid_term ON plasmid_term.term_id=is_plasmid.term_id "
-                '  AND plasmid_term.name="plasmid"'
+                "  AND plasmid_term.name='plasmid'"
             )
             if indexing != "seqid":
                 group_by += ", CAST(is_plasmid.value AS int)"
@@ -1062,14 +1062,14 @@ class DB:
     def get_hsh_locus_to_seqfeature_id(self, only_CDS=False):
         filtering = ""
         if only_CDS:
-            filtering = 'INNER JOIN term as t4 ON t4.term_id=t1.type_term_id AND t4.name = "CDS" '
+            filtering = "INNER JOIN term as t4 ON t4.term_id=t1.type_term_id AND t4.name = 'CDS' "
 
         query = (
             "SELECT t2.value, t1.seqfeature_id "
             "FROM seqfeature as t1 "
             f"{filtering}"
             "INNER JOIN seqfeature_qualifier_value AS t2 ON t1.seqfeature_id=t2.seqfeature_id "
-            'INNER JOIN term as t3 on t3.term_id=t2.term_id AND t3.name="locus_tag" '
+            "INNER JOIN term as t3 on t3.term_id=t2.term_id AND t3.name='locus_tag' "
         )
         results = self.server.adaptor.execute_and_fetchall(
             query,
@@ -1092,10 +1092,10 @@ class DB:
         query = (
             "SELECT locus.value, og.value"
             "FROM seqfeature_qualifier_value as og "
-            'INNER JOIN term AS term_og ON term_og.term_id=og.term_id AND term_og.name="orthogroup" '
+            "INNER JOIN term AS term_og ON term_og.term_id=og.term_id AND term_og.name='orthogroup' "
             "INNER JOIN seqfeature_qualifier_value as locus ON locus.seqfeature_id=og.seqfeature_id "
             "INNER JOIN term AS term_locus ON term_locus.term_id=locus.term_id "
-            '  AND term_locus.name="locus_tag";'
+            "  AND term_locus.name='locus_tag';"
         )
         query_results = self.server.adaptor.execute_and_fetchall(
             query,
@@ -1130,7 +1130,7 @@ class DB:
         query = (
             "SELECT value, taxon_id, count(*) "
             "FROM seqfeature_qualifier_value as ortho_table "
-            'INNER JOIN term ON ortho_table.term_id = term.term_id AND term.name="orthogroup" '
+            "INNER JOIN term ON ortho_table.term_id = term.term_id AND term.name='orthogroup' "
             "INNER JOIN seqfeature AS feature ON feature.seqfeature_id=ortho_table.seqfeature_id "
             "INNER JOIN bioentry AS entry ON entry.bioentry_id=feature.bioentry_id "
             "GROUP BY value, taxon_id; "
@@ -1277,7 +1277,7 @@ class DB:
             "SELECT accession, count(*) FROM seqfeature AS seq "
             " INNER JOIN term AS t ON t.term_id = seq.type_term_id "
             " INNER JOIN bioentry AS entry ON seq.bioentry_id=entry.bioentry_id "
-            ' AND t.name="tRNA" GROUP BY accession; '
+            " AND t.name='tRNA' GROUP BY accession; "
         )
         n_tRNA_results = self.server.adaptor.execute_and_fetchall(query)
         results = {}
@@ -1292,7 +1292,7 @@ class DB:
             "SELECT locus_tag.value, name.name "
             "FROM seqfeature_qualifier_value AS locus_tag "
             "INNER JOIN term AS locus_term ON locus_term.term_id=locus_tag.term_id "
-            ' AND locus_term.name="locus_tag" '
+            " AND locus_term.name='locus_tag' "
             "INNER JOIN seqfeature AS feature ON feature.seqfeature_id=locus_tag.seqfeature_id "
             "INNER JOIN bioentry AS entry ON feature.bioentry_id=entry.bioentry_id "
             "INNER JOIN taxon_name AS name ON entry.taxon_id = name.taxon_id "
@@ -1302,13 +1302,13 @@ class DB:
         return {locus: description for locus, description in results}
 
     def get_term_id(self, term, create_if_absent=False, ontology="Annotation Tags"):
-        query = f'SELECT term_id FROM term WHERE name="{term}";'
+        query = f"SELECT term_id FROM term WHERE name='{term}';"
         result = self.server.adaptor.execute_and_fetchall(query)
         gc_term_id = None
         if len(result) == 0 and create_if_absent:
-            sql1 = f'SELECT ontology_id FROM ontology WHERE name="{ontology}";'
+            sql1 = f"SELECT ontology_id FROM ontology WHERE name='{ontology}';"
             ontology_id = self.server.adaptor.execute_and_fetchall(sql1)[0][0]
-            sql = f'INSERT INTO term (name, ontology_id) VALUES ("{term}", {ontology_id});'
+            sql = f"INSERT INTO term (name, ontology_id) VALUES ('{term}', {ontology_id});"
             self.server.adaptor.execute(sql)
             gc_term_id = self.server.adaptor.cursor.lastrowid
         else:
@@ -1330,7 +1330,7 @@ class DB:
             "SELECT * "
             "FROM bioentry_qualifier_value AS has_plasmid "
             "INNER JOIN term AS pls_term ON pls_term.term_id=has_plasmid.term_id "
-            ' AND pls_term.name="plasmid" AND has_plasmid.value=1 '
+            " AND pls_term.name='plasmid' AND has_plasmid.value=1 "
             "INNER JOIN bioentry AS plasmid ON has_plasmid.bioentry_id=plasmid.bioentry_id "
             "WHERE plasmid.taxon_id=entry.taxon_id"
         )
@@ -1341,7 +1341,7 @@ class DB:
             "INNER JOIN bioentry_qualifier_value AS orga ON entry.bioentry_id=orga.bioentry_id "
             "INNER JOIN taxon_name as txn_name ON entry.taxon_id=txn_name.taxon_id "
             "INNER JOIN term AS orga_term ON orga.term_id=orga_term.term_id "
-            ' AND orga_term.name="organism" '
+            " AND orga_term.name='organism' "
             f"{where_clause} GROUP BY entry.taxon_id;"
         )
         descr = self.server.adaptor.execute_and_fetchall(query, taxids)
@@ -1366,7 +1366,7 @@ class DB:
         query = (
             "SELECT entry.taxon_id, entry.taxon_id, COUNT(*) "
             " FROM seqfeature AS seq "
-            ' INNER JOIN term AS cds ON cds.term_id = seq.type_term_id AND cds.name="CDS" '
+            " INNER JOIN term AS cds ON cds.term_id = seq.type_term_id AND cds.name='CDS' "
             " INNER JOIN bioentry AS entry ON entry.bioentry_id = seq.bioentry_id "
             f"{where_clause} GROUP BY entry.taxon_id;"
         )
@@ -1452,7 +1452,7 @@ class DB:
 
         query = (
             f"SELECT {index}, COUNT(*) FROM seqfeature AS prot "
-            ' INNER JOIN term AS t ON t.term_id = prot.type_term_id AND t.name="CDS" '
+            " INNER JOIN term AS t ON t.term_id = prot.type_term_id AND t.name='CDS' "
             " INNER JOIN bioentry AS entry ON entry.bioentry_id = prot.bioentry_id "
             f"{filtering}"
             f"GROUP BY {index};"
@@ -1488,7 +1488,7 @@ class DB:
             sql,
         )
 
-        sql = f'INSERT INTO reference_phylogeny VALUES ("{tree}");'
+        sql = f"INSERT INTO reference_phylogeny VALUES ('{tree}');"
         self.server.adaptor.execute(
             sql,
         )
@@ -1503,7 +1503,7 @@ class DB:
         sql = (
             "SELECT bioentry_id FROM seqfeature_qualifier_value AS tag"
             " INNER JOIN seqfeature AS seq ON seq.seqfeature_id = tag.seqfeature_id "
-            f' where value = "{locus_tag}";'
+            f" where value = '{locus_tag}';"
         )
         results = self.server.adaptor.execute_and_fetchall(sql)
         return results[0][0]
@@ -1625,7 +1625,7 @@ class DB:
             "SELECT seqfeature_id "
             "FROM seqfeature_qualifier_values AS locus_tag "
             "INNER JOIN seqfeature AS feature ON feature.seqfeature_id=locus_tag.seqfeature_id "
-            'INNER JOIN term AS t ON feature.type_term_id=t.term_id AND t.name = "CDS" '
+            "INNER JOIN term AS t ON feature.type_term_id=t.term_id AND t.name = 'CDS' "
             "WHERE locus_tag.value=?;"
         )
         ret = self.server.execute_and_fetchall(query, locus_tag)
@@ -1635,18 +1635,18 @@ class DB:
 
     def get_seqid(self, locus_tag, feature_type=False):
         add_type = ""
-        sel = 'AND cds_term.name="CDS"'
+        sel = "AND cds_term.name='CDS'"
         if feature_type:
             add_type = ", cds_term.name"
             sel = (
-                'AND (cds_term.name="CDS" OR cds_term.name="tRNA" '
-                ' OR cds_term.name="tmRNA" OR cds_term.name="rRNA") '
+                "AND (cds_term.name='CDS' OR cds_term.name='tRNA' "
+                " OR cds_term.name='tmRNA' OR cds_term.name='rRNA') "
             )
         is_pseudo = (
             ", CASE WHEN EXISTS ("
             "SELECT NULL FROM seqfeature_qualifier_value AS pseudo "
             "INNER JOIN term AS pseudo_term ON pseudo.term_id=pseudo_term.term_id "
-            '  AND (pseudo_term.name = "pseudo" OR pseudo_term.name = "pseudogene") '
+            "  AND (pseudo_term.name = 'pseudo' OR pseudo_term.name = 'pseudogene') "
             "WHERE pseudo.seqfeature_id = locus_tag.seqfeature_id"
             ") THEN 1 ELSE 0 END "
         )
@@ -1708,7 +1708,7 @@ class DB:
         is_pseudo_query = (
             "SELECT NULL FROM seqfeature_qualifier_value AS pseudo "
             "INNER JOIN term AS pseudo_term ON pseudo.term_id=pseudo_term.term_id "
-            '  AND (pseudo_term.name = "pseudo" OR pseudo_term.name = "pseudogene") '
+            "  AND (pseudo_term.name = 'pseudo' OR pseudo_term.name = 'pseudogene') "
             "WHERE pseudo.seqfeature_id = fet.seqfeature_id"
         )
 
@@ -1750,13 +1750,13 @@ class DB:
                 if term_name not in ["locus_tag", "protein_id", "gene", "product"]:
                     raise RuntimeError(f"Value not support {term_name}")
 
-        term_names_query = ",".join(f'"{name}"' for name in term_names)
+        term_names_query = ",".join(f"'{name}'" for name in term_names)
 
         add_cond = ""
         if inc_non_CDS:
             add_cond = (
-                'OR cds_term.name="tRNA" OR cds_term.name="tmRNA" '
-                'OR cds_term.name="rRNA"'
+                "OR cds_term.name='tRNA' OR cds_term.name='tmRNA' "
+                "OR cds_term.name='rRNA'"
             )
 
         no_pseudo = ""
@@ -1765,7 +1765,7 @@ class DB:
                 "AND NOT EXISTS ("
                 " SELECT NULL FROM seqfeature_qualifier_value AS cds"
                 " INNER JOIN term AS pseudo_term ON cds.term_id=pseudo_term.term_id "
-                '  AND (pseudo_term.name="pseudogene" OR pseudo_term.name="pseudo") '
+                "  AND (pseudo_term.name='pseudogene' OR pseudo_term.name='pseudo') "
                 " WHERE cds.seqfeature_id=seq.seqfeature_id "
                 ")"
             )
@@ -1781,7 +1781,7 @@ class DB:
             sel = (
                 "INNER JOIN seqfeature_qualifier_value AS locus_tag ON locus_tag.seqfeature_id=v.seqfeature_id "
                 "INNER JOIN term as locus_tag_term ON locus_tag.term_id=locus_tag_term.term_id "
-                ' AND locus_tag_term.name="locus_tag" '
+                " AND locus_tag_term.name='locus_tag' "
             )
             where = f" locus_tag.value IN ({entries}) "
         else:
@@ -1793,7 +1793,7 @@ class DB:
             "INNER JOIN term AS t ON t.term_id = v.term_id "
             "INNER JOIN seqfeature AS seq ON seq.seqfeature_id = v.seqfeature_id "
             "INNER JOIN term AS cds_term ON seq.type_term_id=cds_term.term_id "
-            f' AND (cds_term.name="CDS" {add_cond})'
+            f" AND (cds_term.name='CDS' {add_cond})"
             f"{sel}"
             f"WHERE {where} AND t.name IN ({term_names_query}) {no_pseudo};"
         )
@@ -1840,7 +1840,7 @@ class DB:
                 "INNER JOIN bioentry_qualifier_value AS organism "
                 "    ON organism.bioentry_id = entry.bioentry_id "
                 "INNER JOIN term AS organism_term ON organism.term_id = organism_term.term_id "
-                ' AND organism_term.name = "organism" '
+                " AND organism_term.name = 'organism' "
                 f"WHERE feature.seqfeature_id IN ({seqids_query});"
             )
         elif id_type == "bioentry":
@@ -1848,7 +1848,7 @@ class DB:
                 f"SELECT organism.bioentry_id, {val} "
                 "FROM bioentry_qualifier_value AS organism "
                 "INNER JOIN term AS organism_term ON organism.term_id = organism_term.term_id "
-                ' AND organism_term.name = "organism" '
+                " AND organism_term.name = 'organism' "
                 f"WHERE organism.bioentry_id IN ({seqids_query});"
             )
         else:
@@ -1986,7 +1986,7 @@ class DB:
                 "INNER JOIN bioentry_qualifier_value AS is_plasmid ON "
                 "  is_plasmid.bioentry_id=entry.bioentry_id "
                 "INNER JOIN term AS plasmid_term ON plasmid_term.term_id=is_plasmid.term_id "
-                '  AND plasmid_term.name="plasmid"'
+                "  AND plasmid_term.name='plasmid'"
             )
             where_clause = (
                 f" (entry.taxon_id IN ({entries}) AND is_plasmid.value=0) "
@@ -2052,7 +2052,7 @@ class DB:
             "SELECT translation.value  "
             "FROM seqfeature_qualifier_value AS translation "
             "INNER JOIN term AS transl_term ON transl_term.term_id=translation.term_id "
-            ' AND transl_term.name="translation" '
+            " AND transl_term.name='translation' "
             "WHERE translation.seqfeature_id = ?;"
         )
         results = self.server.adaptor.execute_and_fetchall(query, [seqid])
@@ -2071,7 +2071,7 @@ class DB:
         db_terms = [t for t in terms if t != "length"]
         if "length" in terms:
             db_terms.append("translation")
-        sel_terms = ",".join('"' + f"{i}" + '"' for i in db_terms)
+        sel_terms = ",".join(f"'{i}'" for i in db_terms)
         join, sel = "", ""
         if taxon_ids is not None:
             taxon_id_query = self.gen_placeholder_string(taxon_ids)
@@ -2084,7 +2084,7 @@ class DB:
 
         query = (
             f"SELECT feature.seqfeature_id, og.orthogroup, t.name, "
-            '   CASE WHEN t.name=="translation" THEN '
+            "   CASE WHEN t.name=='translation' THEN "
             "   LENGTH(value) ELSE value END "
             "FROM og_hits AS og "
             "INNER JOIN seqfeature_qualifier_value AS feature ON og.seqid = feature.seqfeature_id "
@@ -2202,8 +2202,8 @@ class DB:
         else:
             raise RuntimeError("Expected either taxon_id or bioentry_id")
 
-        seq_term_query = ",".join(f'"{name}"' for name in seq_term_names)
-        qual_term_query = ",".join(f'"{name}"' for name in seq_qual_term_names)
+        seq_term_query = ",".join(f"'{name}'" for name in seq_term_names)
+        qual_term_query = ",".join(f"'{name}'" for name in seq_qual_term_names)
 
         query = (
             "select t1.bioentry_id, t2.seqfeature_id,t5.start_pos, "
@@ -2382,7 +2382,7 @@ class DB:
                 "INNER JOIN bioentry_qualifier_value AS is_plasmid ON "
                 "  is_plasmid.bioentry_id=entry.bioentry_id "
                 "INNER JOIN term AS plasmid_term ON plasmid_term.term_id=is_plasmid.term_id "
-                '  AND plasmid_term.name="plasmid"'
+                "  AND plasmid_term.name='plasmid'"
             )
             header.append("plasmid")
 
@@ -2484,7 +2484,7 @@ class DB:
                 "INNER JOIN bioentry_qualifier_value AS is_plasmid ON "
                 "  is_plasmid.bioentry_id=entry.bioentry_id "
                 "INNER JOIN term AS plasmid_term ON plasmid_term.term_id=is_plasmid.term_id "
-                '  AND plasmid_term.name="plasmid"'
+                "  AND plasmid_term.name='plasmid'"
             )
 
         query = (
@@ -2692,7 +2692,7 @@ class DB:
                 "INNER JOIN bioentry_qualifier_value AS is_plasmid ON "
                 "  is_plasmid.bioentry_id=bioentry.bioentry_id "
                 "INNER JOIN term AS plasmid_term ON plasmid_term.term_id=is_plasmid.term_id "
-                '  AND plasmid_term.name="plasmid"'
+                "  AND plasmid_term.name='plasmid'"
             )
 
         query = (
@@ -2781,7 +2781,7 @@ class DB:
         return self.server.adaptor.execute_and_fetchall(query)[0][0]
 
     def check_entry_existence(self, entry_id, entry_col, table):
-        query = f'SELECT 1 FROM {table} WHERE {entry_col}="{entry_id}" LIMIT 1'
+        query = f"SELECT 1 FROM {table} WHERE {entry_col}='{entry_id}' LIMIT 1"
         return bool(self.server.adaptor.execute_one(query))
 
     def check_og_entry_id(self, entry_id):

--- a/webapp/lib/ete_phylo.py
+++ b/webapp/lib/ete_phylo.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python
 import ete3
-from ete3 import NodeStyle, StackedBarFace, TextFace, Tree, TreeStyle
-from matplotlib.colors import rgb2hex
-
+from ete3 import NodeStyle
+from ete3 import StackedBarFace
+from ete3 import TextFace
+from ete3 import Tree
+from ete3 import TreeStyle
 from lib import colors
+from matplotlib.colors import rgb2hex
 
 
 class EteTree:
-
-    DEFAULT_COLORS = ['#fc8d59', '#91bfdb', '#99d594',
-                      '#c51b7d', '#f1a340', '#999999']
+    DEFAULT_COLORS = ["#fc8d59", "#91bfdb", "#99d594", "#c51b7d", "#f1a340", "#999999"]
     RED = "#ff0000"
     BLUE = "#58ACFA"
     GREEN = "#99d594"
@@ -71,8 +72,9 @@ class EteTree:
         t.margin_right = 13
         return t
 
-    def rename_leaves(self, hsh_names, default_val="-", leaf_name_type=int,
-                      highlight_leaves=None):
+    def rename_leaves(
+        self, hsh_names, default_val="-", leaf_name_type=int, highlight_leaves=None
+    ):
         self.default_val = default_val
         if not isinstance(hsh_names, dict):
             raise Exception("Expects dict type for hsh_names")
@@ -143,10 +145,20 @@ class SimpleColorColumn(Column):
     # should really be refactored.
     # Separation of concern sometimes broken...
 
-    def __init__(self, values, header=None, use_col=True,
-                 face_params=None, header_params=None, col_func=None,
-                 default_val=0, default_val_is_num=False, color_gradient=False,
-                 gradient_value_range=None, is_str_index=False):
+    def __init__(
+        self,
+        values,
+        header=None,
+        use_col=True,
+        face_params=None,
+        header_params=None,
+        col_func=None,
+        default_val=0,
+        default_val_is_num=False,
+        color_gradient=False,
+        gradient_value_range=None,
+        is_str_index=False,
+    ):
         super().__init__(header, face_params, header_params)
         self.values = values
         self.header = header
@@ -187,12 +199,13 @@ class SimpleColorColumn(Column):
                 italic = "ITalic"
 
         text_face = TextFace(str(val), fstyle=italic)
-        if (val == self.default_val and self.default_val_is_num) or \
-                (val != self.default_val and self.color_gradient):
+        if (val == self.default_val and self.default_val_is_num) or (
+            val != self.default_val and self.color_gradient
+        ):
             rgba = self.cm.to_rgba(val, bytes=True)
             text_face.inner_background.color = colors.to_rgb_str(rgba)
             luminance = colors.get_luminance(rgba)
-            if luminance >= .5:
+            if luminance >= 0.5:
                 text_face.fgcolor = "#000000"
             else:
                 text_face.fgcolor = "#ffffff"
@@ -207,10 +220,11 @@ class SimpleColorColumn(Column):
 
 
 class ValueColoredColumn(Column):
-    """Gets the color by applying col_func to the value.
-    """
-    def __init__(self, values, col_func, header=None,
-                 face_params=None, header_params=None):
+    """Gets the color by applying col_func to the value."""
+
+    def __init__(
+        self, values, col_func, header=None, face_params=None, header_params=None
+    ):
         self.values = values
         self.col_func = col_func
         self.header = header
@@ -234,12 +248,24 @@ class MatchingColorColumn(ValueColoredColumn):
     to_match. In that case it gets the color by applying col_func
     to the value.
     """
-    def __init__(self, values, to_match, col_func, header=None,
-                 face_params=None, header_params=None):
+
+    def __init__(
+        self,
+        values,
+        to_match,
+        col_func,
+        header=None,
+        face_params=None,
+        header_params=None,
+    ):
         self.to_match = to_match
         super(MatchingColorColumn, self).__init__(
-            values, col_func, header=header, face_params=face_params,
-            header_params=header_params)
+            values,
+            col_func,
+            header=header,
+            face_params=face_params,
+            header_params=header_params,
+        )
 
     def get_color(self, index, val):
         if val == self.to_match.get(index):
@@ -254,6 +280,7 @@ class ModuleCompletenessColumn(Column):
     *  - none missing: green
     *  - missing KOs: orange
     """
+
     def __init__(self, values, header=None, add_missing=True):
         super().__init__(header)
         self.values = values
@@ -321,24 +348,27 @@ class ReferenceColumn(Column):
         pass
 
 
-class EteTool():
-
-    '''
+class EteTool:
+    """
     Plot ete3 phylogenetic profiles.
 
     - self.add_simple_barplot: add a barplot face from taxon2value dictionnary
     - self.add_text_face: add text face
     - self.add_heatmap: add column with cells with value + colored background
     - self.rename_leaves: rename tree leaves from a dictionnary (old_name2new_name)
-    '''
+    """
 
-    def __init__(self,
-                 tree_file):
-
+    def __init__(self, tree_file):
         self.column_count = 0
 
-        self.default_colors = ['#fc8d59', '#91bfdb', '#99d594', '#c51b7d',
-                               '#f1a340', '#999999']
+        self.default_colors = [
+            "#fc8d59",
+            "#91bfdb",
+            "#99d594",
+            "#c51b7d",
+            "#f1a340",
+            "#999999",
+        ]
 
         self.color_index = 0
 
@@ -367,32 +397,29 @@ class EteTool():
         self.tss.guiding_lines_color = "gray"
         self.tss.show_leaf_name = False
 
-    def add_stacked_barplot(self, taxon2value_list, header_name,
-                            color_list=False):
-
+    def add_stacked_barplot(self, taxon2value_list, header_name, color_list=False):
         pass
 
-    def rename_leaves(self, taxon2new_taxon, keep_original=False,
-                      add_face=True):
+    def rename_leaves(self, taxon2new_taxon, keep_original=False, add_face=True):
         for i, lf in enumerate(self.tree.iter_leaves()):
             if not keep_original:
                 if lf.name in taxon2new_taxon:
                     label = taxon2new_taxon[lf.name]
                 else:
-                    label = 'n/a'
+                    label = "n/a"
             else:
                 if lf.name in taxon2new_taxon:
-                    label = '%s (%s)' % (taxon2new_taxon[lf.name], lf.name)
+                    label = "%s (%s)" % (taxon2new_taxon[lf.name], lf.name)
                 else:
-                    label = 'n/a'
+                    label = "n/a"
             if add_face:
-                n = TextFace(label, fgcolor="black", fsize=12, fstyle='italic')
+                n = TextFace(label, fgcolor="black", fsize=12, fstyle="italic")
                 lf.add_face(n, 0)
             lf.name = label
 
-    def add_heatmap(self, taxon2value, header_name, continuous_scale=False,
-                    show_text=False):
-
+    def add_heatmap(
+        self, taxon2value, header_name, continuous_scale=False, show_text=False
+    ):
         from lib.colors import get_continuous_scale
 
         self._add_header(header_name)
@@ -401,16 +428,15 @@ class EteTool():
             color_scale = get_continuous_scale(taxon2value.values())
 
         for i, lf in enumerate(self.tree.iter_leaves()):
-
             if lf.name not in taxon2value:
-                n = TextFace('')
+                n = TextFace("")
             else:
                 value = taxon2value[lf.name]
 
                 if show_text:
-                    n = TextFace('%s' % value)
+                    n = TextFace("%s" % value)
                 else:
-                    n = TextFace('    ')
+                    n = TextFace("    ")
 
                 n.margin_top = 2
                 n.margin_right = 3
@@ -422,7 +448,7 @@ class EteTool():
                 n.border.color = "#ffffff"
                 if continuous_scale:
                     n.background.color = rgb2hex(color_scale[0].to_rgba(float(value)))
-                n.opacity = 1.
+                n.opacity = 1.0
                 i += 1
 
             if self.rotate:
@@ -432,8 +458,7 @@ class EteTool():
         self.column_count += 1
 
     def _add_header(self, header_name, column_add=0):
-
-        n = TextFace(f'{header_name}')
+        n = TextFace(f"{header_name}")
         n.margin_top = 1
         n.margin_right = 1
         n.margin_left = 20
@@ -442,12 +467,13 @@ class EteTool():
         n.vt_align = 2
         n.rotation = 270
         n.inner_background.color = "white"
-        n.opacity = 1.
+        n.opacity = 1.0
         # add header
-        self.tss.aligned_header.add_face(n, self.column_count-1+column_add)
+        self.tss.aligned_header.add_face(n, self.column_count - 1 + column_add)
 
-    def _get_default_barplot_color(self,):
-
+    def _get_default_barplot_color(
+        self,
+    ):
         col = self.default_colors[self.color_index]
 
         if self.color_index == 5:
@@ -457,11 +483,17 @@ class EteTool():
 
         return col
 
-    def add_simple_barplot(self, taxon2value, header_name, color=False,
-                           show_values=False, substract_min=False,
-                           highlight_cutoff=False, highlight_reverse=False,
-                           max_value=False):
-
+    def add_simple_barplot(
+        self,
+        taxon2value,
+        header_name,
+        color=False,
+        show_values=False,
+        substract_min=False,
+        highlight_cutoff=False,
+        highlight_reverse=False,
+        max_value=False,
+    ):
         if not show_values:
             self._add_header(header_name, column_add=0)
         else:
@@ -472,15 +504,14 @@ class EteTool():
         min_value = min(values_lists)
 
         if substract_min:
-            values_lists = [i-min_value for i in values_lists]
+            values_lists = [i - min_value for i in values_lists]
             for taxon in list(taxon2value.keys()):
-                taxon2value[taxon] = taxon2value[taxon]-min_value
+                taxon2value[taxon] = taxon2value[taxon] - min_value
 
         if not color:
             color = self._get_default_barplot_color()
 
         for i, lf in enumerate(self.tree.iter_leaves()):
-
             try:
                 value = taxon2value[lf.name]
             except KeyError:
@@ -493,7 +524,7 @@ class EteTool():
                 else:
                     real_value = value
                 if isinstance(real_value, float):
-                    a = TextFace(" %s " % str(round(real_value,2)))
+                    a = TextFace(" %s " % str(round(real_value, 2)))
                 else:
                     a = TextFace(" %s " % str(real_value))
                 a.margin_top = 1
@@ -506,10 +537,10 @@ class EteTool():
             else:
                 barplot_column = 0
             if not max_value:
-                fraction_biggest = (float(value)/max(values_lists))*100
+                fraction_biggest = (float(value) / max(values_lists)) * 100
             else:
-                fraction_biggest = (float(value)/max_value)*100
-            fraction_rest = 100-fraction_biggest
+                fraction_biggest = (float(value) / max_value) * 100
+            fraction_rest = 100 - fraction_biggest
 
             if highlight_cutoff:
                 if substract_min:
@@ -529,8 +560,12 @@ class EteTool():
             else:
                 lcolor = color
 
-            b = StackedBarFace([fraction_biggest, fraction_rest], width=100,
-                               height=15, colors=[lcolor, 'white'])
+            b = StackedBarFace(
+                [fraction_biggest, fraction_rest],
+                width=100,
+                height=15,
+                colors=[lcolor, "white"],
+            )
             b.rotation = 0
             b.inner_border.color = "grey"
             b.inner_border.width = 0
@@ -540,14 +575,17 @@ class EteTool():
                 b.rotation = 270
             lf.add_face(b, self.column_count + barplot_column, position="aligned")
 
-        self.column_count += (1 + barplot_column)
+        self.column_count += 1 + barplot_column
 
-    def add_barplot_counts(self,):
-         # todo
+    def add_barplot_counts(
+        self,
+    ):
+        # todo
         pass
 
-    def remove_dots(self,):
-
+    def remove_dots(
+        self,
+    ):
         nstyle = NodeStyle()
         nstyle["shape"] = "sphere"
         nstyle["size"] = 0
@@ -559,7 +597,6 @@ class EteTool():
             n.set_style(nstyle)
 
     def add_text_face(self, taxon2text, header_name, color_scale=False):
-
         from lib.colors import get_categorical_color_scale
 
         if color_scale:
@@ -570,17 +607,17 @@ class EteTool():
         # add column
         for i, lf in enumerate(self.tree.iter_leaves()):
             if lf.name in taxon2text:
-                n = TextFace('%s' % taxon2text[lf.name])
+                n = TextFace("%s" % taxon2text[lf.name])
                 if color_scale:
                     n.background.color = value2color[taxon2text[lf.name]]
             else:
                 print(lf.name, "not in", taxon2text)
-                n = TextFace('-')
+                n = TextFace("-")
             n.margin_top = 1
             n.margin_right = 10
             n.margin_left = 10
             n.margin_bottom = 1
-            n.opacity = 1.
+            n.opacity = 1.0
             if self.rotate:
                 n.rotation = 270
             lf.add_face(n, self.column_count, position="aligned")
@@ -588,9 +625,8 @@ class EteTool():
         self.column_count += 1
 
 
-class EteToolCompact():
-
-    '''
+class EteToolCompact:
+    """
     Plot ete3 phylogenetic profiles.
 
     - self.add_simple_barplot: add a barplot face from taxon2value dictionnary
@@ -598,7 +634,7 @@ class EteToolCompact():
     - self.rename_leaves: rename tree leaves from a dictionnary (old_name2new_name)
     - self.add_categorical_colorscale_legend: add legend
     - self.add_continuous_colorscale_legend: add legend
-    '''
+    """
 
     def __init__(self, tree_file):
         self.column_count = 0
@@ -609,10 +645,16 @@ class EteToolCompact():
 
         self.tree_length = len([i for i in self.tree.iter_leaves()])
 
-        self.text_scale = (self.tree_length)*0.01  # math.log2
+        self.text_scale = (self.tree_length) * 0.01  # math.log2
 
-        self.default_colors = ['#fc8d59', '#91bfdb', '#99d594', '#c51b7d',
-                               '#f1a340', '#999999']
+        self.default_colors = [
+            "#fc8d59",
+            "#91bfdb",
+            "#99d594",
+            "#c51b7d",
+            "#f1a340",
+            "#999999",
+        ]
 
         self.color_index = 0
 
@@ -627,7 +669,9 @@ class EteToolCompact():
         self.tss.show_leaf_name = False
         self.tss.branch_vertical_margin = 0
 
-    def _get_default_barplot_color(self,):
+    def _get_default_barplot_color(
+        self,
+    ):
         col = self.default_colors[self.color_index]
 
         if self.color_index == 5:
@@ -638,7 +682,7 @@ class EteToolCompact():
         return col
 
     def _add_header(self, header_name, column_add=0):
-        n = TextFace(f'{header_name}')
+        n = TextFace(f"{header_name}")
         n.margin_top = 1
         n.margin_right = 1
         n.margin_left = 20
@@ -647,19 +691,21 @@ class EteToolCompact():
         n.vt_align = 2
         n.rotation = 270
         n.inner_background.color = "white"
-        n.opacity = 1.
+        n.opacity = 1.0
         # add header
-        self.tss.aligned_header.add_face(n, self.column_count-1+column_add)
+        self.tss.aligned_header.add_face(n, self.column_count - 1 + column_add)
 
     def rename_leaves(self, taxon2new_taxon):
         for i, lf in enumerate(self.tree.iter_leaves()):
-            n = TextFace(taxon2new_taxon[lf.name], fgcolor="black", fsize=12,
-                         fstyle='italic')
+            n = TextFace(
+                taxon2new_taxon[lf.name], fgcolor="black", fsize=12, fstyle="italic"
+            )
             lf.add_face(n, 0)
 
     def add_continuous_colorscale_legend(self, title, min_val, max_val, scale):
         self.tss.legend.add_face(
-            TextFace(f"{title}", fsize=4 * self.text_scale), column=0)
+            TextFace(f"{title}", fsize=4 * self.text_scale), column=0
+        )
 
         if min_val != max_val:
             n = TextFace(" " * int(self.text_scale), fsize=4 * self.text_scale)
@@ -677,14 +723,15 @@ class EteToolCompact():
             n2.inner_background.color = rgb2hex(scale[0].to_rgba(float(min_val)))
 
             self.tss.legend.add_face(n, column=1)
-            self.tss.legend.add_face(TextFace(
-                f"{max_val} % (max)", fsize=4 * self.text_scale), column=2)
+            self.tss.legend.add_face(
+                TextFace(f"{max_val} % (max)", fsize=4 * self.text_scale), column=2
+            )
             self.tss.legend.add_face(n2, column=1)
-            self.tss.legend.add_face(TextFace(
-                f"{min_val} % (min)", fsize=4 * self.text_scale), column=2)
+            self.tss.legend.add_face(
+                TextFace(f"{min_val} % (min)", fsize=4 * self.text_scale), column=2
+            )
         else:
-            n2 = TextFace(" " * int(self.text_scale),
-                          fsize=4 * self.text_scale)
+            n2 = TextFace(" " * int(self.text_scale), fsize=4 * self.text_scale)
             n2.margin_top = 1
             n2.margin_right = 1
             n2.margin_left = 10
@@ -693,17 +740,16 @@ class EteToolCompact():
 
             self.tss.legend.add_face(n2, column=0)
             self.tss.legend.add_face(
-                TextFace(f"{max_val} % Id", fsize=4 * self.text_scale),
-                column=1)
+                TextFace(f"{max_val} % Id", fsize=4 * self.text_scale), column=1
+            )
 
     def add_categorical_colorscale_legend(self, title, scale):
-
         self.tss.legend.add_face(
-            TextFace(f"{title}", fsize=4 * self.text_scale), column=0)
+            TextFace(f"{title}", fsize=4 * self.text_scale), column=0
+        )
 
         col = 1
         for n, value in enumerate(scale):
-
             n2 = TextFace(" " * int(self.text_scale), fsize=4 * self.text_scale)
             n2.margin_top = 1
             n2.margin_right = 1
@@ -713,18 +759,25 @@ class EteToolCompact():
 
             self.tss.legend.add_face(n2, column=col)
             self.tss.legend.add_face(
-                TextFace(f"{value}", fsize=4 * self.text_scale), column=col+1)
+                TextFace(f"{value}", fsize=4 * self.text_scale), column=col + 1
+            )
 
             col += 2
             if col > 16:
                 self.tss.legend.add_face(
-                    TextFace("    ", fsize=4 * self.text_scale),
-                    column=0)
+                    TextFace("    ", fsize=4 * self.text_scale), column=0
+                )
                 col = 1
 
-    def add_simple_barplot(self, taxon2value, header_name, color=False,
-                           show_values=False, substract_min=False,
-                           max_value=False):
+    def add_simple_barplot(
+        self,
+        taxon2value,
+        header_name,
+        color=False,
+        show_values=False,
+        substract_min=False,
+        max_value=False,
+    ):
         if not show_values:
             self._add_header(header_name, column_add=0)
         else:
@@ -735,15 +788,14 @@ class EteToolCompact():
         min_value = min(values_lists)
 
         if substract_min:
-            values_lists = [i-min_value for i in values_lists]
+            values_lists = [i - min_value for i in values_lists]
             for taxon in list(taxon2value.keys()):
-                taxon2value[taxon] = taxon2value[taxon]-min_value
+                taxon2value[taxon] = taxon2value[taxon] - min_value
 
         if not color:
             color = self._get_default_barplot_color()
 
         for i, lf in enumerate(self.tree.iter_leaves()):
-
             try:
                 value = taxon2value[lf.name]
             except Exception:
@@ -765,15 +817,17 @@ class EteToolCompact():
             else:
                 barplot_column = 0
             if not max_value:
-                fraction_biggest = (float(value)/max(values_lists))*100
+                fraction_biggest = (float(value) / max(values_lists)) * 100
             else:
-                fraction_biggest = (float(value)/max_value)*100
-            fraction_rest = 100-fraction_biggest
+                fraction_biggest = (float(value) / max_value) * 100
+            fraction_rest = 100 - fraction_biggest
 
-            b = StackedBarFace([fraction_biggest, fraction_rest],
-                               width=100 * (self.text_scale/3),
-                               height=18,
-                               colors=[color, 'white'])
+            b = StackedBarFace(
+                [fraction_biggest, fraction_rest],
+                width=100 * (self.text_scale / 3),
+                height=18,
+                colors=[color, "white"],
+            )
             b.rotation = 0
             b.margin_right = 10
             b.margin_left = 10
@@ -784,23 +838,25 @@ class EteToolCompact():
                 b.rotation = 270
             lf.add_face(b, self.column_count + barplot_column, position="aligned")
 
-        self.column_count += (1 + barplot_column)
+        self.column_count += 1 + barplot_column
 
-    def add_heatmap(self, taxon2value, header_name, scale_type="continuous",
-                    palette=False):
-        from lib.colors import (get_categorical_color_scale,
-                                get_continuous_scale)
+    def add_heatmap(
+        self, taxon2value, header_name, scale_type="continuous", palette=False
+    ):
+        from lib.colors import get_categorical_color_scale
+        from lib.colors import get_continuous_scale
 
         if scale_type == "continuous":
             scale = get_continuous_scale(taxon2value.values())
-            self.add_continuous_colorscale_legend("Closest hit identity",
-                                                  min(taxon2value.values()),
-                                                  max(taxon2value.values()),
-                                                  scale)
+            self.add_continuous_colorscale_legend(
+                "Closest hit identity",
+                min(taxon2value.values()),
+                max(taxon2value.values()),
+                scale,
+            )
         elif scale_type == "categorical":
             scale = get_categorical_color_scale(taxon2value.values())
-            self.add_categorical_colorscale_legend("MLST",
-                                                   scale)
+            self.add_categorical_colorscale_legend("MLST", scale)
         else:
             raise IOError("unknown type")
 
@@ -818,23 +874,25 @@ class EteToolCompact():
             n.margin_right = 0
             n.margin_left = 10
             n.margin_bottom = 0
-            n.opacity = 1.
+            n.opacity = 1.0
             if self.rotate:
                 n.rotation = 270
             lf.add_face(n, self.column_count, position="aligned")
 
         self.column_count += 1
 
-    def remove_labels(self,):
+    def remove_labels(
+        self,
+    ):
         for i, lf in enumerate(self.tree.iter_leaves()):
             n = TextFace("")
             lf.add_face(n, 0)
 
 
 def get_newick(node, newick, parentdist, leaf_names):
-    '''
+    """
     convert hierarchical clustering to newick format
-    '''
+    """
     if node.is_leaf():
         return "%s:%.2f%s" % (leaf_names[node.id], parentdist - node.dist, newick)
     else:

--- a/webapp/lib/queries.py
+++ b/webapp/lib/queries.py
@@ -1,6 +1,4 @@
-
-class VFQueries():
-
+class VFQueries:
     hit_table = "vf_hits"
     description_table = "vf_defs"
     id_col = "vf_gene_id"
@@ -32,14 +30,15 @@ class VFQueries():
 
     def get_hits(self, taxids):
         where_clause = self.gen_where_clause("taxid", taxids)
-        columns = ["bioentry.taxon_id",
-                   f"{self.hit_table}.{self.id_col}",
-                   "evalue",
-                   "prot_name",
-                   "vfid",
-                   "category",
-                   "vf_category_id",
-                   ]
+        columns = [
+            "bioentry.taxon_id",
+            f"{self.hit_table}.{self.id_col}",
+            "evalue",
+            "prot_name",
+            "vfid",
+            "category",
+            "vf_category_id",
+        ]
         query = (
             f"SELECT {', '.join(columns)} "
             f"FROM {self.hit_table} "
@@ -53,8 +52,9 @@ class VFQueries():
         df = self.to_pandas_frame(results, [col.split(".")[-1] for col in columns])
         return df
 
-    def get_hit_counts(self, ids, indexing="taxid", search_on="taxid",
-                       keep_taxid=False, plasmids=None):
+    def get_hit_counts(
+        self, ids, indexing="taxid", search_on="taxid", keep_taxid=False, plasmids=None
+    ):
         if indexing == "seqid":
             index = "seqfeature.seqfeature_id"
             if keep_taxid:
@@ -71,14 +71,14 @@ class VFQueries():
             index += ", CAST(is_plasmid.value AS int) "
             subclause = self.gen_where_clause(search_on, plasmids)
             where_clause = (
-                    f"({where_clause} AND is_plasmid.value=0) "
-                    f" OR ({subclause} AND is_plasmid.value=1)"
+                f"({where_clause} AND is_plasmid.value=0) "
+                f" OR ({subclause} AND is_plasmid.value=1)"
             )
             plasmid_join = (
                 "INNER JOIN bioentry_qualifier_value AS is_plasmid ON "
                 "  is_plasmid.bioentry_id=bioentry.bioentry_id "
                 "INNER JOIN term AS plasmid_term ON plasmid_term.term_id=is_plasmid.term_id "
-                "  AND plasmid_term.name=\"plasmid\""
+                '  AND plasmid_term.name="plasmid"'
             )
 
         query = (
@@ -124,8 +124,9 @@ class VFQueries():
             header = ["seqid", self.id_col]
             if keep_taxid:
                 header.append("taxid")
-                results = ((seqid, obj_id, taxid)
-                           for seqid, taxid, obj_id, count in results)
+                results = (
+                    (seqid, obj_id, taxid) for seqid, taxid, obj_id, count in results
+                )
             else:
                 results = ((seqid, obj_id) for seqid, obj_id, count in results)
 
@@ -135,8 +136,7 @@ class VFQueries():
 
     def get_hit_descriptions(self, hit_ids, columns=None):
         if columns is None:
-            columns = [self.id_col, "prot_name", "vfid", "category",
-                       "vf_category_id"]
+            columns = [self.id_col, "prot_name", "vfid", "category", "vf_category_id"]
         if hit_ids is None:
             where = ""
         else:
@@ -145,9 +145,7 @@ class VFQueries():
 
         col_selection = ", ".join([f"descr.{col}" for col in columns])
         query = (
-            f"SELECT {col_selection} "
-            f"FROM {self.description_table} as descr "
-            f"{where};"
+            f"SELECT {col_selection} FROM {self.description_table} as descr {where};"
         )
         results = self.server.adaptor.execute_and_fetchall(query, hit_ids)
         return self.to_pandas_frame(results, columns)

--- a/webapp/lib/search_bar.py
+++ b/webapp/lib/search_bar.py
@@ -1,7 +1,9 @@
-
 import pandas as pd
 from whoosh import index
-from whoosh.fields import ID, KEYWORD, TEXT, SchemaClass
+from whoosh.fields import ID
+from whoosh.fields import KEYWORD
+from whoosh.fields import TEXT
+from whoosh.fields import SchemaClass
 from whoosh.qparser import MultifieldParser
 
 
@@ -14,8 +16,7 @@ class SearchBarSchema(SchemaClass):
     og = KEYWORD(stored=True)
 
 
-class EntryType():
-
+class EntryType:
     @property
     def _name_prefix(self):
         return self.entry_type
@@ -25,18 +26,17 @@ class EntryType():
         return self.object_type[0].upper()
 
     def add_to_index(self, index, entry_id, descr):
-        index.writer.add_document(entry_type=self.entry_type,
-                                  name=self.get_name(entry_id),
-                                  description=descr)
+        index.writer.add_document(
+            entry_type=self.entry_type, name=self.get_name(entry_id), description=descr
+        )
 
     def get_entry_id(cls, name):
         return name.lstrip(cls._name_prefix)
 
 
 class KoEntry(EntryType):
-
     object_type = "ko"
-    _name_format_spec = '05'
+    _name_format_spec = "05"
 
     def get_name(self, entry_id):
         if pd.isna(entry_id):
@@ -45,16 +45,14 @@ class KoEntry(EntryType):
 
 
 class CogEntry(KoEntry):
-
     object_type = "cog"
     _name_prefix = "COG"
-    _name_format_spec = '04'
+    _name_format_spec = "04"
 
 
 class ModuleEntry(EntryType):
-
     object_type = "module"
-    _name_format_spec = '05d'
+    _name_format_spec = "05d"
 
     def get_name(self, entry_id):
         return f"{self._name_prefix}{entry_id:{self._name_format_spec}}"
@@ -64,20 +62,17 @@ class ModuleEntry(EntryType):
 
 
 class PathwayEntry(ModuleEntry):
-
     object_type = "pathway"
     _name_prefix = "map"
 
 
 class PfamEntry(KoEntry):
-
     entry_type = "D"
     object_type = "pfam"
     _name_prefix = "PF"
 
 
 class AmrEntry(EntryType):
-
     entry_type = "R"
     object_type = "amr"
 
@@ -86,36 +81,43 @@ class AmrEntry(EntryType):
 
 
 class VfEntry(EntryType):
-
     object_type = "vf"
 
     def get_name(self, entry_id):
         return entry_id
 
 
-class GeneEntry():
-
+class GeneEntry:
     entry_type = "G"
     object_type = "locus"
 
     def add_to_index(self, index, locus_tag, gene, product, organism, og):
-        index.writer.add_document(entry_type=self.entry_type,
-                                  locus_tag=locus_tag,
-                                  name=gene,
-                                  description=product,
-                                  organism=organism,
-                                  og=og)
+        index.writer.add_document(
+            entry_type=self.entry_type,
+            locus_tag=locus_tag,
+            name=gene,
+            description=product,
+            organism=organism,
+            og=og,
+        )
 
 
-entry_classes = [KoEntry, CogEntry, ModuleEntry, PathwayEntry, PfamEntry,
-                 AmrEntry, VfEntry, GeneEntry]
+entry_classes = [
+    KoEntry,
+    CogEntry,
+    ModuleEntry,
+    PathwayEntry,
+    PfamEntry,
+    AmrEntry,
+    VfEntry,
+    GeneEntry,
+]
 entry_type_to_cls = {cls().entry_type: cls for cls in entry_classes}
 
 field_list = ["entry_type", "name", "description", "organism", "locus_tag"]
 
 
 class ChlamdbIndex:
-
     def new_index(name):
         chlamdb_index = ChlamdbIndex()
         chlamdb_index.index = index.create_in(name, SearchBarSchema)

--- a/webapp/settings/settings.py
+++ b/webapp/settings/settings.py
@@ -31,44 +31,40 @@ ALLOWED_HOSTS = hosts.split(",")
 if trusted_origins:
     CSRF_TRUSTED_ORIGINS = trusted_origins.split(",")
 
-BIODB_CONF = {
-    "zdb.db_type": "sqlite",
-    "zdb.db_name": "George",
-    "zdb.psswd": ""
-}
+BIODB_CONF = {"zdb.db_type": "sqlite", "zdb.db_name": "George", "zdb.psswd": ""}
 
 
 INSTALLED_APPS = (
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'dal',
-    'dal_select2',
-    'chlamdb',
-    'gunicorn',
-    'templatetags',
-    'django.contrib.admin',
-    'django.contrib.sitemaps',
-    'crispy_forms'
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "dal",
+    "dal_select2",
+    "chlamdb",
+    "gunicorn",
+    "templatetags",
+    "django.contrib.admin",
+    "django.contrib.sitemaps",
+    "crispy_forms",
 )
 
 
 MIDDLEWARE = [
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.security.SecurityMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'chlamdb.middleware.MyMiddleware',
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.security.SecurityMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "chlamdb.middleware.MyMiddleware",
 ]
 
-ROOT_URLCONF = 'settings.urls'
-LANGUAGE_CODE = 'en-us'
-TIME_ZONE = 'Europe/Paris'
+ROOT_URLCONF = "settings.urls"
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "Europe/Paris"
 USE_I18N = True
 USE_L10N = True
 USE_TZ = True
@@ -77,7 +73,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
-STATIC_URL = '/assets/'
+STATIC_URL = "/assets/"
 
 # We always want to server files in served_assets. When using the dev server,
 # files in STATICFILES_DIRS are served so we need to set that to served_assets.
@@ -94,21 +90,18 @@ else:
 APPEND_SLASH = True  # Ajoute un slash en fin d'URL
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-
-        'DIRS': [os.path.join(BASE_DIR, 'templates')],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [os.path.join(BASE_DIR, "templates")],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
 
-INTERNAL_IPS = (
-    '127.0.0.1',
-)
+INTERNAL_IPS = ("127.0.0.1",)

--- a/webapp/settings/urls.py
+++ b/webapp/settings/urls.py
@@ -1,10 +1,11 @@
 from django.contrib import admin
-from django.urls import include, re_path
+from django.urls import include
+from django.urls import re_path
 
 admin.autodiscover()
 
 urlpatterns = [
-    re_path(r'^admin/', admin.site.urls),
-    re_path(r'^chlamdb/', include('chlamdb.urls')),
-    re_path(r'^', include('chlamdb.urls')),
+    re_path(r"^admin/", admin.site.urls),
+    re_path(r"^chlamdb/", include("chlamdb.urls")),
+    re_path(r"^", include("chlamdb.urls")),
 ]

--- a/webapp/setup.py
+++ b/webapp/setup.py
@@ -1,43 +1,43 @@
-from setuptools import setup, find_packages
-from os import path
 import glob
-
 from io import open
+from os import path
+
+from setuptools import find_packages
+from setuptools import setup
 
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
-
-    name='zdb',
-    version='3.0',
-    description='zDB',
+    name="zdb",
+    version="3.0",
+    description="zDB",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/metagenlab/chlamdb',
-    author='Trestan Pillonel',
-    author_email='trestan.pillonel@gmail.com',
+    long_description_content_type="text/markdown",
+    url="https://github.com/metagenlab/chlamdb",
+    author="Trestan Pillonel",
+    author_email="trestan.pillonel@gmail.com",
     classifiers=[
         # How mature is this project? Common values are
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        'Development Status :: 3 - Alpha',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 3 - Alpha",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
-    keywords='genome orthology comparative genomics bacteria KEGG COG EC Pfam Interpro',
-    packages=find_packages(exclude=['chlamdb', 'db_setup', 'tests']),
-    python_requires='>=3.0',
-    scripts=[script for script in glob.glob('db_setup/*')],
+    keywords="genome orthology comparative genomics bacteria KEGG COG EC Pfam Interpro",
+    packages=find_packages(exclude=["chlamdb", "db_setup", "tests"]),
+    python_requires=">=3.0",
+    scripts=[script for script in glob.glob("db_setup/*")],
     project_urls={
-        'Bug Reports': 'https://github.com/metagenlab/chlamdb/issues',
-        'Source': 'https://github.com/metagenlab/chlamdb',
+        "Bug Reports": "https://github.com/metagenlab/chlamdb/issues",
+        "Source": "https://github.com/metagenlab/chlamdb",
     },
 )

--- a/webapp/templatetags/custom_tags.py
+++ b/webapp/templatetags/custom_tags.py
@@ -10,4 +10,4 @@ def keyvalue(dict, key):
 
 @register.filter
 def remove_spaces(value):
-    return value.replace(' ', '+')
+    return value.replace(" ", "+")

--- a/webapp/views/analysis_view_metadata.py
+++ b/webapp/views/analysis_view_metadata.py
@@ -1,6 +1,5 @@
-class AnalysisViewMetadata():
-
-    _types_available_for = ['amr', 'cog', 'ko', 'pfam', 'orthogroup', 'vf']
+class AnalysisViewMetadata:
+    _types_available_for = ["amr", "cog", "ko", "pfam", "orthogroup", "vf"]
     static_icon = True
 
     def __init__(self, object_type, object_name_plural):
@@ -21,9 +20,8 @@ class AnalysisViewMetadata():
 
 
 class EntryListMetadata(AnalysisViewMetadata):
-
     name = "index"
-    _types_available_for = ['amr', 'cog', 'ko', 'pfam', 'vf']
+    _types_available_for = ["amr", "cog", "ko", "pfam", "vf"]
     title = "Index"
     _description = "Index of all {} identified in all genomes"
     _url = "/entry_list_{}"
@@ -31,7 +29,6 @@ class EntryListMetadata(AnalysisViewMetadata):
 
 
 class ExtractionMetadata(AnalysisViewMetadata):
-
     name = "extract"
     title = "Extraction Form"
     _description = "List of {} present/absent from selected genomes"
@@ -40,7 +37,6 @@ class ExtractionMetadata(AnalysisViewMetadata):
 
 
 class VennMetadata(AnalysisViewMetadata):
-
     name = "venn"
     title = "Venn Diagram"
     _description = "Venn diagrams of unique and shared {} among selected genomes"
@@ -50,7 +46,6 @@ class VennMetadata(AnalysisViewMetadata):
 
 
 class TabularComparisonMetadata(AnalysisViewMetadata):
-
     name = "table_comp"
     title = "Presence/absence table"
     _description = "Presence/absence table of {} in selected genomes"
@@ -59,7 +54,6 @@ class TabularComparisonMetadata(AnalysisViewMetadata):
 
 
 class HeatmapMetadata(AnalysisViewMetadata):
-
     name = "heatmap"
     title = "Heatmap"
     _description = "Heatmap of {} presence/absence in selected genomes"
@@ -69,7 +63,6 @@ class HeatmapMetadata(AnalysisViewMetadata):
 
 
 class AccumulationRarefactionMetadata(AnalysisViewMetadata):
-
     name = "pan_genome"
     title = "Accumulation / rarefaction plot"
     _description = "Accumulation / rarefaction plot of {} in selected genomes"
@@ -79,9 +72,8 @@ class AccumulationRarefactionMetadata(AnalysisViewMetadata):
 
 
 class CategoriesBarchartMetadata(AnalysisViewMetadata):
-
     name = "bar"
-    _types_available_for = ['cog', 'ko']
+    _types_available_for = ["cog", "ko"]
     title = "Categories barchart"
     _description = "Barcharts of {} categories in selected genomes"
     _url = "/{}_barchart/"
@@ -89,9 +81,8 @@ class CategoriesBarchartMetadata(AnalysisViewMetadata):
 
 
 class CategoriesFreqHeatmapMetadata(AnalysisViewMetadata):
-
     name = "cat_freq"
-    _types_available_for = ['cog']
+    _types_available_for = ["cog"]
     title = "Categories freq. heatmap"
     _description = "Heatmap of frequencies of genes identifed in each COG category"
     _url = "/{}_phylo_heatmap/True/"
@@ -99,9 +90,8 @@ class CategoriesFreqHeatmapMetadata(AnalysisViewMetadata):
 
 
 class CategoriesCountHeatmapMetadata(AnalysisViewMetadata):
-
     name = "cat_count"
-    _types_available_for = ['cog']
+    _types_available_for = ["cog"]
     title = "Categories count heatmap"
     _description = "Heatmap of counts of genes identifed in each COG category"
     _url = "/{}_phylo_heatmap/False/"
@@ -109,22 +99,23 @@ class CategoriesCountHeatmapMetadata(AnalysisViewMetadata):
 
 
 class GwasMetadata(AnalysisViewMetadata):
-
     name = "gwas"
-    _types_available_for = ['amr', 'cog', 'ko', 'pfam', 'vf', 'orthogroup']
+    _types_available_for = ["amr", "cog", "ko", "pfam", "vf", "orthogroup"]
     title = "Genome Wide Association Study"
     _description = "Association of {} with user-defined phenotype"
     _url = "/gwas_{}/"
     icon = "/img/gwas.png"
 
 
-analysis_views_metadata = [EntryListMetadata,
-                           ExtractionMetadata,
-                           VennMetadata,
-                           TabularComparisonMetadata,
-                           HeatmapMetadata,
-                           AccumulationRarefactionMetadata,
-                           CategoriesBarchartMetadata,
-                           CategoriesFreqHeatmapMetadata,
-                           CategoriesCountHeatmapMetadata,
-                           GwasMetadata]
+analysis_views_metadata = [
+    EntryListMetadata,
+    ExtractionMetadata,
+    VennMetadata,
+    TabularComparisonMetadata,
+    HeatmapMetadata,
+    AccumulationRarefactionMetadata,
+    CategoriesBarchartMetadata,
+    CategoriesFreqHeatmapMetadata,
+    CategoriesCountHeatmapMetadata,
+    GwasMetadata,
+]

--- a/webapp/views/autocomplete.py
+++ b/webapp/views/autocomplete.py
@@ -1,10 +1,8 @@
 from dal.autocomplete import Select2ListView
-
 from views.utils import AccessionFieldHandler
 
 
 class AutocompleteTaxid(Select2ListView):
-
     def get_list(self):
         with_plasmids = self.forwarded.get("include_plasmids", False)
         exclude = self.forwarded.get("exclude", [])
@@ -12,14 +10,16 @@ class AutocompleteTaxid(Select2ListView):
         return AccessionFieldHandler().get_choices(
             with_plasmids=with_plasmids,
             exclude=exclude,
-            exclude_taxids_in_groups=exclude_taxids_in_groups)
+            exclude_taxids_in_groups=exclude_taxids_in_groups,
+        )
 
 
 class AutocompleteNMissing(Select2ListView):
-
     def get_list(self):
         taxids, plasmids = AccessionFieldHandler().extract_choices(
-            self.forwarded.get("included", []), self.forwarded.get("include_plasmids", False))
+            self.forwarded.get("included", []),
+            self.forwarded.get("include_plasmids", False),
+        )
         n_max = len(taxids)
         if plasmids:
             n_max += len(plasmids)

--- a/webapp/views/custom_plots.py
+++ b/webapp/views/custom_plots.py
@@ -4,19 +4,20 @@ from django.shortcuts import render
 from django.views import View
 from ete3 import Tree
 from lib.db_utils import DB
-from lib.ete_phylo import EteTree, SimpleColorColumn
-
+from lib.ete_phylo import EteTree
+from lib.ete_phylo import SimpleColorColumn
 from views.mixins import ComparisonViewMixin
 from views.object_type_metadata import my_locals
-from views.utils import ResultTab, TabularResultTab
+from views.utils import ResultTab
+from views.utils import TabularResultTab
 
 
 class CusomPlotsView(View):
-
     title = "Custom plots"
-    description = "Produce phylogenetic trees and tables including "\
-                  "annotations of your choice."
-    template = 'chlamdb/custom_plots.html'
+    description = (
+        "Produce phylogenetic trees and tables including annotations of your choice."
+    )
+    template = "chlamdb/custom_plots.html"
     _db = None
 
     def dispatch(self, request, *args, **kwargs):
@@ -25,16 +26,20 @@ class CusomPlotsView(View):
 
     def get_result_tabs(self, table):
         return [
-            ResultTab("phylogenetic_tree", "Phylogenetic tree",
-                      "chlamdb/result_asset.html",
-                      asset_path=getattr(self, "tree_path", None)),
+            ResultTab(
+                "phylogenetic_tree",
+                "Phylogenetic tree",
+                "chlamdb/result_asset.html",
+                asset_path=getattr(self, "tree_path", None),
+            ),
             TabularResultTab(
-                "custom_plot_table", "Table",
+                "custom_plot_table",
+                "Table",
                 table_headers=table["headers"],
                 table_data=table["data"],
                 table_data_accessors=table["accessors"],
-                )
-            ]
+            ),
+        ]
 
     @property
     def db(self):
@@ -47,7 +52,7 @@ class CusomPlotsView(View):
         context = {
             "page_title": self.title,
             "description": self.description,
-            "form": self.form
+            "form": self.form,
         }
         context.update(kwargs)
         return my_locals(context)
@@ -80,9 +85,8 @@ class CusomPlotsView(View):
         table = self.prepare_table(counts, genome_descriptions)
 
         context = self.get_context(
-            show_results=True,
-            result_tabs=self.get_result_tabs(table)
-            )
+            show_results=True, result_tabs=self.get_result_tabs(table)
+        )
         return render(request, self.template, context)
 
     def prepare_tree(self, counts_list, genome_descriptions, to_highlight):
@@ -98,7 +102,9 @@ class CusomPlotsView(View):
         e_tree.rename_leaves(ref_names, highlight_leaves=to_highlight)
         for counts in counts_list:
             for label, count in counts.iterrows():
-                col = SimpleColorColumn.fromSeries(count, header=label, color_gradient=True)
+                col = SimpleColorColumn.fromSeries(
+                    count, header=label, color_gradient=True
+                )
                 e_tree.add_column(col)
         self.tree_path = "/temp/custom_tree.svg"
         path = settings.ASSET_ROOT + self.tree_path
@@ -110,7 +116,9 @@ class CusomPlotsView(View):
         headers = ["Name"]
         data = genome_descriptions
         for counts in counts_list:
-            data = data.merge(counts.T, how="left", left_on="taxon_id", right_index=True)
+            data = data.merge(
+                counts.T, how="left", left_on="taxon_id", right_index=True
+            )
             accessors.extend(counts.index)
             headers.extend(counts.index)
         data.where(data.notna(), 0, inplace=True)

--- a/webapp/views/entry_lists.py
+++ b/webapp/views/entry_lists.py
@@ -1,13 +1,15 @@
 from django.shortcuts import render
 from django.views import View
-
 from views.analysis_view_metadata import EntryListMetadata
-from views.mixins import (AmrViewMixin, BaseViewMixin, CogViewMixin,
-                          KoViewMixin, PfamViewMixin, VfViewMixin)
+from views.mixins import AmrViewMixin
+from views.mixins import BaseViewMixin
+from views.mixins import CogViewMixin
+from views.mixins import KoViewMixin
+from views.mixins import PfamViewMixin
+from views.mixins import VfViewMixin
 
 
 class EntryListViewBase(View, BaseViewMixin):
-
     _specific_colname_to_header_mapping = {"freq": "Frequency (n genomes)"}
     _metadata_cls = EntryListMetadata
 
@@ -21,14 +23,13 @@ class EntryListViewBase(View, BaseViewMixin):
         context = self.get_context(
             table_headers=self.table_headers,
             table_data_accessors=self.table_data_accessors,
-            table_data=table_data)
-        return render(request, 'chlamdb/entry_list.html', context)
+            table_data=table_data,
+        )
+        return render(request, "chlamdb/entry_list.html", context)
 
     def get_table_data(self):
         # retrieve hits
-        all_hits = self.get_hit_counts(self.taxids,
-                                       search_on="taxid",
-                                       indexing="taxid")
+        all_hits = self.get_hit_counts(self.taxids, search_on="taxid", indexing="taxid")
         # retrieve descriptions
         descriptions = self.get_hit_descriptions(all_hits.index.to_list())
 
@@ -37,14 +38,13 @@ class EntryListViewBase(View, BaseViewMixin):
         pfam_freq = all_hits[all_hits > 0].count(axis=1)
 
         # combine into df
-        combined_df = descriptions.merge(pfam_count.rename('count'),
-                                         left_index=True,
-                                         right_index=True)\
-                                  .merge(pfam_freq.rename('freq'),
-                                         left_index=True,
-                                         right_index=True)\
-                                  .sort_values(["count", "freq"],
-                                               ascending=False)
+        combined_df = (
+            descriptions.merge(
+                pfam_count.rename("count"), left_index=True, right_index=True
+            )
+            .merge(pfam_freq.rename("freq"), left_index=True, right_index=True)
+            .sort_values(["count", "freq"], ascending=False)
+        )
 
         combined_df = combined_df.where(combined_df.notna(), "-")
         return combined_df
@@ -55,25 +55,20 @@ class EntryListViewBase(View, BaseViewMixin):
 
 
 class PfamEntryListView(EntryListViewBase, PfamViewMixin):
-
     pass
 
 
 class KoEntryListView(EntryListViewBase, KoViewMixin):
-
     pass
 
 
 class CogEntryListView(EntryListViewBase, CogViewMixin):
-
     pass
 
 
 class AmrEntryListView(EntryListViewBase, AmrViewMixin):
-
     pass
 
 
 class VfEntryListView(EntryListViewBase, VfViewMixin):
-
     pass

--- a/webapp/views/errors.py
+++ b/webapp/views/errors.py
@@ -1,18 +1,17 @@
-
 errors = {
     "no_hits": {
         "error": True,
         "error_title": "Empty result set.",
-        "error_message":  "No hits were found for the current selection."
+        "error_message": "No hits were found for the current selection.",
     },
     "no_module_info": {
         "error": True,
         "error_title": "No information.",
-        "error_message":  "No information was found for this module."
+        "error_message": "No information was found for this module.",
     },
     "unknown_accession": {
         "error": True,
         "error_title": "Unknown accession.",
-        "error_message":  "Accepts protein ids, locus tags and orthogroup IDs."
+        "error_message": "Accepts protein ids, locus tags and orthogroup IDs.",
     },
 }

--- a/webapp/views/groups.py
+++ b/webapp/views/groups.py
@@ -1,17 +1,17 @@
 from collections import namedtuple
 
 from chlamdb.forms import make_group_add_form
-from django.shortcuts import redirect, render
+from django.shortcuts import redirect
+from django.shortcuts import render
 from django.urls import reverse
 from django.views import View
-
-from views.mixins import BaseViewMixin, GenomesTableMixin
+from views.mixins import BaseViewMixin
+from views.mixins import GenomesTableMixin
 from views.object_type_metadata import GroupMetadata
 
 
 class GroupsOverview(BaseViewMixin, View, GroupMetadata):
-
-    template = 'chlamdb/groups_overview.html'
+    template = "chlamdb/groups_overview.html"
     view_name = "groups"
 
     @property
@@ -19,14 +19,14 @@ class GroupsOverview(BaseViewMixin, View, GroupMetadata):
         return namedtuple("metadata", "description")(self.overview_description)
 
     def get(self, request, *args, **kwargs):
-        groups = [self.format_entry(group[0], to_url=True)
-                  for group in self.db.get_groups()]
+        groups = [
+            self.format_entry(group[0], to_url=True) for group in self.db.get_groups()
+        ]
         return render(request, self.template, self.get_context(groups=groups))
 
 
 class GroupDetails(BaseViewMixin, View, GroupMetadata, GenomesTableMixin):
-
-    template = 'chlamdb/group_details.html'
+    template = "chlamdb/group_details.html"
     view_name = "groups"
     genome_source_object = "group"
 
@@ -38,11 +38,14 @@ class GroupDetails(BaseViewMixin, View, GroupMetadata, GenomesTableMixin):
         self.group = group
         taxids = self.db.get_taxids_for_groups([group])
         genome_table = self.get_genomes_table(tuple(taxids))
-        return render(request, self.template, self.get_context(group=self.group, genome_table=genome_table))
+        return render(
+            request,
+            self.template,
+            self.get_context(group=self.group, genome_table=genome_table),
+        )
 
 
 class GroupDelete(BaseViewMixin, View, GroupMetadata, GenomesTableMixin):
-
     view_name = "groups_delete"
     genome_source_object = "group"
 
@@ -53,8 +56,7 @@ class GroupDelete(BaseViewMixin, View, GroupMetadata, GenomesTableMixin):
 
 
 class GroupAdd(BaseViewMixin, View, GroupMetadata):
-
-    template = 'chlamdb/group_add.html'
+    template = "chlamdb/group_add.html"
     view_name = "groups"
     genome_source_object = "group"
     description = "Add form"
@@ -81,6 +83,7 @@ class GroupAdd(BaseViewMixin, View, GroupMetadata):
 
         self.db.load_data_into_table("groups", [(group_name,)])
         self.db.load_data_into_table(
-            "taxon_in_group", [(group_name, taxid) for taxid in genomes])
+            "taxon_in_group", [(group_name, taxid) for taxid in genomes]
+        )
         self.db.commit()
         return redirect(reverse("groups", args=[group_name]))

--- a/webapp/views/gwas.py
+++ b/webapp/views/gwas.py
@@ -7,21 +7,34 @@ from django.conf import settings
 from django.shortcuts import render
 from django.views import View
 from ete3 import Tree
-from lib.ete_phylo import EteTree, MatchingColorColumn, ValueColoredColumn
+from lib.ete_phylo import EteTree
+from lib.ete_phylo import MatchingColorColumn
+from lib.ete_phylo import ValueColoredColumn
 from scoary import scoary
 from scoary.permutations import CONFINT_CACHE
-
 from views.analysis_view_metadata import GwasMetadata
-from views.mixins import (AmrViewMixin, CogViewMixin, KoViewMixin,
-                          OrthogroupViewMixin, PfamViewMixin, VfViewMixin)
-from views.utils import ResultTab, TabularResultTab
+from views.mixins import AmrViewMixin
+from views.mixins import CogViewMixin
+from views.mixins import KoViewMixin
+from views.mixins import OrthogroupViewMixin
+from views.mixins import PfamViewMixin
+from views.mixins import VfViewMixin
+from views.utils import ResultTab
+from views.utils import TabularResultTab
 
 
 class GWASBaseView(View):
-
-    template = 'chlamdb/gwas.html'
-    _gwas_data_accessors = ["sensitivity", "specificity", "fisher_p",
-                            "fisher_q", "empirical_p", "best", "worst", "fq*ep"]
+    template = "chlamdb/gwas.html"
+    _gwas_data_accessors = [
+        "sensitivity",
+        "specificity",
+        "fisher_p",
+        "fisher_q",
+        "empirical_p",
+        "best",
+        "worst",
+        "fq*ep",
+    ]
     _specific_colname_to_header_mapping = {
         "Gene": "Entry",
         "fisher_p": "p-value",
@@ -41,25 +54,27 @@ class GWASBaseView(View):
     @property
     def table_data_accessors(self):
         mixin_accessors = super(GWASBaseView, self).table_data_accessors
-        return [mixin_accessors[0],
-                *self._gwas_data_accessors,
-                *mixin_accessors[1:]]
+        return [mixin_accessors[0], *self._gwas_data_accessors, *mixin_accessors[1:]]
 
     def get_result_tabs(self, results):
         return [
             TabularResultTab(
-                "gwas_table", "Table",
+                "gwas_table",
+                "Table",
                 table_headers=self.table_headers,
                 table_data=results,
                 table_data_accessors=self.table_data_accessors,
                 colvis_button=True,
                 selectable=True,
                 custom_plot_button=True,
-                ),
-            ResultTab("gwas_tree", "Phylogenetic tree",
-                      "chlamdb/result_asset.html",
-                      asset_path=getattr(self, "tree_path", None))
-            ]
+            ),
+            ResultTab(
+                "gwas_tree",
+                "Phylogenetic tree",
+                "chlamdb/result_asset.html",
+                asset_path=getattr(self, "tree_path", None),
+            ),
+        ]
 
     def dispatch(self, request, *args, **kwargs):
         self.form_class = make_gwas_form(self.db)
@@ -81,15 +96,17 @@ class GWASBaseView(View):
         results, hits = self.run_gwas(phenotype, qval_threshold, max_genes)
         if results is None:
             context = self.get_context(
-                error=True, error_title="No significant association",
+                error=True,
+                error_title="No significant association",
                 error_message=f"No association of {self.object_name} with the"
-                f" phenotype had q-value<{qval_threshold}")
+                f" phenotype had q-value<{qval_threshold}",
+            )
             return render(request, self.template, context)
 
         descriptions = self.get_hit_descriptions(results["Gene"].to_list())
-        results = results.merge(descriptions,
-                                left_on="Gene",
-                                right_on=descriptions.index)
+        results = results.merge(
+            descriptions, left_on="Gene", right_on=descriptions.index
+        )
 
         for key in self._gwas_data_accessors:
             results[key] = results[key].apply(self.format_float)
@@ -102,8 +119,8 @@ class GWASBaseView(View):
         context = self.get_context(
             show_results=True,
             qval_threshold=qval_threshold,
-            result_tabs=self.get_result_tabs(results)
-            )
+            result_tabs=self.get_result_tabs(results),
+        )
         return render(request, self.template, context)
 
     def prepare_tree(self, phenotype, hits, results):
@@ -124,16 +141,22 @@ class GWASBaseView(View):
         neg_phenotype = neg_phenotype.to_dict()["trait"]
         phenotype = phenotype.to_dict()["trait"]
 
-        e_tree.add_column(ValueColoredColumn(
-            phenotype,
-            header="Phenotype",
-            col_func=lambda x: EteTree.BLUE if x == 0 else EteTree.RED))
+        e_tree.add_column(
+            ValueColoredColumn(
+                phenotype,
+                header="Phenotype",
+                col_func=lambda x: EteTree.BLUE if x == 0 else EteTree.RED,
+            )
+        )
 
         positive = results["supporting"] > results["opposing"]
-        for ((gene, hit), pos) in zip(hits.iterrows(), positive):
+        for (gene, hit), pos in zip(hits.iterrows(), positive):
             col_column = MatchingColorColumn(
-                hit.to_dict(), phenotype if pos else neg_phenotype, header=gene,
-                col_func=lambda x: EteTree.BLUE if x == 0 else EteTree.RED)
+                hit.to_dict(),
+                phenotype if pos else neg_phenotype,
+                header=gene,
+                col_func=lambda x: EteTree.BLUE if x == 0 else EteTree.RED,
+            )
             e_tree.add_column(col_column)
         return e_tree
 
@@ -148,7 +171,7 @@ class GWASBaseView(View):
         with TemporaryDirectory() as tmp:
             genotype_path = os.path.join(tmp, "genotype")
             with open(genotype_path, "w") as fh:
-                fh.write(",".join(["Gene"] + all_taxids_str)+"\n")
+                fh.write(",".join(["Gene"] + all_taxids_str) + "\n")
                 for entry, counts in all_hits.iterrows():
                     row = [str(entry), *[str(i) for i in counts[all_taxids]]]
                     fh.write(",".join(row) + "\n")
@@ -163,19 +186,21 @@ class GWASBaseView(View):
             # Reset the db connection as it otherwise leads to issues with
             # using an SQL object that was created in a separate thread.
             CONFINT_CACHE.con, CONFINT_CACHE.cur = CONFINT_CACHE.get_cur()
-            scoary(genotype_path,
-                   phenotype_path,
-                   os.path.join(tmp, "out"),
-                   newicktree=tree_path,
-                   multiple_testing=f'bonferroni:{qval_threshold}',
-                   max_genes=max_genes)
+            scoary(
+                genotype_path,
+                phenotype_path,
+                os.path.join(tmp, "out"),
+                newicktree=tree_path,
+                multiple_testing=f"bonferroni:{qval_threshold}",
+                max_genes=max_genes,
+            )
 
             # Summary file is absent if no gene passed filtering
             if not os.path.isfile(os.path.join(tmp, "out", "summary.tsv")):
                 return (None, None)
             res = pd.read_csv(
-                os.path.join(tmp, "out", "traits", "trait", "result.tsv"),
-                sep="\t")
+                os.path.join(tmp, "out", "traits", "trait", "result.tsv"), sep="\t"
+            )
 
         return res, all_hits.loc[res["Gene"]]
 
@@ -185,30 +210,24 @@ class GWASBaseView(View):
 
 
 class AmrGwasView(GWASBaseView, AmrViewMixin):
-
     pass
 
 
 class PfamGwasView(GWASBaseView, PfamViewMixin):
-
     pass
 
 
 class KoGwasView(GWASBaseView, KoViewMixin):
-
     pass
 
 
 class CogGwasView(GWASBaseView, CogViewMixin):
-
     pass
 
 
 class OrthogroupGwasView(GWASBaseView, OrthogroupViewMixin):
-
     pass
 
 
 class VfGwasView(GWASBaseView, VfViewMixin):
-
     pass

--- a/webapp/views/hits_extraction.py
+++ b/webapp/views/hits_extraction.py
@@ -1,21 +1,26 @@
-
-
 import pandas as pd
 from chlamdb.forms import make_extract_form
 from django.shortcuts import render
 from django.views import View
-
 from views.analysis_view_metadata import ExtractionMetadata
 from views.errors import errors
-from views.mixins import (AmrViewMixin, CogViewMixin, KoViewMixin,
-                          OrthogroupViewMixin, PfamViewMixin, VfViewMixin)
-from views.utils import (ResultTab, format_cog, format_cog_url, format_ko_url,
-                         format_locus, format_lst_to_html, format_orthogroup)
+from views.mixins import AmrViewMixin
+from views.mixins import CogViewMixin
+from views.mixins import KoViewMixin
+from views.mixins import OrthogroupViewMixin
+from views.mixins import PfamViewMixin
+from views.mixins import VfViewMixin
+from views.utils import ResultTab
+from views.utils import format_cog
+from views.utils import format_cog_url
+from views.utils import format_ko_url
+from views.utils import format_locus
+from views.utils import format_lst_to_html
+from views.utils import format_orthogroup
 
 
 class ExtractHitsBaseView(View):
-
-    template = 'chlamdb/extract_hits.html'
+    template = "chlamdb/extract_hits.html"
 
     results_table_help = (
         "<b>{0} table</b>: it contains the list of"
@@ -24,7 +29,8 @@ class ExtractHitsBaseView(View):
         "{1} as well as the fraction of included genomes"
         "containing it {2} and the fraction of genomes in the whole database"
         "containing it {2}.<br>"
-        "{3}")
+        "{3}"
+    )
 
     _table_help_complement = ""
     _col_descriptions = {}
@@ -33,19 +39,21 @@ class ExtractHitsBaseView(View):
 
     @property
     def table_cols_description(self):
-        return [self._col_descriptions.get(header, header.lower())
-                for header in self.table_headers[:-2]]
+        return [
+            self._col_descriptions.get(header, header.lower())
+            for header in self.table_headers[:-2]
+        ]
 
     @property
     def table_help(self):
-        once = "exactly once" if getattr(self, "single_copy", False)\
-                else "at least once"
+        once = (
+            "exactly once" if getattr(self, "single_copy", False) else "at least once"
+        )
         col_descr = ", ".join(self.table_cols_description[:-1])
         col_descr += " and " + self.table_cols_description[-1]
-        return self.results_table_help.format(self.object_name_plural,
-                                              col_descr,
-                                              once,
-                                              self._table_help_complement)
+        return self.results_table_help.format(
+            self.object_name_plural, col_descr, once, self._table_help_complement
+        )
 
     @property
     def view_name(self):
@@ -54,13 +62,14 @@ class ExtractHitsBaseView(View):
     @property
     def result_tabs(self):
         return [
-            ResultTab(1, self.object_name_plural, "chlamdb/extract_hits_results_table.html"),
-            ]
+            ResultTab(
+                1, self.object_name_plural, "chlamdb/extract_hits_results_table.html"
+            ),
+        ]
 
     @property
     def table_count_headers(self):
-        return ["Presence in selection (%)",
-                "Presence in database (%)"]
+        return ["Presence in selection (%)", "Presence in database (%)"]
 
     @property
     def _table_headers(self):
@@ -72,24 +81,27 @@ class ExtractHitsBaseView(View):
 
     def dispatch(self, request, *args, **kwargs):
         self.extract_form_class = make_extract_form(
-            self.db, self.view_name, plasmid=True, label=self.object_name_plural)
+            self.db, self.view_name, plasmid=True, label=self.object_name_plural
+        )
         return super(ExtractHitsBaseView, self).dispatch(request, *args, **kwargs)
 
     def get_context(self, **kwargs):
         context = super(ExtractHitsBaseView, self).get_context(**kwargs)
         context["table_help"] = self.table_help
         if getattr(self, "show_results", False):
-            context.update({
-                "show_results": True,
-                "n_missing": self.form.n_missing,
-                "n_hits": self.n_hits,
-                "table_headers": self.table_headers,
-                "table_data": self.table_data,
-                "included_taxids": self.form.included_taxids,
-                "excluded_taxids": self.form.excluded_taxids,
-                "selection": self.selection,
-                "result_tabs": self.result_tabs,
-                })
+            context.update(
+                {
+                    "show_results": True,
+                    "n_missing": self.form.n_missing,
+                    "n_hits": self.n_hits,
+                    "table_headers": self.table_headers,
+                    "table_data": self.table_data,
+                    "included_taxids": self.form.included_taxids,
+                    "excluded_taxids": self.form.excluded_taxids,
+                    "selection": self.selection,
+                    "result_tabs": self.result_tabs,
+                }
+            )
         return context
 
     def get(self, request, *args, **kwargs):
@@ -108,32 +120,40 @@ class ExtractHitsBaseView(View):
         # Extract form data
         self.single_copy = "checkbox_single_copy" in request.POST
 
-        self.min_fraq = int((self.form.n_included - self.form.n_missing) /
-                            self.form.n_included * 100)
+        self.min_fraq = int(
+            (self.form.n_included - self.form.n_missing) / self.form.n_included * 100
+        )
 
         self.n_excluded = len(self.form.excluded_taxids)
         if self.form.excluded_plasmids is not None:
             self.n_excluded += len(self.form.excluded_plasmids)
 
         # Count hits for selection
-        hit_counts = self.get_hit_counts(self.form.included_taxids,
-                                         plasmids=self.form.included_plasmids,
-                                         search_on="taxid")
+        hit_counts = self.get_hit_counts(
+            self.form.included_taxids,
+            plasmids=self.form.included_plasmids,
+            search_on="taxid",
+        )
         if not self.single_copy:
             hit_counts["presence"] = self._to_percent(
-                hit_counts[hit_counts > 0].count(axis=1), self.form.n_included)
+                hit_counts[hit_counts > 0].count(axis=1), self.form.n_included
+            )
             hit_counts["selection"] = hit_counts.presence >= self.min_fraq
         else:
             excluded_hits = hit_counts[hit_counts > 1].count(axis=1)
             hit_counts["presence"] = self._to_percent(
-                hit_counts[hit_counts == 1].count(axis=1), self.form.n_included)
-            hit_counts["selection"] = ((hit_counts.presence >= self.min_fraq)
-                                       & (excluded_hits == 0))
+                hit_counts[hit_counts == 1].count(axis=1), self.form.n_included
+            )
+            hit_counts["selection"] = (hit_counts.presence >= self.min_fraq) & (
+                excluded_hits == 0
+            )
 
         if self.n_excluded > 0:
             mat_exclude = self.get_hit_counts(
-                self.form.excluded_taxids, plasmids=self.form.excluded_plasmids,
-                search_on="taxid")
+                self.form.excluded_taxids,
+                plasmids=self.form.excluded_plasmids,
+                search_on="taxid",
+            )
             mat_exclude["presence"] = mat_exclude[mat_exclude > 0].count(axis=1)
             mat_exclude["exclude"] = mat_exclude.presence > 0
             neg_index = mat_exclude[mat_exclude.exclude].index
@@ -148,16 +168,19 @@ class ExtractHitsBaseView(View):
 
         # Count hits for all genomes
         hit_counts_all = self.get_hit_counts(
-            self.selection, search_on=self.object_column)
+            self.selection, search_on=self.object_column
+        )
         self.n_hits = len(hit_counts_all.index)
         self.max_n = len(self.db.taxon_ids())
 
         if not self.single_copy:
             hit_counts_all = self._to_percent(
-                hit_counts_all[hit_counts_all > 0].count(axis=1), self.max_n)
+                hit_counts_all[hit_counts_all > 0].count(axis=1), self.max_n
+            )
         else:
             hit_counts_all = self._to_percent(
-                hit_counts_all[hit_counts_all == 1].count(axis=1), self.max_n)
+                hit_counts_all[hit_counts_all == 1].count(axis=1), self.max_n
+            )
         context = self.prepare_data(hit_counts, hit_counts_all)
 
         if context is None:
@@ -183,7 +206,6 @@ class ExtractHitsBaseView(View):
 
 
 class ExtractOrthogroupView(ExtractHitsBaseView, OrthogroupViewMixin):
-
     _table_headers = ["Orthogroup", "Genes", "Products"]
 
     _table_help_complement = (
@@ -196,20 +218,25 @@ class ExtractOrthogroupView(ExtractHitsBaseView, OrthogroupViewMixin):
         "and quickly linked to additional details about locus annotations."
     )
 
-    _col_descriptions = {"COG": "COG category",
-                         "KO": "KO assignment"}
+    _col_descriptions = {"COG": "COG category", "KO": "KO assignment"}
 
     @property
     def result_tabs(self):
         return [
-            ResultTab(1, self.object_name_plural, "chlamdb/extract_hits_results_table.html"),
+            ResultTab(
+                1, self.object_name_plural, "chlamdb/extract_hits_results_table.html"
+            ),
             ResultTab(2, "Details table", "chlamdb/extract_hits_details_table.html"),
-            ]
+        ]
 
     @property
     def table_headers(self):
-        return [""] + self._table_headers + getattr(self, "opt_header", [])\
-               + self.table_count_headers
+        return (
+            [""]
+            + self._table_headers
+            + getattr(self, "opt_header", [])
+            + self.table_count_headers
+        )
 
     @staticmethod
     def get_optional_annotations(db, seqids):
@@ -257,12 +284,14 @@ class ExtractOrthogroupView(ExtractHitsBaseView, OrthogroupViewMixin):
         annotations = self.db.get_genes_from_og(
             orthogroups=self.selection,
             taxon_ids=all_taxids,
-            terms=["gene", "product", "locus_tag"])
+            terms=["gene", "product", "locus_tag"],
+        )
         if annotations.empty:
             return None
 
         self.opt_header, optional_annotations = self.get_optional_annotations(
-            self.db, seqids=annotations.index.tolist())
+            self.db, seqids=annotations.index.tolist()
+        )
         annotations = annotations.join(optional_annotations)
         grouped = annotations.groupby("orthogroup")
         genes = grouped["gene"].apply(list)
@@ -278,82 +307,103 @@ class ExtractOrthogroupView(ExtractHitsBaseView, OrthogroupViewMixin):
             cnt_in = hit_counts.presence.loc[entry_id]
             g = genes.loc[entry_id]
             gene_data = format_lst_to_html(
-                "-" if pd.isna(entry) else entry for entry in g)
+                "-" if pd.isna(entry) else entry for entry in g
+            )
             prod_data = format_lst_to_html(products.loc[entry_id])
             entry_link = format_orthogroup(entry_id, to_url=True)
             optional = []
             if "KO" in self.opt_header and entry_id in kos:
-                optional.append(format_lst_to_html(
-                    kos.loc[entry_id], add_count=True, format_func=format_ko_url))
+                optional.append(
+                    format_lst_to_html(
+                        kos.loc[entry_id], add_count=True, format_func=format_ko_url
+                    )
+                )
             if "COG" in self.opt_header:
-                optional.append(format_lst_to_html(
-                    cogs.loc[entry_id], add_count=True, format_func=format_cog_url))
-            entry = [format_orthogroup(entry_id), entry_link, gene_data, prod_data, *optional, cnt_in, count]
+                optional.append(
+                    format_lst_to_html(
+                        cogs.loc[entry_id], add_count=True, format_func=format_cog_url
+                    )
+                )
+            entry = [
+                format_orthogroup(entry_id),
+                entry_link,
+                gene_data,
+                prod_data,
+                *optional,
+                cnt_in,
+                count,
+            ]
             self.table_data.append(entry)
 
-        ref_genomes = self.db.get_genomes_description(
-        ).loc[self.form.included_taxids].reset_index()
+        ref_genomes = (
+            self.db.get_genomes_description()
+            .loc[self.form.included_taxids]
+            .reset_index()
+        )
 
         details_header, details_data = self.get_table_details(self.db, annotations)
 
         self.show_results = True
-        context = self.get_context(ref_genomes=ref_genomes,
-                                   details_header=details_header,
-                                   details_data=details_data,
-                                   show_circos_form=True)
+        context = self.get_context(
+            ref_genomes=ref_genomes,
+            details_header=details_header,
+            details_data=details_data,
+            show_circos_form=True,
+        )
         return context
 
 
 class ExtractPfamView(ExtractHitsBaseView, PfamViewMixin):
-
     pass
 
 
 class ExtractAmrView(ExtractHitsBaseView, AmrViewMixin):
-
     pass
 
 
 class ExtractVfView(ExtractHitsBaseView, VfViewMixin):
-
     pass
 
 
 class ExtractKoView(ExtractHitsBaseView, KoViewMixin):
-
-    _col_descriptions = {"Description": "description including the corresponding"
-                                        " EC numbers used in enzyme nomenclature",
-                         "Modules": "Kegg modules to which it belongs"}
+    _col_descriptions = {
+        "Description": "description including the corresponding"
+        " EC numbers used in enzyme nomenclature",
+        "Modules": "Kegg modules to which it belongs",
+    }
 
 
 class ExtractCogView(ExtractHitsBaseView, CogViewMixin):
-
     _table_headers = ["COG", "Function", "Description"]
 
     _table_help_complement = (
-        '<br><b> COG categories barchart</b>: this plot displays for each COG '
-        'category in '
+        "<br><b> COG categories barchart</b>: this plot displays for each COG "
+        "category in "
         '<span style="color: rgb(135, 186, 245)"><b>light-blue</b></span> the '
-        'number of genes shared by the selected genomes, while in '
+        "number of genes shared by the selected genomes, while in "
         '<span style="color: rgb(16, 76, 145)"><b>blue</b></span> , the total '
-        'number of genes annotated with that COG in the selected genomes '
-        '(shared and unique to each selected genome). Next to the light-blue '
-        'barcharts there is a percentage value as the result of the number of '
-        'reported COGs for each category divided by the number of shared COG '
-        'in all categories, while next to the blue barcharts the value '
-        'represents COGs count are divided by the total COGs unique and shared '
-        ' in the selected genomes.'
-        '<br>A longer light-blue bar can be interpreted as an enrichment of '
-        'that shared COG category in the selected genomes compared to their '
-        'complete COG profiles.'
+        "number of genes annotated with that COG in the selected genomes "
+        "(shared and unique to each selected genome). Next to the light-blue "
+        "barcharts there is a percentage value as the result of the number of "
+        "reported COGs for each category divided by the number of shared COG "
+        "in all categories, while next to the blue barcharts the value "
+        "represents COGs count are divided by the total COGs unique and shared "
+        " in the selected genomes."
+        "<br>A longer light-blue bar can be interpreted as an enrichment of "
+        "that shared COG category in the selected genomes compared to their "
+        "complete COG profiles."
     )
 
     @property
     def result_tabs(self):
         return [
-            ResultTab(1, self.object_name_plural, "chlamdb/extract_hits_results_table.html"),
-            ResultTab(2, "COG categories barchart", "chlamdb/extract_hits_cog_barcharts.html"),
-            ]
+            ResultTab(
+                1, self.object_name_plural, "chlamdb/extract_hits_results_table.html"
+            ),
+            ResultTab(
+                2, "COG categories barchart", "chlamdb/extract_hits_cog_barcharts.html"
+            ),
+        ]
 
     def prepare_data(self, hit_counts, hit_counts_all):
         cat_count = {}
@@ -361,7 +411,6 @@ class ExtractCogView(ExtractHitsBaseView, CogViewMixin):
         cogs_funct = self.db.get_cog_code_description()
         self.table_data = []
         for cog_id in self.selection:
-
             # some cogs do not have a description, skip those
             if cog_id not in cogs_summaries:
                 continue
@@ -373,8 +422,14 @@ class ExtractCogView(ExtractHitsBaseView, CogViewMixin):
                 inc, not_incl = cat_count.get(func, (0, 0))
                 cat_count[func] = (inc + hit_counts.presence.loc[cog_id], not_incl)
             funcs = "<br>".join(f"{func} ({func_desc})" for func, func_desc in func_acc)
-            data = (format_cog(cog_id), format_cog(cog_id, as_url=True), funcs, cog_descr,
-                    hit_counts.presence.loc[cog_id], hit_counts_all.loc[cog_id])
+            data = (
+                format_cog(cog_id),
+                format_cog(cog_id, as_url=True),
+                funcs,
+                cog_descr,
+                hit_counts.presence.loc[cog_id],
+                hit_counts_all.loc[cog_id],
+            )
             self.table_data.append(data)
 
         # get the categories for all cogs
@@ -384,21 +439,33 @@ class ExtractCogView(ExtractHitsBaseView, CogViewMixin):
                 cat_count[func] = (inc, not_incl + hit_counts_all.loc[cog_id])
 
         # Code to generate the barchart diagrams
-        cat_map_str = ",".join([f"\"{func}\": \"{descr}\"" for func, descr in cogs_funct.items()])
+        cat_map_str = ",".join(
+            [f'"{func}": "{descr}"' for func, descr in cogs_funct.items()]
+        )
         category_map = f"var category_description = {{{cat_map_str}}};"
         ttl_sel = sum([c1 for func, (c1, c2) in cat_count.items()])
         ttl_all = sum([c2 for func, (c1, c2) in cat_count.items()])
 
-        cat_count_comp = ",".join([f"\"{func}\": [\"{c2}\", \"{c1}\"]" for func, (c1, c2) in cat_count.items()])
+        cat_count_comp = ",".join(
+            [f'"{func}": ["{c2}", "{c1}"]' for func, (c1, c2) in cat_count.items()]
+        )
         category_count_complete = f"var category_count_complete = {{{cat_count_comp}}};"
 
-        serie_selection_val = [str(round(float(c1) / ttl_sel, 2)) for func, (c1, c2) in cat_count.items()]
-        serie_all_val = [str(round(float(c2) / ttl_all, 2)) for func, (c1, c2) in cat_count.items()]
-        serie_selection = f"{{labels: \"selection\", values: [{','.join(serie_selection_val)}]}}"
-        serie_all = f"{{labels: \"complete genomes\", values: [{','.join(serie_all_val)}]}}"
+        serie_selection_val = [
+            str(round(float(c1) / ttl_sel, 2)) for func, (c1, c2) in cat_count.items()
+        ]
+        serie_all_val = [
+            str(round(float(c2) / ttl_all, 2)) for func, (c1, c2) in cat_count.items()
+        ]
+        serie_selection = (
+            f'{{labels: "selection", values: [{",".join(serie_selection_val)}]}}'
+        )
+        serie_all = (
+            f'{{labels: "complete genomes", values: [{",".join(serie_all_val)}]}}'
+        )
         series_str = ",".join([serie_all, serie_selection])
         series = f"[{series_str}]"
-        labels_str = ",".join([f"\"{funct}\"" for funct in cat_count.keys()])
+        labels_str = ",".join([f'"{funct}"' for funct in cat_count.keys()])
         labels = f"[{labels_str}]"
 
         self.show_results = True
@@ -407,4 +474,4 @@ class ExtractCogView(ExtractHitsBaseView, CogViewMixin):
             series=series,
             category_map=category_map,
             category_count_complete=category_count_complete,
-            )
+        )

--- a/webapp/views/mixins.py
+++ b/webapp/views/mixins.py
@@ -1,19 +1,26 @@
 import pandas as pd
 from django.conf import settings
 from lib.db_utils import DB
-
 from views.analysis_view_metadata import analysis_views_metadata
-from views.object_type_metadata import (AmrMetadata, CogMetadata, KoMetadata,
-                                        OrthogroupMetadata, PfamMetadata,
-                                        VfMetadata, my_locals)
-from views.utils import (DataTableConfig, format_genome, format_hmm_url,
-                         format_ko_module, format_lst_to_html,
-                         format_refseqid_to_ncbi, get_genomes_data, page2title,
-                         safe_replace)
+from views.object_type_metadata import AmrMetadata
+from views.object_type_metadata import CogMetadata
+from views.object_type_metadata import KoMetadata
+from views.object_type_metadata import OrthogroupMetadata
+from views.object_type_metadata import PfamMetadata
+from views.object_type_metadata import VfMetadata
+from views.object_type_metadata import my_locals
+from views.utils import DataTableConfig
+from views.utils import format_genome
+from views.utils import format_hmm_url
+from views.utils import format_ko_module
+from views.utils import format_lst_to_html
+from views.utils import format_refseqid_to_ncbi
+from views.utils import get_genomes_data
+from views.utils import page2title
+from views.utils import safe_replace
 
 
-class Transform():
-
+class Transform:
     def __init__(self, colname, transform, kwargs=None, outcolname=None):
         self.colname = colname
         self.transform = transform
@@ -32,7 +39,6 @@ class Transform():
 
 
 class TransformWithAccessoryColumn(Transform):
-
     def __init__(self, colname, accessory_colname, transform):
         self.colname = colname
         self.accessory_colname = accessory_colname
@@ -43,7 +49,8 @@ class TransformWithAccessoryColumn(Transform):
 
     def apply(self, df):
         df[self.colname] = df[[self.colname, self.accessory_colname]].apply(
-            self.transform, axis=1)
+            self.transform, axis=1
+        )
 
     def maybe_add_accessory_col_for_query(self, columns, transformed):
         if not transformed or not columns or self.colname not in columns:
@@ -52,8 +59,7 @@ class TransformWithAccessoryColumn(Transform):
             columns.append(self.accessory_colname)
 
 
-class BaseViewMixin():
-
+class BaseViewMixin:
     _db = None
     _base_colname_to_header_mapping = {}
     _specific_colname_to_header_mapping = {}
@@ -66,8 +72,10 @@ class BaseViewMixin():
         return self._db
 
     def page_title(self):
-        return page2title.get(getattr(self, "view_name", None)) or \
-            page2title[f"{self.object_type}_comparison"]
+        return (
+            page2title.get(getattr(self, "view_name", None))
+            or page2title[f"{self.object_type}_comparison"]
+        )
 
     @property
     def object_column(self):
@@ -75,13 +83,13 @@ class BaseViewMixin():
 
     def colname_to_header(self, colname):
         return self._specific_colname_to_header_mapping.get(
-            colname, self._base_colname_to_header_mapping.get(
-                colname, colname.capitalize()))
+            colname,
+            self._base_colname_to_header_mapping.get(colname, colname.capitalize()),
+        )
 
     @property
     def table_headers(self):
-        return [self.colname_to_header(col)
-                for col in self.table_data_accessors]
+        return [self.colname_to_header(col) for col in self.table_data_accessors]
 
     def transform_data(self, descriptions):
         for transform in self.transforms:
@@ -90,14 +98,15 @@ class BaseViewMixin():
 
     @property
     def transforms(self):
-        return [
-            Transform(self.object_column, self.format_entry, {"to_url": True})]
+        return [Transform(self.object_column, self.format_entry, {"to_url": True})]
 
     @property
     def available_views(self):
-        return [view_metadata(self.object_type, self.object_name_plural)
-                for view_metadata in analysis_views_metadata
-                if view_metadata.available_for(self.object_type)]
+        return [
+            view_metadata(self.object_type, self.object_name_plural)
+            for view_metadata in analysis_views_metadata
+            if view_metadata.available_for(self.object_type)
+        ]
 
     @property
     def metadata(self):
@@ -109,17 +118,21 @@ class BaseViewMixin():
             "page_title": self.page_title(),
         }
         if hasattr(self, "metadata"):
-            context.update({
-                "description": getattr(self.metadata, "description", ""),
-                "tab_name": getattr(self.metadata, "name", ""),
-                })
+            context.update(
+                {
+                    "description": getattr(self.metadata, "description", ""),
+                    "tab_name": getattr(self.metadata, "name", ""),
+                }
+            )
         if hasattr(self, "object_type"):
-            context.update({
-                "object_type": self.object_type,
-                "object_name": self.object_name_plural,
-                "object_name_plural": self.object_name_plural,
-                "available_views": self.available_views,
-                })
+            context.update(
+                {
+                    "object_type": self.object_type,
+                    "object_name": self.object_name_plural,
+                    "object_name_plural": self.object_name_plural,
+                    "available_views": self.available_views,
+                }
+            )
         if hasattr(self, "form"):
             context["form"] = self.form
         context.update(kwargs)
@@ -130,21 +143,27 @@ class BaseViewMixin():
             first_col = 1
         else:
             first_col = 0
-        return ", ".join(self.table_headers[first_col:-1]) + " and " + \
-               self.table_headers[-1]
+        return (
+            ", ".join(self.table_headers[first_col:-1])
+            + " and "
+            + self.table_headers[-1]
+        )
 
 
 class AmrViewMixin(BaseViewMixin, AmrMetadata):
-
     object_column = "gene"
 
-    _base_colname_to_header_mapping = {
-        "seq_name": "Description",
-        "hmm_id": "HMM"
-    }
+    _base_colname_to_header_mapping = {"seq_name": "Description", "hmm_id": "HMM"}
 
-    table_data_accessors = ["gene", "seq_name", "scope", "type", "class",
-                            "subclass", "hmm_id"]
+    table_data_accessors = [
+        "gene",
+        "seq_name",
+        "scope",
+        "type",
+        "class",
+        "subclass",
+        "hmm_id",
+    ]
 
     @property
     def transforms(self):
@@ -152,7 +171,7 @@ class AmrViewMixin(BaseViewMixin, AmrMetadata):
             Transform(self.object_column, self.format_entry, {"to_url": True}),
             Transform("hmm_id", format_hmm_url),
             Transform("class", safe_replace, {"args": ["/", " / "]}),
-            Transform("subclass", safe_replace, {"args": ["/", " / "]})
+            Transform("subclass", safe_replace, {"args": ["/", " / "]}),
         ]
 
     @property
@@ -171,8 +190,9 @@ class AmrViewMixin(BaseViewMixin, AmrMetadata):
     def aggregate_amr_annotations(self, amr_annotations):
         gene_annot_counts = amr_annotations.gene.value_counts()
         for gene in gene_annot_counts[gene_annot_counts > 1].keys():
-            amr_annotations[amr_annotations["gene"] == gene] = \
+            amr_annotations[amr_annotations["gene"] == gene] = (
                 self.aggregate_annotations_for_gene(gene, amr_annotations)
+            )
 
     def aggregate_annotations_for_gene(self, gene, annotations):
         """
@@ -188,7 +208,6 @@ class AmrViewMixin(BaseViewMixin, AmrMetadata):
 
 
 class CogViewMixin(BaseViewMixin, CogMetadata):
-
     _base_colname_to_header_mapping = {
         "cog": "ID",
         "function": "Function(s) cat.",
@@ -215,7 +234,8 @@ class CogViewMixin(BaseViewMixin, CogMetadata):
 
     def get_hit_descriptions(self, ids, transformed=True, only_cog_desc=True, **kwargs):
         descriptions = self.db.get_cog_summaries(
-            ids, only_cog_desc=only_cog_desc, as_df=True)
+            ids, only_cog_desc=only_cog_desc, as_df=True
+        )
         if transformed:
             descriptions = self.transform_data(descriptions)
         return descriptions
@@ -224,13 +244,13 @@ class CogViewMixin(BaseViewMixin, CogMetadata):
     def transforms(self):
         return [
             Transform(self.object_column, self.format_entry, {"to_url": True}),
-            Transform("function", self.format_function_descr,
-                      outcolname="function_descr"),
+            Transform(
+                "function", self.format_function_descr, outcolname="function_descr"
+            ),
         ]
 
 
 class KoViewMixin(BaseViewMixin, KoMetadata):
-
     _base_colname_to_header_mapping = {
         "ko": "KO",
     }
@@ -241,30 +261,43 @@ class KoViewMixin(BaseViewMixin, KoMetadata):
     def get_hit_counts(self):
         return self.db.get_ko_hits
 
-    def get_hit_descriptions(self, ids, transformed=True, extended_data=True,
-                             taxid_for_pathway_formatting=None, **kwargs):
+    def get_hit_descriptions(
+        self,
+        ids,
+        transformed=True,
+        extended_data=True,
+        taxid_for_pathway_formatting=None,
+        **kwargs,
+    ):
         descriptions = self.db.get_ko_desc(ids, as_df=True)
         descriptions = descriptions.set_index(["ko"], drop=False)
         if extended_data:
             if not transformed:
                 raise NotImplementedError(
-                    "Can only use extended_data with transformed=True")
+                    "Can only use extended_data with transformed=True"
+                )
             modules = self.db.get_ko_modules(ids, as_pandas=True)
             if not modules.empty:
                 modules = modules.groupby("ko_id").apply(self.format_modules)
                 descriptions = descriptions.merge(
-                    modules.rename("modules"), how="left",
-                    left_index=True, right_index=True)
+                    modules.rename("modules"),
+                    how="left",
+                    left_index=True,
+                    right_index=True,
+                )
             else:
                 descriptions["modules"] = None
             pathways = self.db.get_ko_pathways(ids, as_df=True)
             if not pathways.empty:
                 pathways = pathways.groupby("ko").apply(
-                    self.format_pathways,
-                    with_taxid=taxid_for_pathway_formatting)
+                    self.format_pathways, with_taxid=taxid_for_pathway_formatting
+                )
                 descriptions = descriptions.merge(
-                    pathways.rename("pathways"), how="left",
-                    left_index=True, right_index=True)
+                    pathways.rename("pathways"),
+                    how="left",
+                    left_index=True,
+                    right_index=True,
+                )
             else:
                 descriptions["pathways"] = None
 
@@ -275,8 +308,9 @@ class KoViewMixin(BaseViewMixin, KoMetadata):
 
     @staticmethod
     def format_modules(modules, as_list=False):
-        gen = (format_ko_module(row.module_id, row.desc)
-               for i, row in modules.iterrows())
+        gen = (
+            format_ko_module(row.module_id, row.desc) for i, row in modules.iterrows()
+        )
         if as_list:
             return list(gen)
         return "<br>".join(gen)
@@ -284,20 +318,21 @@ class KoViewMixin(BaseViewMixin, KoMetadata):
     @staticmethod
     def format_pathways(pathways, with_taxid=None):
         if with_taxid is None:
-            fmt_str = "<a href=\"/KEGG_mapp_ko/map{id:05d}\">{descr}</a>"
+            fmt_str = '<a href="/KEGG_mapp_ko/map{id:05d}">{descr}</a>'
         else:
-            fmt_str = "<a href=\"/KEGG_mapp_ko/map{id:05d}/{taxid}\">{descr}</a>"
-        gen = (fmt_str.format(id=row.pathway, descr=row.description, taxid=with_taxid)
-               for i, row in pathways.iterrows())
+            fmt_str = '<a href="/KEGG_mapp_ko/map{id:05d}/{taxid}">{descr}</a>'
+        gen = (
+            fmt_str.format(id=row.pathway, descr=row.description, taxid=with_taxid)
+            for i, row in pathways.iterrows()
+        )
         return "<br>".join(gen)
 
 
 class PfamViewMixin(BaseViewMixin, PfamMetadata):
-
     _base_colname_to_header_mapping = {
         "pfam": "Domain ID",
         "def": "Description",
-        "ttl_cnt": "nDomains"
+        "ttl_cnt": "nDomains",
     }
 
     table_data_accessors = ["pfam", "def"]
@@ -314,11 +349,7 @@ class PfamViewMixin(BaseViewMixin, PfamMetadata):
 
 
 class OrthogroupViewMixin(BaseViewMixin, OrthogroupMetadata):
-
-    _base_colname_to_header_mapping = {
-        "product": "Products",
-        "gene": "Genes"
-    }
+    _base_colname_to_header_mapping = {"product": "Products", "gene": "Genes"}
 
     table_data_accessors = ["orthogroup", "products", "gene"]
 
@@ -331,12 +362,16 @@ class OrthogroupViewMixin(BaseViewMixin, OrthogroupMetadata):
         grouped = genes.groupby("orthogroup")
         genes = grouped["gene"].apply(list).apply(format_lst_to_html)
         products = grouped["product"].apply(list).apply(format_lst_to_html)
-        descriptions = pd.DataFrame({"orthogroup": ids},
-                                    index=pd.Index(ids, name="orthogroup"))
+        descriptions = pd.DataFrame(
+            {"orthogroup": ids}, index=pd.Index(ids, name="orthogroup")
+        )
 
         descriptions = descriptions.merge(
             pd.DataFrame({"gene": genes, "products": products}),
-            "left", left_index=True, right_index=True)
+            "left",
+            left_index=True,
+            right_index=True,
+        )
         if transformed:
             descriptions = self.transform_data(descriptions)
 
@@ -344,7 +379,6 @@ class OrthogroupViewMixin(BaseViewMixin, OrthogroupMetadata):
 
 
 class VfViewMixin(BaseViewMixin, VfMetadata):
-
     object_column = "vf_gene_id"
 
     _base_colname_to_header_mapping = {
@@ -352,7 +386,6 @@ class VfViewMixin(BaseViewMixin, VfMetadata):
         "prot_name": "Protein",
         "vfid": "VF ID",
         "gb_accession": "Protein ID",
-
     }
 
     table_data_accessors = ["vf_gene_id", "prot_name", "vfid", "category"]
@@ -367,8 +400,7 @@ class VfViewMixin(BaseViewMixin, VfMetadata):
 
     def get_hit_descriptions(self, ids, transformed=True, **kwargs):
         cols = kwargs.get("columns")
-        self.transform_category.maybe_add_accessory_col_for_query(
-            cols, transformed)
+        self.transform_category.maybe_add_accessory_col_for_query(cols, transformed)
         descriptions = self.db.vf.get_hit_descriptions(ids, columns=cols)
         if "vf_gene_id" in descriptions:
             descriptions = descriptions.set_index("vf_gene_id", drop=False)
@@ -378,19 +410,24 @@ class VfViewMixin(BaseViewMixin, VfMetadata):
 
     @staticmethod
     def format_vfid(vfid):
-        return f'<a href="http://www.mgc.ac.cn/cgi-bin/VFs/vfs.cgi?VFID={vfid}"'\
-               f'target="_blank">{vfid}</a>'
+        return (
+            f'<a href="http://www.mgc.ac.cn/cgi-bin/VFs/vfs.cgi?VFID={vfid}"'
+            f'target="_blank">{vfid}</a>'
+        )
 
     @staticmethod
     def format_vf_category(category_and_id):
         category, vfcid = category_and_id
-        return f'<a href="http://www.mgc.ac.cn/cgi-bin/VFs/VFcategory.cgi?{vfcid}"'\
-               f'target="_blank">{category}</a>'
+        return (
+            f'<a href="http://www.mgc.ac.cn/cgi-bin/VFs/VFcategory.cgi?{vfcid}"'
+            f'target="_blank">{category}</a>'
+        )
 
     @property
     def transform_category(self):
         return TransformWithAccessoryColumn(
-            "category", "vf_category_id", self.format_vf_category)
+            "category", "vf_category_id", self.format_vf_category
+        )
 
     @property
     def transforms(self):
@@ -398,22 +435,23 @@ class VfViewMixin(BaseViewMixin, VfMetadata):
             Transform(self.object_column, self.format_entry, {"to_url": True}),
             Transform("gb_accession", format_refseqid_to_ncbi),
             Transform("vfid", self.format_vfid),
-            self.transform_category
+            self.transform_category,
         ]
 
 
-class ComparisonViewMixin():
+class ComparisonViewMixin:
     """This class is somewhat of a hack to get pseudo inheritance
     from the correct mixin for views that get the object_type as
     parameter.
     """
+
     type2mixin = {
         "cog": CogViewMixin,
         "pfam": PfamViewMixin,
         "ko": KoViewMixin,
         "orthogroup": OrthogroupViewMixin,
         "amr": AmrViewMixin,
-        "vf": VfViewMixin
+        "vf": VfViewMixin,
     }
 
     mixin = None
@@ -429,14 +467,14 @@ class ComparisonViewMixin():
         return super(ComparisonViewMixin, self).dispatch(request, *args, **kwargs)
 
 
-class GenomesTableMixin():
-
+class GenomesTableMixin:
     _genome_table_help = (
         "This table contains the list of genomes included in the {} and a "
         "summary of their content. <br> Clicking on the genome name "
         "(first column) a second table with the protein content is displayed. "
         "It shows to which contig each protein belongs and provides the link "
-        "to the locus tags. <br> Fasta and gbk files can be downloaded.")
+        "to the locus tags. <br> Fasta and gbk files can be downloaded."
+    )
 
     @property
     def genome_table_help(self):
@@ -447,23 +485,26 @@ class GenomesTableMixin():
 
         filenames_tax_id = self.db.get_filenames_to_taxon_id()
         filenames_tax_id_db = pd.DataFrame.from_dict(list(filenames_tax_id.items()))
-        filenames_tax_id_db.columns = ['filename', 'taxon_id']
-        filenames_tax_id_db.index = list(filenames_tax_id_db['taxon_id'])
+        filenames_tax_id_db.columns = ["filename", "taxon_id"]
+        filenames_tax_id_db.index = list(filenames_tax_id_db["taxon_id"])
         filenames_list = list(filenames_tax_id_db["filename"])
 
         path_template = settings.BLAST_DB_PATH + "/{ext}/{filename}.{ext}"
         link_template = '<a href="{}"> .{{ext}} </a>'.format(path_template)
         for ext in ["faa", "fna", "ffn", "gbk"]:
-            filenames_tax_id_db[f'path_to_{ext}'] = [
+            filenames_tax_id_db[f"path_to_{ext}"] = [
                 link_template.format(filename=filename, ext=ext)
-                for filename in filenames_list]
+                for filename in filenames_list
+            ]
 
         filenames_tax_id_db = filenames_tax_id_db[
-            ["path_to_faa", "path_to_fna", "path_to_ffn", "path_to_gbk"]]
+            ["path_to_faa", "path_to_fna", "path_to_ffn", "path_to_gbk"]
+        ]
         genomes_data = genomes_data.join(filenames_tax_id_db, on="taxon_id")
 
         genomes_data["accession"] = genomes_data[["id", "description"]].apply(
-            format_genome, axis=1)
+            format_genome, axis=1
+        )
 
         data_table_header = [
             "Name",
@@ -476,7 +517,7 @@ class GenomesTableMixin():
             "faa seq",
             "fna seq",
             "ffn seq",
-            "gbk file"
+            "gbk file",
         ]
 
         table_data_accessors = [
@@ -490,12 +531,15 @@ class GenomesTableMixin():
             "path_to_faa",
             "path_to_fna",
             "path_to_ffn",
-            "path_to_gbk"]
+            "path_to_gbk",
+        ]
 
         table_data = genomes_data[table_data_accessors]
 
-        return {"table_data": table_data,
-                "table_headers": data_table_header,
-                "data_table_config": DataTableConfig(),
-                "table_data_accessors": table_data_accessors,
-                "table_help": self.genome_table_help}
+        return {
+            "table_data": table_data,
+            "table_headers": data_table_header,
+            "data_table_config": DataTableConfig(),
+            "table_data_accessors": table_data_accessors,
+            "table_help": self.genome_table_help,
+        }

--- a/webapp/views/object_type_metadata.py
+++ b/webapp/views/object_type_metadata.py
@@ -1,11 +1,15 @@
 from urllib.parse import quote
 
-from views.utils import (format_amr, format_cog, format_ko, format_orthogroup,
-                         format_pfam, missing_mandatory, optional2status)
+from views.utils import format_amr
+from views.utils import format_cog
+from views.utils import format_ko
+from views.utils import format_orthogroup
+from views.utils import format_pfam
+from views.utils import missing_mandatory
+from views.utils import optional2status
 
 
-class BaseObjectMetadata():
-
+class BaseObjectMetadata:
     @property
     @staticmethod
     def is_enabled(self):
@@ -25,7 +29,6 @@ class BaseObjectMetadata():
 
 
 class AmrMetadata(BaseObjectMetadata):
-
     object_type = "amr"
     object_name = "AMR gene"
 
@@ -35,7 +38,6 @@ class AmrMetadata(BaseObjectMetadata):
 
 
 class CogMetadata(BaseObjectMetadata):
-
     object_type = "cog"
     object_name = "COG entry"
     object_name_plural = "COG entries"
@@ -47,7 +49,6 @@ class CogMetadata(BaseObjectMetadata):
 
 
 class KoMetadata(BaseObjectMetadata):
-
     object_type = "ko"
     object_name = "Kegg Ortholog"
 
@@ -57,7 +58,6 @@ class KoMetadata(BaseObjectMetadata):
 
 
 class PfamMetadata(BaseObjectMetadata):
-
     object_type = "pfam"
     object_name = "Pfam domain"
 
@@ -67,7 +67,6 @@ class PfamMetadata(BaseObjectMetadata):
 
 
 class OrthogroupMetadata(BaseObjectMetadata):
-
     object_type = "orthogroup"
     object_name = "Orthologous group"
 
@@ -79,28 +78,24 @@ class OrthogroupMetadata(BaseObjectMetadata):
 
 
 class VfMetadata(BaseObjectMetadata):
-
     object_type = "vf"
     object_name = "Virulence factor"
 
     @staticmethod
     def format_entry(entry, to_url=False):
-        """Will point to the details page as soon as it exists
-        """
+        """Will point to the details page as soon as it exists"""
         if to_url:
-            return f"<a href=\"/fam_vf/{entry}\">{entry}</a>"
+            return f'<a href="/fam_vf/{entry}">{entry}</a>'
         return entry
 
 
 class ModuleMetadata(BaseObjectMetadata):
-
     object_type = "module"
     object_name = "KEGG Module"
 
     @staticmethod
     def format_entry(entry, to_url=False):
-        """Will point to the details page as soon as it exists
-        """
+        """Will point to the details page as soon as it exists"""
         if to_url:
             return f"<a href=/KEGG_module_map/{entry}>{entry}</a>"
         return entry
@@ -111,14 +106,12 @@ class ModuleMetadata(BaseObjectMetadata):
 
 
 class PathwayMetadata(BaseObjectMetadata):
-
     object_type = "pathway"
     object_name = "KEGG Pathway"
 
     @staticmethod
     def format_entry(entry, to_url=False):
-        """Will point to the details page as soon as it exists
-        """
+        """Will point to the details page as soon as it exists"""
         if to_url:
             return f"<a href=/KEGG_mapp_ko/{entry}>{entry}</a>"
         return entry
@@ -129,7 +122,6 @@ class PathwayMetadata(BaseObjectMetadata):
 
 
 class GroupMetadata(BaseObjectMetadata):
-
     object_type = "group"
     object_name = "Genome Group"
     overview_description = "Overview of defined groups of genomes."
@@ -141,28 +133,38 @@ class GroupMetadata(BaseObjectMetadata):
         return entry
 
 
-class MetadataGetter():
-
-    metadata_classes = [AmrMetadata, CogMetadata, KoMetadata, PfamMetadata,
-                        OrthogroupMetadata, VfMetadata, ModuleMetadata,
-                        PathwayMetadata]
+class MetadataGetter:
+    metadata_classes = [
+        AmrMetadata,
+        CogMetadata,
+        KoMetadata,
+        PfamMetadata,
+        OrthogroupMetadata,
+        VfMetadata,
+        ModuleMetadata,
+        PathwayMetadata,
+    ]
 
     _annotations = ["cog", "pfam", "ko", "amr", "vf"]
     _orthology = ["orthogroup"]
 
     def __init__(self):
         self.metadata_instances = [cls() for cls in self.metadata_classes]
-        self.object_type_to_metadata = {obj.object_type: obj
-                                        for obj in self.metadata_instances}
+        self.object_type_to_metadata = {
+            obj.object_type: obj for obj in self.metadata_instances
+        }
 
     def get_annotations_metadata(self):
-        return (self.object_type_to_metadata[object_type]
-                for object_type in self._annotations
-                if self.object_type_to_metadata[object_type].is_enabled)
+        return (
+            self.object_type_to_metadata[object_type]
+            for object_type in self._annotations
+            if self.object_type_to_metadata[object_type].is_enabled
+        )
 
     def get_orthology_metadata(self):
-        return (self.object_type_to_metadata[object_type]
-                for object_type in self._orthology)
+        return (
+            self.object_type_to_metadata[object_type] for object_type in self._orthology
+        )
 
     @property
     def group_metadata(self):

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -14,29 +14,34 @@ def safe_replace(string, search_string, replace_string):
 
 
 title2page = {
-    'Antimicrobial Resistance Gene': ["fam_amr"],
-    'COG Ortholog': ['fam_cog'],
-    'Comparisons: Antimicrobial Resistance': ['amr_comparison'],
-    'Comparisons: Clusters of Orthologous groups (COGs)': ['cog_comparison'],
-    'Comparisons: Kegg Orthologs (KO)': ['ko_comparison'],
-    'Comparisons: PFAM domains': ['pfam_comparison'],
-    'Comparisons: orthologous groups': ['orthogroup_comparison'],
-    'Comparisons: Virulence Factors': ['vf_comparison'],
-    'Genomes': ['genomes'],
-    'Genome alignments: Circos plot': ['circos'],
-    'Genome alignments: Plot region': ['plot_region'],
-    'Genome groups': ['groups'],
-    'Genome overview': ['extract_contigs'],
-    'Homology search: Blast': ['blast'],
-    'Kegg Ortholog': ['fam_ko'],
-    'Kegg metabolic pathways': ['kegg_genomes'],
-    'Kegg module': ['KEGG_module_map'],
-    'Metabolism: kegg based': [
-        'KEGG_mapp_ko', 'kegg', 'kegg_genomes_modules', 'kegg_module',
-        'kegg_module_subcat', 'module_comparison'],
-    'Pfam domain': ['fam_pfam'],
-    'Phylogeny': ['phylogeny_intro'],
-    'Virulence Factor Gene': ["fam_vf"],
+    "Antimicrobial Resistance Gene": ["fam_amr"],
+    "COG Ortholog": ["fam_cog"],
+    "Comparisons: Antimicrobial Resistance": ["amr_comparison"],
+    "Comparisons: Clusters of Orthologous groups (COGs)": ["cog_comparison"],
+    "Comparisons: Kegg Orthologs (KO)": ["ko_comparison"],
+    "Comparisons: PFAM domains": ["pfam_comparison"],
+    "Comparisons: orthologous groups": ["orthogroup_comparison"],
+    "Comparisons: Virulence Factors": ["vf_comparison"],
+    "Genomes": ["genomes"],
+    "Genome alignments: Circos plot": ["circos"],
+    "Genome alignments: Plot region": ["plot_region"],
+    "Genome groups": ["groups"],
+    "Genome overview": ["extract_contigs"],
+    "Homology search: Blast": ["blast"],
+    "Kegg Ortholog": ["fam_ko"],
+    "Kegg metabolic pathways": ["kegg_genomes"],
+    "Kegg module": ["KEGG_module_map"],
+    "Metabolism: kegg based": [
+        "KEGG_mapp_ko",
+        "kegg",
+        "kegg_genomes_modules",
+        "kegg_module",
+        "kegg_module_subcat",
+        "module_comparison",
+    ],
+    "Pfam domain": ["fam_pfam"],
+    "Phylogeny": ["phylogeny_intro"],
+    "Virulence Factor Gene": ["fam_vf"],
 }
 
 page2title = {}
@@ -48,8 +53,9 @@ for value, keys in title2page.items():
 # (e.g. taxid -> organism name) to avoid db queries
 with DB.load_db(settings.BIODB_DB_PATH, settings.BIODB_CONF) as db:
     hsh_config = db.get_config_table(ret_mandatory=True)
-    optional2status = {name: value for name,
-                       (mandatory, value) in hsh_config.items() if not mandatory}
+    optional2status = {
+        name: value for name, (mandatory, value) in hsh_config.items() if not mandatory
+    }
     optional2status["cog"] = optional2status["COG"]
     optional2status["ko"] = optional2status["KEGG"]
     optional2status["module"] = optional2status["KEGG"]
@@ -57,12 +63,15 @@ with DB.load_db(settings.BIODB_DB_PATH, settings.BIODB_CONF) as db:
     optional2status["amr"] = optional2status["AMR"]
     optional2status["vf"] = optional2status["BLAST_vfdb"]
 
-    missing_mandatory = [name for name, (mandatory, value) in hsh_config.items()
-                         if mandatory and not value]
+    missing_mandatory = [
+        name
+        for name, (mandatory, value) in hsh_config.items()
+        if mandatory and not value
+    ]
 
 
 def to_s(f):
-    return "\"" + str(f) + "\""
+    return '"' + str(f) + '"'
 
 
 def format_lst_to_html(lst_elem, add_count=True, format_func=lambda x: x):
@@ -91,13 +100,13 @@ def format_orthogroup(og, to_url=False, from_str=False):
     if not from_str:
         base_str = f"group_{og}"
     if to_url:
-        return f"<a href=\"/orthogroup/{base_str}\">{base_str}</a>"
+        return f'<a href="/orthogroup/{base_str}">{base_str}</a>'
     return base_str
 
 
 def format_locus(locus, to_url=True):
     if to_url:
-        return f"<a href=\"/locusx/{locus}\">{locus}</a>"
+        return f'<a href="/locusx/{locus}">{locus}</a>'
     return locus
 
 
@@ -106,7 +115,7 @@ def format_cog(cog_id, as_url=False, base=None):
         base = f"COG{int(cog_id):04d}"
     if as_url is False:
         return base
-    return f"<a href=\"/fam_cog/{base}\">{base}</a>"
+    return f'<a href="/fam_cog/{base}">{base}</a>'
 
 
 def format_cog_url(cog_id):
@@ -118,7 +127,7 @@ def format_ko(ko_id, as_url=False, base=None):
         base = f"K{int(ko_id):05d}"
     if not as_url:
         return base
-    return f"<a href=\"/fam_ko/{base}\">{base}</a>"
+    return f'<a href="/fam_ko/{base}">{base}</a>'
 
 
 def format_ko_url(ko_id):
@@ -128,7 +137,7 @@ def format_ko_url(ko_id):
 def format_amr(gene, to_url=False):
     if not to_url:
         return gene
-    return f"<a href=\"/fam_amr/{gene}\">{gene}</a>"
+    return f'<a href="/fam_amr/{gene}">{gene}</a>'
 
 
 icon_external_link = '<i class="fas fa-external-link-alt"></i>'
@@ -137,8 +146,10 @@ icon_external_link = '<i class="fas fa-external-link-alt"></i>'
 def format_hmm_url(hmm_id):
     if hmm_id:
         hmm_id = hmm_id.rsplit(".", 1)[0]
-        return f'<a href="https://www.ncbi.nlm.nih.gov/genome/annotation_prok/evidence/{hmm_id}"'\
-               f' target="_blank">{hmm_id}&nbsp{icon_external_link}</a>'  # noqa
+        return (
+            f'<a href="https://www.ncbi.nlm.nih.gov/genome/annotation_prok/evidence/{hmm_id}"'
+            f' target="_blank">{hmm_id}&nbsp{icon_external_link}</a>'
+        )  # noqa
     return hmm_id
 
 
@@ -159,9 +170,12 @@ def format_ko_path(hsh_pathways, ko, as_list=False, with_taxid=None):
             return []
         return "-"
     if with_taxid is None:
-        fmt_lst = (f"<a href=\"/KEGG_mapp_ko/map{i:05d}\">{d}</a>" for i, d in pathways)
+        fmt_lst = (f'<a href="/KEGG_mapp_ko/map{i:05d}">{d}</a>' for i, d in pathways)
     else:
-        fmt_lst = (f"<a href=\"/KEGG_mapp_ko/map{i:05d}/{with_taxid}\">{d}</a>" for i, d in pathways)
+        fmt_lst = (
+            f'<a href="/KEGG_mapp_ko/map{i:05d}/{with_taxid}">{d}</a>'
+            for i, d in pathways
+        )
 
     if as_list:
         return list(fmt_lst)
@@ -170,9 +184,9 @@ def format_ko_path(hsh_pathways, ko, as_list=False, with_taxid=None):
 
 def format_ko_module(module_id, module_desc=None):
     if module_desc is None:
-        return f"<a href=\"/KEGG_module_map/M{module_id:05d}\">M{module_id:05d}</a>"
+        return f'<a href="/KEGG_module_map/M{module_id:05d}">M{module_id:05d}</a>'
     else:
-        return f"<a href=\"/KEGG_module_map/M{module_id:05d}\">{module_desc}</a>"
+        return f'<a href="/KEGG_module_map/M{module_id:05d}">{module_desc}</a>'
 
 
 def format_ko_modules(hsh_modules, ko):
@@ -183,7 +197,7 @@ def format_ko_modules(hsh_modules, ko):
 
 
 def format_refseqid_to_ncbi(seqid):
-    return f"<a href=\"http://www.ncbi.nlm.nih.gov/protein/{seqid}\">{seqid}</a>"
+    return f'<a href="http://www.ncbi.nlm.nih.gov/protein/{seqid}">{seqid}</a>'
 
 
 def format_gene(gene):
@@ -211,12 +225,19 @@ def format_genome(taxid_and_description):
     return f'<a href="/extract_contigs/{taxid}">{description}</a>'
 
 
-class DataTableConfig():
-
-    def __init__(self, table_id="results", ordering=True, paging=True,
-                 export_buttons=True, colvis_button=False, display_index=False,
-                 display_as_datatable=True, selectable=False,
-                 custom_plot_button=False):
+class DataTableConfig:
+    def __init__(
+        self,
+        table_id="results",
+        ordering=True,
+        paging=True,
+        export_buttons=True,
+        colvis_button=False,
+        display_index=False,
+        display_as_datatable=True,
+        selectable=False,
+        custom_plot_button=False,
+    ):
         self.table_id = table_id
         self.ordering = ordering
         self.paging = paging
@@ -235,46 +256,45 @@ class DataTableConfig():
     def buttons(self):
         buttons = []
         if self.colvis_button:
-            buttons.append({"extend": 'colvis', "columns": ':not(.noVis)'})
+            buttons.append({"extend": "colvis", "columns": ":not(.noVis)"})
         if self.export_buttons:
-            buttons.extend([
-                {"extend": 'excel', "title": self.table_id},
-                {"extend": 'csv', "title": self.table_id}
-            ])
+            buttons.extend(
+                [
+                    {"extend": "excel", "title": self.table_id},
+                    {"extend": "csv", "title": self.table_id},
+                ]
+            )
         return buttons
 
     @property
     def dom(self):
         if self.export_buttons or self.colvis_button:
-            return 'lBfrtip'
-        return 'lfrtip'
+            return "lBfrtip"
+        return "lfrtip"
 
     def to_json(self):
         config = {
-                "paging": self.paging,
-                "ordering": self.ordering,
-                "info": False,
-                "buttons": self.buttons,
-                "dom": self.dom,
-                "display_as_datatable": self.display_as_datatable,
-                "custom_plot_button": self.custom_plot_button,
-            }
+            "paging": self.paging,
+            "ordering": self.ordering,
+            "info": False,
+            "buttons": self.buttons,
+            "dom": self.dom,
+            "display_as_datatable": self.display_as_datatable,
+            "custom_plot_button": self.custom_plot_button,
+        }
         if self.selectable:
             config["select"] = {
-                "items": 'row',
-                "style": 'os',
+                "items": "row",
+                "style": "os",
                 "headerCheckbox": True,
             }
-            config["columnDefs"] = [{
-                "orderable": False,
-                "render": ["select"],
-                "target": 0
-            }]
+            config["columnDefs"] = [
+                {"orderable": False, "render": ["select"], "target": 0}
+            ]
         return json.dumps(config, cls=DjangoJSONEncoder)
 
 
-class ResultTab():
-
+class ResultTab:
     def __init__(self, tabid, title, template, show_badge=False, badge=None, **kwargs):
         self.id = tabid
         self.title = title
@@ -286,27 +306,41 @@ class ResultTab():
 
 
 class TabularResultTab(ResultTab):
-
-    def __init__(self, tabid, title, template="chlamdb/result_table.html",
-                 ordering=True, paging=True, export_buttons=True,
-                 colvis_button=False, display_index=False,
-                 show_badge=False, selectable=False, custom_plot_button=False,
-                 **kwargs):
+    def __init__(
+        self,
+        tabid,
+        title,
+        template="chlamdb/result_table.html",
+        ordering=True,
+        paging=True,
+        export_buttons=True,
+        colvis_button=False,
+        display_index=False,
+        show_badge=False,
+        selectable=False,
+        custom_plot_button=False,
+        **kwargs,
+    ):
         self.data_table_config = DataTableConfig(
-            table_id=tabid, ordering=ordering, paging=paging,
-            export_buttons=export_buttons, colvis_button=colvis_button,
-            display_index=display_index, selectable=selectable,
-            custom_plot_button=custom_plot_button)
+            table_id=tabid,
+            ordering=ordering,
+            paging=paging,
+            export_buttons=export_buttons,
+            colvis_button=colvis_button,
+            display_index=display_index,
+            selectable=selectable,
+            custom_plot_button=custom_plot_button,
+        )
         if show_badge:
             badge = len(kwargs["table_data"])
         else:
             badge = None
         super(TabularResultTab, self).__init__(
-            tabid, title, template, show_badge=show_badge, badge=badge, **kwargs)
+            tabid, title, template, show_badge=show_badge, badge=badge, **kwargs
+        )
 
 
-class EntryIdParser():
-
+class EntryIdParser:
     og_re = re.compile("group_([0-9]*)")
     cog_re = re.compile("COG([0-9]{4})")
     pfam_re = re.compile("PF([0-9]{4,5})")
@@ -358,7 +392,7 @@ def locusx_genomic_region(db, seqid, window):
     is_circular = contig_topology == "circular"
     df_seqids = db.get_features_location(bioentry, search_on="bioentry_id")
 
-    if 2*window >= contig_size:
+    if 2 * window >= contig_size:
         window_start = 0
         window_stop = contig_size
     elif window_start < 0 and not is_circular:
@@ -369,9 +403,9 @@ def locusx_genomic_region(db, seqid, window):
         df_seqids = df_seqids[df_seqids.end_pos > window_start]
     elif window_start < 0:
         # circular contig
-        diff = contig_size+window_start
-        mask_circled = (df_seqids.end_pos >= diff)
-        mask_same = (df_seqids.start_pos <= window_stop)
+        diff = contig_size + window_start
+        mask_circled = df_seqids.end_pos >= diff
+        mask_same = df_seqids.start_pos <= window_stop
 
         df_seqids.loc[mask_same, "start_pos"] -= window_start
         df_seqids.loc[mask_same, "end_pos"] -= window_start
@@ -389,20 +423,20 @@ def locusx_genomic_region(db, seqid, window):
 
     elif window_stop > contig_size:
         # circular contig
-        diff = window_stop-contig_size
+        diff = window_stop - contig_size
 
-        mask_same = (df_seqids.end_pos >= window_start)
-        mask_circled = (df_seqids.start_pos <= diff)
+        mask_same = df_seqids.end_pos >= window_start
+        mask_circled = df_seqids.start_pos <= diff
 
         df_seqids.loc[mask_same, "start_pos"] -= diff
         df_seqids.loc[mask_same, "end_pos"] -= diff
-        df_seqids.loc[mask_circled, "start_pos"] += (contig_size-diff)
-        df_seqids.loc[mask_circled, "end_pos"] += (contig_size-diff)
+        df_seqids.loc[mask_circled, "start_pos"] += contig_size - diff
+        df_seqids.loc[mask_circled, "end_pos"] += contig_size - diff
         df_seqids = df_seqids.loc[mask_same | mask_circled]
         window_start -= diff
         window_stop = contig_size
     else:
-        df_seqids = df_seqids[(df_seqids.end_pos>window_start)]
+        df_seqids = df_seqids[(df_seqids.end_pos > window_start)]
         df_seqids = df_seqids[(df_seqids.start_pos < window_stop)]
 
     if len(df_seqids) != len(df_seqids["seqfeature_id"].unique()):
@@ -411,22 +445,27 @@ def locusx_genomic_region(db, seqid, window):
         # and stored as two separate genes with the same seqid in BioSQL.
         # If we want to display the whole contig as a continuous sequence, it is necessary
         # to detect this and manually merge this overlapping gene.
-        grouped = df_seqids[["seqfeature_id", "strand", "end_pos",
-                             "start_pos"]].groupby("seqfeature_id")
+        grouped = df_seqids[
+            ["seqfeature_id", "strand", "end_pos", "start_pos"]
+        ].groupby("seqfeature_id")
         start = grouped["start_pos"].min()
         end = grouped["end_pos"].max()
         strands = df_seqids[["seqfeature_id", "strand", "bioentry_id"]].drop_duplicates(
-            "seqfeature_id")
-        df_seqids = start.to_frame().join(end).join(
-            strands.set_index("seqfeature_id"))
+            "seqfeature_id"
+        )
+        df_seqids = start.to_frame().join(end).join(strands.set_index("seqfeature_id"))
     else:
         df_seqids = df_seqids.set_index("seqfeature_id")
 
     # Some parts are redundant with get_features_location
     # those two function should be merged at some point
-    infos = db.get_proteins_info(df_seqids.index.tolist(),
-                                 to_return=["gene", "locus_tag", "product"],
-                                 as_df=True, inc_non_CDS=True, inc_pseudo=True)
+    infos = db.get_proteins_info(
+        df_seqids.index.tolist(),
+        to_return=["gene", "locus_tag", "product"],
+        as_df=True,
+        inc_non_CDS=True,
+        inc_pseudo=True,
+    )
     cds_type = db.get_CDS_type(df_seqids.index.tolist())
     all_infos = infos.join(cds_type)
     all_infos = all_infos.join(df_seqids)
@@ -444,11 +483,13 @@ def genomic_region_df_to_js(df, start, end, contig_size, contig_topology, name=N
             feature_type = "pseudo"
 
         prod = to_s(data["product"])
-        features.append((
-            f"{{start: {data.start_pos}, gene: {to_s(feature_name)}, end: {data.end_pos},"
-            f"strand: {data.strand}, type: {to_s(feature_type)}, product: {prod},"
-            f"locus_tag: {to_s(data.locus_tag)}}}"
-        ))
+        features.append(
+            (
+                f"{{start: {data.start_pos}, gene: {to_s(feature_name)}, end: {data.end_pos},"
+                f"strand: {data.strand}, type: {to_s(feature_type)}, product: {prod},"
+                f"locus_tag: {to_s(data.locus_tag)}}}"
+            )
+        )
     features_str = "[" + ",".join(features) + "]"
     genome_name = ""
     if name is not None:
@@ -458,9 +499,9 @@ def genomic_region_df_to_js(df, start, end, contig_size, contig_topology, name=N
             features: {features_str}}}"
 
 
-def make_div(figure_or_data, include_plotlyjs=False, show_link=False,
-             div_id=None):
+def make_div(figure_or_data, include_plotlyjs=False, show_link=False, div_id=None):
     from plotly import offline
+
     div = offline.plot(
         figure_or_data,
         include_plotlyjs=include_plotlyjs,
@@ -480,8 +521,7 @@ def make_div(figure_or_data, include_plotlyjs=False, show_link=False,
     return div
 
 
-class AccessionFieldHandler():
-
+class AccessionFieldHandler:
     plasmid_prefix = "plasmid:"
     group_prefix = "group:"
     _db = None
@@ -517,8 +557,13 @@ class AccessionFieldHandler():
             self._db = DB.load_db_from_name(biodb_path)
         return self._db
 
-    def get_choices(self, with_plasmids=True, with_groups=True,
-                    exclude=[], exclude_taxids_in_groups=[]):
+    def get_choices(
+        self,
+        with_plasmids=True,
+        with_groups=True,
+        exclude=[],
+        exclude_taxids_in_groups=[],
+    ):
         result = self.db.get_genomes_description()
         result.set_index(result.index.astype(str), inplace=True)
         accession_choices = []
@@ -527,16 +572,20 @@ class AccessionFieldHandler():
             if with_plasmids and data.has_plasmid:
                 # Distinguish plasmids from taxons
                 plasmid = self.plasmid_id_to_key(taxid)
-                accession_choices.append((plasmid,
-                                          f"{data.description} plasmid"))
+                accession_choices.append((plasmid, f"{data.description} plasmid"))
         if with_groups:
-            accession_choices.extend([(self.group_id_to_key(group[0]), group[0])
-                                      for group in self.db.get_groups()])
+            accession_choices.extend(
+                [
+                    (self.group_id_to_key(group[0]), group[0])
+                    for group in self.db.get_groups()
+                ]
+            )
 
         exclude = set(exclude)
         # We also exclude taxids contained in the excluded groups
-        groups_to_exclude = [self.group_key_to_id(key) for key in exclude
-                             if self.is_group(key)]
+        groups_to_exclude = [
+            self.group_key_to_id(key) for key in exclude if self.is_group(key)
+        ]
         if groups_to_exclude:
             in_groups = self.db.get_taxids_for_groups(groups_to_exclude)
             exclude = exclude.union({str(el) for el in in_groups})
@@ -545,19 +594,27 @@ class AccessionFieldHandler():
         taxids_to_exclude = list(filter(self.is_taxid, exclude))
         if taxids_to_exclude:
             exclude = exclude.union(
-                {self.group_id_to_key(groupid) for groupid in
-                 self.db.get_groups_containing_taxids(taxids_to_exclude)})
+                {
+                    self.group_id_to_key(groupid)
+                    for groupid in self.db.get_groups_containing_taxids(
+                        taxids_to_exclude
+                    )
+                }
+            )
 
         # Finally we exclude taxids from groups in exclude_taxids_in_groups
-        groups_to_exclude = [self.group_key_to_id(key)
-                             for key in exclude_taxids_in_groups
-                             if self.is_group(key)]
+        groups_to_exclude = [
+            self.group_key_to_id(key)
+            for key in exclude_taxids_in_groups
+            if self.is_group(key)
+        ]
         if groups_to_exclude:
             in_groups = self.db.get_taxids_for_groups(groups_to_exclude)
             exclude = exclude.union({str(el) for el in in_groups})
 
-        accession_choices = filter(lambda choice: choice[0] not in exclude,
-                                   accession_choices)
+        accession_choices = filter(
+            lambda choice: choice[0] not in exclude, accession_choices
+        )
         return tuple(accession_choices)
 
     def extract_taxid(self, index):
@@ -589,6 +646,8 @@ def get_genomes_data(db, taxids=None):
     genomes_data = genomes_data.join(genomes_descr)
 
     genomes_data.gc = genomes_data.gc.apply(lambda x: round(100 * x))
-    genomes_data.coding_density = genomes_data.coding_density.apply(lambda x: round(100 * x))
+    genomes_data.coding_density = genomes_data.coding_density.apply(
+        lambda x: round(100 * x)
+    )
     genomes_data.length = genomes_data.length.apply(lambda x: round(x / pow(10, 6), 2))
     return genomes_data

--- a/webapp/views/venn.py
+++ b/webapp/views/venn.py
@@ -1,21 +1,22 @@
-
 from chlamdb.forms import make_venn_from
 from django.shortcuts import render
 from django.views import View
-
 from views.analysis_view_metadata import VennMetadata
 from views.errors import errors
-from views.mixins import (AmrViewMixin, CogViewMixin, KoViewMixin,
-                          OrthogroupViewMixin, PfamViewMixin, VfViewMixin)
+from views.mixins import AmrViewMixin
+from views.mixins import CogViewMixin
+from views.mixins import KoViewMixin
+from views.mixins import OrthogroupViewMixin
+from views.mixins import PfamViewMixin
+from views.mixins import VfViewMixin
 
 
 def escape_quotes(unsafe):
-    return unsafe.replace("\"", "\\\"")
+    return unsafe.replace('"', '\\"')
 
 
 class VennBaseView(View):
-
-    template = 'chlamdb/venn_generic.html'
+    template = "chlamdb/venn_generic.html"
     _metadata_cls = VennMetadata
     _table_data_descr = "The table contains a list of the {0}, their {1}."
 
@@ -24,20 +25,23 @@ class VennBaseView(View):
         return f"venn_{self.object_type}"
 
     def dispatch(self, request, *args, **kwargs):
-        self.form_class = make_venn_from(self.db, label=self.object_name_plural,
-                                         limit=6, action=self.view_name)
+        self.form_class = make_venn_from(
+            self.db, label=self.object_name_plural, limit=6, action=self.view_name
+        )
         return super(VennBaseView, self).dispatch(request, *args, **kwargs)
 
     def get_context(self, **kwargs):
         context = super(VennBaseView, self).get_context(**kwargs)
         if getattr(self, "show_results", False):
-            context.update({
-                "show_results": True,
-                "table_headers": self.table_headers,
-                "table_data_descr": self.table_data_descr,
-                "series": self.series,
-                "data_dict": self.data_dict,
-                })
+            context.update(
+                {
+                    "show_results": True,
+                    "table_headers": self.table_headers,
+                    "table_data_descr": self.table_data_descr,
+                    "series": self.series,
+                    "data_dict": self.data_dict,
+                }
+            )
         return context
 
     def get(self, request, *args, **kwargs):
@@ -60,18 +64,22 @@ class VennBaseView(View):
         genomes = self.db.get_genomes_description()
         counts = self.get_hit_counts(self.targets)
         if counts.empty:
-            return render(request, self.template,
-                          self.get_context(**errors["no_hits"]))
+            return render(request, self.template, self.get_context(**errors["no_hits"]))
 
         counts = self.prepare_data(counts, genomes)
 
         self.series = []
         for taxon, taxon_counts in counts.items():
-            self.series.append({
-                "name": genomes.loc[int(taxon)].description,
-                "data": [self.format_entry(key)
-                         for key, cnt in taxon_counts.items() if cnt > 0]
-                })
+            self.series.append(
+                {
+                    "name": genomes.loc[int(taxon)].description,
+                    "data": [
+                        self.format_entry(key)
+                        for key, cnt in taxon_counts.items()
+                        if cnt > 0
+                    ],
+                }
+            )
         context = self.get_context()
         return render(request, self.template, context)
 
@@ -83,8 +91,7 @@ class VennBaseView(View):
         data, counts = self.filter_data(data, counts)
         self.data_dict = {}
         for key, info in data.iterrows():
-            row = [info[accessor]
-                   for accessor in self.table_data_accessors]
+            row = [info[accessor] for accessor in self.table_data_accessors]
             row = [el if el is not None else "-" for el in row]
             self.data_dict[self.format_entry(key)] = row
 
@@ -94,26 +101,23 @@ class VennBaseView(View):
     @property
     def table_data_descr(self):
         return self._table_data_descr.format(
-            self.object_name_plural, self._format_column_headers_to_str())
+            self.object_name_plural, self._format_column_headers_to_str()
+        )
 
 
 class VennOrthogroupView(VennBaseView, OrthogroupViewMixin):
-
     pass
 
 
 class VennPfamView(VennBaseView, PfamViewMixin):
-
     pass
 
 
 class VennKoView(VennBaseView, KoViewMixin):
-
     pass
 
 
 class VennSubsetBaseView(VennBaseView):
-
     def dispatch(self, request, category, *args, **kwargs):
         self.category = category.replace("+", " ")
         self.request = request
@@ -122,7 +126,7 @@ class VennSubsetBaseView(VennBaseView):
     def get(self, request, *args, **kwargs):
         self.form = self.form_class()
         try:
-            self.targets = [int(i) for i in self.request.GET.getlist('h')]
+            self.targets = [int(i) for i in self.request.GET.getlist("h")]
         except Exception:
             return render(request, self.template, self.get_context())
 
@@ -133,12 +137,12 @@ class VennSubsetBaseView(VennBaseView):
 
 
 class VennKoSubsetView(VennSubsetBaseView, KoViewMixin):
-
     table_data_accessors = ["ko", "description"]
 
     def get_hit_counts(self, targets):
         counts = self.db.get_ko_count_cat(
-            taxon_ids=targets, subcategory_name=self.category, index=False)
+            taxon_ids=targets, subcategory_name=self.category, index=False
+        )
         counts = counts.drop("module_id", axis=1)
         counts = counts.drop_duplicates(subset=["taxon_id", "KO"])
         counts = counts.set_index(["taxon_id", "KO"])
@@ -147,23 +151,19 @@ class VennKoSubsetView(VennSubsetBaseView, KoViewMixin):
 
 
 class VennCogView(VennBaseView, CogViewMixin):
-
     def filter_data(self, data, counts):
         return data, counts.reindex(data.index)
 
 
 class VennCogSubsetView(VennSubsetBaseView, VennCogView):
-
     def filter_data(self, data, counts):
         filtered_data = data[data.function.str.contains(self.category)]
         return (filtered_data, counts.reindex(filtered_data.index))
 
 
 class VennAmrView(VennBaseView, AmrViewMixin):
-
     pass
 
 
 class VennVfView(VennBaseView, VfViewMixin):
-
     pass


### PR DESCRIPTION
It seems libsqlite 3.49.1 does not support using double quotes for strings in the SQL queries. Single quotes is actually the correct way to define strings in SQL, so we (hopefully) fixed all such SQL queries here.

## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

