### PR TITLE
Fix accession in contig tab of locusx view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Common Changelog](https://common-changelog.org)
 ### Fixed
 
 - Fix SQL queries for libsqlite 3.49.1. ([#151](https://github.com/metagenlab/zDB/pull/151)) (Niklaus Johner)
+-  Fix accession in contig tab of locusx view. ([#153](https://github.com/metagenlab/zDB/pull/153)) (Niklaus Johner)
 
 ### Changed
 

--- a/webapp/views/locus.py
+++ b/webapp/views/locus.py
@@ -107,13 +107,13 @@ def tab_general(db, seqid):
 
 
 def tab_contig(db, seqid):
-    bioentry, _, contig_size, _ = db.get_bioentry_list(seqid, search_on="seqid")
+    bioentry, accession, contig_size, _ = db.get_bioentry_list(seqid, search_on="seqid")
     qualifiers = db.get_bioentry_qualifiers(bioentry).set_index("term")["value"]
     return {
         "contig_size": contig_size,
         "contig_topology": qualifiers["topology"],
         "contig_is_plasmid": qualifiers["plasmid"] == "1",
-        "contig_accession": qualifiers["accessions"],
+        "contig_accession": accession,
     }
 
 


### PR DESCRIPTION
Some contigs have several accessions which broke the representation of the accession. We could have fixed it to display all accessions associated with a contig, but I do not see the point, so instead we just show the one from the bioentry table.

**Before**
![contig _accession_broken](https://github.com/user-attachments/assets/46a5e5b0-a36c-4029-bcb3-f1b61b475676)

**After**
![contig_accession_fixed](https://github.com/user-attachments/assets/88a04b51-0e67-405f-8c8a-9676f0109547)


## Checklist
- [x] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

