### PR TITLE
Add genomic island predictions and views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,10 +66,10 @@ to [Common Changelog](https://common-changelog.org)
 ### Fixed
 
 - Fix binding of folders when running with singularity. ([#116](https://github.com/metagenlab/zDB/pull/116)) (Niklaus Johner)
-- Fix checkM conda environment. ([#114](https://github.com/metagenlab/zDB/pull/114)
-- Fix AMRFinderPlus database update for Linux. ([#113](https://github.com/metagenlab/zDB/pull/113)
-- Fix AMRFinderPlus database update for Linux. ([#113](https://github.com/metagenlab/zDB/pull/113)
-- Update containers zDB release v 1.3. ([#112](https://github.com/metagenlab/zDB/pull/112)
+- Fix checkM conda environment. ([#114](https://github.com/metagenlab/zDB/pull/114)) (Niklaus Johner)
+- Fix AMRFinderPlus database update for Linux. ([#113](https://github.com/metagenlab/zDB/pull/113)) (Niklaus Johner)
+- Fix AMRFinderPlus database update for Linux. ([#113](https://github.com/metagenlab/zDB/pull/113)) (Niklaus Johner)
+- Update containers zDB release v 1.3. ([#112](https://github.com/metagenlab/zDB/pull/112)) (Niklaus Johner)
 
 
 ## 1.3.0 - 2024-07-11 (broken release as containers are outdated)
@@ -77,7 +77,7 @@ to [Common Changelog](https://common-changelog.org)
 ### Changed
 
 - Update the documentation. ([#110](https://github.com/metagenlab/zDB/pull/110)) (Niklaus Johner)
-- Execute tblastn search against the fna (contigs) database. ([#106](https://github.com/metagenlab/zDB/pull/106)
+- Execute tblastn search against the fna (contigs) database. ([#106](https://github.com/metagenlab/zDB/pull/106)) (Niklaus Johner)
 - Handle groups when selecting genomes wherever pertinent. ([#84](https://github.com/metagenlab/zDB/pull/84) and [#85](https://github.com/metagenlab/zDB/pull/85)) (Niklaus Johner)
 - Allow using groups to define phenotype in GWAS view. ([#82](https://github.com/metagenlab/zDB/pull/82)) (Niklaus Johner)
 - Display form validation errors next to the corresponding fields. ([#83](https://github.com/metagenlab/zDB/pull/83)) (Niklaus Johner)
@@ -132,8 +132,8 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
-- Fix filtering of COGs in annotation pipeline. ([#108](https://github.com/metagenlab/zDB/pull/108)
-- Fix blast view for hits with identifier containing a version number. ([#106](https://github.com/metagenlab/zDB/pull/106)
+- Fix filtering of COGs in annotation pipeline. ([#108](https://github.com/metagenlab/zDB/pull/108)) (Niklaus Johner)
+- Fix blast view for hits with identifier containing a version number. ([#106](https://github.com/metagenlab/zDB/pull/106)) (Niklaus Johner)
 - Fix PFAM identifiers missing leading 0. ([#105](https://github.com/metagenlab/zDB/pull/105)) (Niklaus Johner)
 - Fix product representation in GWAS view for orthogroups. ([#102](https://github.com/metagenlab/zDB/pull/102)) (Niklaus Johner)
 - Fix Scoary-2 integration. ([#101](https://github.com/metagenlab/zDB/pull/101)) (Niklaus Johner)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ to [Common Changelog](https://common-changelog.org)
 
 - Use up to date KEGG database as reference. ([#157](https://github.com/metagenlab/zDB/pull/157)) (Niklaus Johner)
 - Fix SQL queries for libsqlite 3.49.1. ([#151](https://github.com/metagenlab/zDB/pull/151)) (Niklaus Johner)
--  Fix accession in contig tab of locusx view. ([#153](https://github.com/metagenlab/zDB/pull/153)) (Niklaus Johner)
+- Fix accession in contig tab of locusx view. ([#153](https://github.com/metagenlab/zDB/pull/153)) (Niklaus Johner)
 
 ### Changed
 
@@ -20,6 +20,8 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Added
 
+- Add basic views for genomic islands (entry list and details view). ([#158](https://github.com/metagenlab/zDB/pull/158)) (Niklaus Johner)
+- Add genomic island prediction to annotation pipeline. ([#158](https://github.com/metagenlab/zDB/pull/158)) (Niklaus Johner)
 - Add command line parameter to set CSRF_TRUSTED_ORIGINS. ([#145](https://github.com/metagenlab/zDB/pull/145)) (Niklaus Johner)
 
 ## 1.3.4 - 2024-11-06

--- a/bin/setup_chlamdb.py
+++ b/bin/setup_chlamdb.py
@@ -851,6 +851,7 @@ def load_gis(params, gff_files, db_name):
             for el in genomic_islands
         ]
     )
+    db.set_status_in_config_table("GIS", 1)
     db.commit()
 
 

--- a/bin/zdb
+++ b/bin/zdb
@@ -516,6 +516,10 @@ elif [[ "$1" == "run" ]]; then
 				args="${args} --vf_coverage=${vf_coverage}"
 				shift
 				;;
+			--gi)
+				args="${args} --gi"
+				shift
+				;;
 			--singularity_dir=*)
 				singularity_dir=$(realpath ${i#*=})
 				shift
@@ -544,6 +548,7 @@ elif [[ "$1" == "run" ]]; then
 				echo " --vf_evalue: evalue cutoff for the blast against the VF database. Defaults to 1e-10."
 				echo " --vf_coverage: coverage cutoff for query in blast against the VF database. Defaults to 60%."
 				echo " --vf_seqid: sequence id cutoff for filtering VF blast results. Defaults to 60%."
+				echo " --gi: perform gi (genomic islands) annotation"
 				echo " --ref_dir: directory where the reference databases were setup up (default zdb_ref)"
 				echo " --cpu: number of parallel processes allowed (default 8)"
 				echo " --mem: max memory usage allowed (default 8GB)"

--- a/conda/islandpath.yaml
+++ b/conda/islandpath.yaml
@@ -1,0 +1,7 @@
+name: islandpath
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - bioconda::islandpath=1.0.6
+  - bioconda::perl-bioperl=1.7.2

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,6 +26,7 @@ params.pfam = false
 params.amr = false
 params.vfdb = false
 params.setup_base_db = false
+params.gi = false
 
 params.checkm_args = "domain Bacteria"
 
@@ -79,7 +80,7 @@ params.diamond_container = "registry.hub.docker.com/buchfink/diamond:version2.0.
 params.mafft_container = "quay.io/biocontainers/mafft:7.487--h779adbc_0"
 params.fasttree_container = "quay.io/biocontainers/fasttree:2.1.8--h779adbc_6"
 params.ncbi_amr_container = "registry.hub.docker.com/ncbi/amr:4.0.3-2024-10-22.1"
-
+params.islandpath_container = "quay.io/biocontainers/islandpath:1.0.6--hdfd78af_0"
 
 /////////////////////////////
 ///// EXECUTION CONTROL /////

--- a/utils/setup_base_db.py
+++ b/utils/setup_base_db.py
@@ -71,6 +71,7 @@ def create_data_table(db):
         ("gbk_files", "optional", False),
         ("AMR", "optional", False),
         ("BLAST_vfdb", "optional", False),
+        ("GIS", "optional", False),
     ]
     db.load_chlamdb_config_tables(entry_list)
     db.commit()

--- a/webapp/assets/css/style_FILE_zDB.css
+++ b/webapp/assets/css/style_FILE_zDB.css
@@ -514,7 +514,7 @@ form div.error span.help-inline {
     position: relative;
     background-color: rgba(37, 194, 121, 0);
     margin-top: 1em;
-    width: 9em;
+    width: 8em;
     height: 4em; 
     box-sizing: border-box;
     font-weight:300;

--- a/webapp/chlamdb/urls.py
+++ b/webapp/chlamdb/urls.py
@@ -204,6 +204,9 @@ urlpatterns = [
         r"^entry_list_ko$", entry_lists.KoEntryListView.as_view(), name="entry_list_ko"
     ),  # noqa
     re_path(
+        r"^entry_list_gi$", entry_lists.GiEntryListView.as_view(), name="entry_list_gi"
+    ),  # noqa
+    re_path(
         r"^entry_list_cog$",
         entry_lists.CogEntryListView.as_view(),
         name="entry_list_cog",

--- a/webapp/chlamdb/urls.py
+++ b/webapp/chlamdb/urls.py
@@ -5,6 +5,7 @@ from views import autocomplete
 from views import custom_plots
 from views import entry_lists
 from views import fam
+from views import genomic_island
 from views import groups
 from views import gwas
 from views import hits_extraction
@@ -149,6 +150,11 @@ urlpatterns = [
         views.get_cog,
         name="get_cog",
     ),  # noqa
+    re_path(
+        r"^genomic_island/([a-zA-Z0-9_\.]+)",
+        genomic_island.GenomicIsland.as_view(),
+        name=genomic_island.GenomicIsland.view_name,
+    ),
     re_path(r"^genomes", views.Genomes.as_view(), name=views.Genomes.view_name),
     re_path(r"^favicon\.ico$", favicon_view),
     re_path(r"^FAQ", views.faq, name="FAQ"),

--- a/webapp/lib/db_utils.py
+++ b/webapp/lib/db_utils.py
@@ -2577,6 +2577,13 @@ class DB:
         ]
         self.server.adaptor.executemany(sql, data)
 
+    def load_genomic_islands(self, data):
+        sql = "CREATE TABLE genomic_islands (gis_id INTEGER PRIMARY KEY, bioentry_id INTEGER, start_pos integer, end_pos integer);"
+        self.server.adaptor.execute(
+            sql,
+        )
+        self.load_data_into_table("genomic_islands", data)
+
     def load_amr_hits(self, data):
         sql = (
             "CREATE TABLE amr_hits (hsh INTEGER, gene varchar(20), seq_name tinytext, "

--- a/webapp/lib/db_utils.py
+++ b/webapp/lib/db_utils.py
@@ -3,6 +3,7 @@ import sqlite3
 import pandas as pd
 from Bio.Seq import Seq
 from BioSQL import BioSeqDatabase
+from lib.queries import GIQueries
 from lib.queries import VFQueries
 
 # This file defines a class DB, that encapsulates all the SQL requests
@@ -38,6 +39,7 @@ class DB:
         # this will need to be changed in case a MySQL database is used
         self.placeholder = "?"
         self.vf = VFQueries(self)
+        self.gi = GIQueries(self)
 
     # the next two methods are necessary for DB objects to be used
     # in 'with' blocks.
@@ -2588,14 +2590,6 @@ class DB:
             sql,
         )
         self.load_data_into_table("genomic_islands", data)
-
-    def get_genomic_island(self, entry_id):
-        sql = "SELECT gis_id, bioentry_id, start_pos, end_pos FROM genomic_islands WHERE gis_id=?"
-        return self.server.adaptor.execute_and_fetchall(sql, [entry_id])[0]
-
-    def get_containing_genomic_islands(self, bioentry_id, start, stop):
-        sql = "SELECT gis_id, start_pos, end_pos FROM genomic_islands WHERE bioentry_id=? AND (? BETWEEN start_pos AND end_pos OR ? BETWEEN start_pos AND end_pos)"
-        return self.server.adaptor.execute_and_fetchall(sql, [bioentry_id, start, stop])
 
     def load_amr_hits(self, data):
         sql = (

--- a/webapp/lib/db_utils.py
+++ b/webapp/lib/db_utils.py
@@ -2584,6 +2584,10 @@ class DB:
         )
         self.load_data_into_table("genomic_islands", data)
 
+    def get_genomic_island(self, entry_id):
+        sql = "SELECT gis_id, bioentry_id, start_pos, end_pos FROM genomic_islands WHERE gis_id=?"
+        return self.server.adaptor.execute_and_fetchall(sql, [entry_id])[0]
+
     def get_containing_genomic_islands(self, bioentry_id, start, stop):
         sql = "SELECT gis_id, start_pos, end_pos FROM genomic_islands WHERE bioentry_id=? AND (? BETWEEN start_pos AND end_pos OR ? BETWEEN start_pos AND end_pos)"
         return self.server.adaptor.execute_and_fetchall(sql, [bioentry_id, start, stop])

--- a/webapp/lib/db_utils.py
+++ b/webapp/lib/db_utils.py
@@ -2133,6 +2133,11 @@ class DB:
                 hsh_results[entry_id][func] = cnt + 1
         return hsh_results
 
+    def get_bioentry_length(self, bioentry_id):
+        query = "SELECT length FROM biosequence WHERE bioentry_id = ?;"
+        results = self.server.adaptor.execute_and_fetchall(query, [bioentry_id])
+        return results[0][0]
+
     def get_bioentry_qualifiers(self, bioentry_id):
         query = (
             "SELECT t.name, value.value "

--- a/webapp/lib/db_utils.py
+++ b/webapp/lib/db_utils.py
@@ -2584,6 +2584,10 @@ class DB:
         )
         self.load_data_into_table("genomic_islands", data)
 
+    def get_containing_genomic_islands(self, bioentry_id, start, stop):
+        sql = "SELECT gis_id, start_pos, end_pos FROM genomic_islands WHERE bioentry_id=? AND (? BETWEEN start_pos AND end_pos OR ? BETWEEN start_pos AND end_pos)"
+        return self.server.adaptor.execute_and_fetchall(sql, [bioentry_id, start, stop])
+
     def load_amr_hits(self, data):
         sql = (
             "CREATE TABLE amr_hits (hsh INTEGER, gene varchar(20), seq_name tinytext, "

--- a/webapp/lib/queries.py
+++ b/webapp/lib/queries.py
@@ -1,13 +1,25 @@
-class VFQueries:
-    hit_table = "vf_hits"
-    description_table = "vf_defs"
-    id_col = "vf_gene_id"
-
+class BaseQueries:
     def __init__(self, db):
         self.db = db
 
     def __getattr__(self, key):
         return getattr(self.db, key)
+
+
+class GIQueries(BaseQueries):
+    def get_genomic_island(self, entry_id):
+        sql = "SELECT gis_id, bioentry_id, start_pos, end_pos FROM genomic_islands WHERE gis_id=?"
+        return self.server.adaptor.execute_and_fetchall(sql, [entry_id])[0]
+
+    def get_containing_genomic_islands(self, bioentry_id, start, stop):
+        sql = "SELECT gis_id, start_pos, end_pos FROM genomic_islands WHERE bioentry_id=? AND (? BETWEEN start_pos AND end_pos OR ? BETWEEN start_pos AND end_pos)"
+        return self.server.adaptor.execute_and_fetchall(sql, [bioentry_id, start, stop])
+
+
+class VFQueries(BaseQueries):
+    hit_table = "vf_hits"
+    description_table = "vf_defs"
+    id_col = "vf_gene_id"
 
     def gen_where_clause(self, search_on, entries):
         entries = self.gen_placeholder_string(entries)

--- a/webapp/templates/chlamdb/genomic_island.html
+++ b/webapp/templates/chlamdb/genomic_island.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+
+
+<html>
+<head>
+{% include "chlamdb/header.html" %}
+{% load custom_tags %}
+</head>
+
+<body>
+  <div class="container-fluid" id="main_container">
+    <div class="row">
+      <div id="wrapper">
+        <div id="page-content-wrapper">
+          <div class="row">
+            <div class="col-lg-12">
+              {% include "chlamdb/menu.html" %}
+              <p class="page-title">
+                <b>{{description|safe}}</b>
+              </p>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</body>
+{% include "chlamdb/style_menu.html" %}
+</html>

--- a/webapp/templates/chlamdb/genomic_island.html
+++ b/webapp/templates/chlamdb/genomic_island.html
@@ -1,10 +1,15 @@
 <!DOCTYPE html>
 
+{% load static %}
 
 <html>
 <head>
 {% include "chlamdb/header.html" %}
 {% load custom_tags %}
+
+<script type="text/javascript" src={% static 'js/genomic_region.js' %}>
+</script>
+
 </head>
 
 <body>
@@ -21,6 +26,23 @@
             </div>
 
           </div>
+
+          <div class=row>
+            <div class="panel panel-default">
+              <div class="panel-heading clearfix">
+                <div class="pull-right">
+                  <button id="download_svg_button" class="btn-link btn-xs" style="background-color: transparent;">
+                    <i class="glyphicon glyphicon-download"></i>
+                  </button>
+                </div>
+                <h3 class="panel-title">Genomic island</h3>
+              </div>
+              <div class="panel-body" style="height:100px; display:flex; justify-content:center; align-items:center; margin-bottom:30px" id="genomic_region_rect">
+                <div id="div_genomic_region"></div>
+              </div>
+            </div>
+          </div>
+
         </div>
       </div>
     </div>
@@ -28,4 +50,20 @@
 
 </body>
 {% include "chlamdb/style_menu.html" %}
+
+<script>
+var genomic_region = {{genomic_region|safe}};
+var genomic_region_rect = document.querySelector("#genomic_region_rect")
+    .getBoundingClientRect();
+var genomic_width = genomic_region_rect.right-genomic_region_rect.left;
+
+createGenomicRegion(d3.select("#div_genomic_region"), genomic_width*.8, "genomic_region", [genomic_region],
+    0, ["{{locus_tag}}"], {{window_size}});
+
+document.querySelector("#download_svg_button").onclick = function() {
+  var svg_elem = document.querySelector("#genomic_region");
+  svgExport.downloadSvg(svg_elem, "{{locus_tag}}");
+};
+</script>
+
 </html>

--- a/webapp/templates/chlamdb/home.html
+++ b/webapp/templates/chlamdb/home.html
@@ -32,7 +32,7 @@
                 </div>
 
                 <!-- Images and boxes menu-->
-                <div class="container-fluid" id="main_container" style="width: 90%;">
+                <div class="container-fluid" id="main_container" style="width: 100%; padding-left: 0;">
                   <div class="row">
                     <div class="col-lg-4 col-md-12 col-sm-12" >
                       <div class="serviceBox_2"  >

--- a/webapp/templates/chlamdb/home.html
+++ b/webapp/templates/chlamdb/home.html
@@ -85,6 +85,13 @@
                               </a>VF genes
                             </li>
                           {% endif %}
+                          {% if optional2status|keyvalue:"gi" == 1 %}
+                            <li class="summary_data">
+                              <a href="{% url 'index_comp' 'gi' %}" >
+                                <b>{{number_gi}}  </b>
+                              </a>Genomic islands
+                            </li>
+                          {% endif %}
                           {% if optional2status|keyvalue:"BLAST_swissprot" == 1 %}
                             <li class="summary_data">
                               <b>{{number_swissprot}}  </b>Swissprot homologs

--- a/webapp/templates/chlamdb/locus.html
+++ b/webapp/templates/chlamdb/locus.html
@@ -222,8 +222,8 @@
                               <th>In genomic island</th>
                               <td>
                                 {% if genomic_islands|length > 0 %}
-                                  {% for pos in genomic_islands %}
-                                    {{pos.1}} - {{pos.2}}
+                                  {% for gi in genomic_islands %}
+                                    {{gi|safe}}
                                     {% if genomic_islands|length > 1 %}
                                       <br>
                                     {% endif %}

--- a/webapp/templates/chlamdb/locus.html
+++ b/webapp/templates/chlamdb/locus.html
@@ -217,6 +217,23 @@
                               <td>{{nucl_length}} (nucleotides)</td>
                             {% endif %}
                           </tr>
+                          {% if optional2status|keyvalue:"genomic_islands" %}
+                            <tr>
+                              <th>In genomic island</th>
+                              <td>
+                                {% if genomic_islands|length > 0 %}
+                                  {% for pos in genomic_islands %}
+                                    {{pos.1}} - {{pos.2}}
+                                    {% if genomic_islands|length > 1 %}
+                                      <br>
+                                    {% endif %}
+                                  {% endfor %}
+                                {% else %}
+                                  -
+                                {% endif %}
+                              </td>
+                            </tr>
+                          {% endif %}
                         </table>
                       </div>
                     </div>

--- a/webapp/views/analysis_view_metadata.py
+++ b/webapp/views/analysis_view_metadata.py
@@ -21,7 +21,7 @@ class AnalysisViewMetadata:
 
 class EntryListMetadata(AnalysisViewMetadata):
     name = "index"
-    _types_available_for = ["amr", "cog", "ko", "pfam", "vf"]
+    _types_available_for = ["amr", "cog", "ko", "pfam", "vf", "gi"]
     title = "Index"
     _description = "Index of all {} identified in all genomes"
     _url = "/entry_list_{}"

--- a/webapp/views/entry_lists.py
+++ b/webapp/views/entry_lists.py
@@ -4,6 +4,7 @@ from views.analysis_view_metadata import EntryListMetadata
 from views.mixins import AmrViewMixin
 from views.mixins import BaseViewMixin
 from views.mixins import CogViewMixin
+from views.mixins import GiViewMixin
 from views.mixins import KoViewMixin
 from views.mixins import PfamViewMixin
 from views.mixins import VfViewMixin
@@ -60,6 +61,15 @@ class PfamEntryListView(EntryListViewBase, PfamViewMixin):
 
 class KoEntryListView(EntryListViewBase, KoViewMixin):
     pass
+
+
+class GiEntryListView(EntryListViewBase, GiViewMixin):
+    def get_table_data(self):
+        return self.get_hit_descriptions(None)
+
+    @property
+    def table_data_accessors(self):
+        return super(EntryListViewBase, self).table_data_accessors
 
 
 class CogEntryListView(EntryListViewBase, CogViewMixin):

--- a/webapp/views/genomic_island.py
+++ b/webapp/views/genomic_island.py
@@ -2,6 +2,7 @@ from django.shortcuts import render
 from django.views import View
 from views.mixins import BaseViewMixin
 from views.utils import format_genome
+from views.utils import format_genomic_island
 from views.utils import genomic_region_df_to_js
 from views.utils import locusx_genomic_region
 
@@ -45,5 +46,5 @@ class GenomicIsland(BaseViewMixin, View):
         return (
             f"Genomic island: "
             f"{format_genome((taxon_id, description))} "
-            f"({accession}: {self.start_pos} - {self.end_pos})"
+            f"({format_genomic_island(self.gis_id, accession, self.start_pos, self.end_pos)})"
         )

--- a/webapp/views/genomic_island.py
+++ b/webapp/views/genomic_island.py
@@ -2,6 +2,8 @@ from django.shortcuts import render
 from django.views import View
 from views.mixins import BaseViewMixin
 from views.utils import format_genome
+from views.utils import genomic_region_df_to_js
+from views.utils import locusx_genomic_region
 
 
 class GenomicIsland(BaseViewMixin, View):
@@ -12,11 +14,25 @@ class GenomicIsland(BaseViewMixin, View):
         self.gis_id, self.bioentry_id, self.start_pos, self.end_pos = (
             self.db.get_genomic_island(entry_id)
         )
+        all_infos, wd_start, wd_end, contig_size, contig_topology = (
+            locusx_genomic_region(
+                self.db,
+                bioentry=self.bioentry_id,
+                window_start=self.start_pos,
+                window_stop=self.end_pos,
+            )
+        )
+        genomic_region = genomic_region_df_to_js(
+            all_infos, wd_start, wd_end, contig_size, contig_topology
+        )
+        window_size = wd_end - wd_start
         context = self.get_context(
             entry_id=self.gis_id,
             start_pos=self.start_pos,
             end_pos=self.end_pos,
             description=self.description,
+            genomic_region=genomic_region,
+            window_size=window_size,
         )
         return render(request, self.template, context)
 

--- a/webapp/views/genomic_island.py
+++ b/webapp/views/genomic_island.py
@@ -1,0 +1,33 @@
+from django.shortcuts import render
+from django.views import View
+from views.mixins import BaseViewMixin
+from views.utils import format_genome
+
+
+class GenomicIsland(BaseViewMixin, View):
+    template = "chlamdb/genomic_island.html"
+    view_name = "genomic_island"
+
+    def get(self, request, entry_id, *args, **kwargs):
+        self.gis_id, self.bioentry_id, self.start_pos, self.end_pos = (
+            self.db.get_genomic_island(entry_id)
+        )
+        context = self.get_context(
+            entry_id=self.gis_id,
+            start_pos=self.start_pos,
+            end_pos=self.end_pos,
+            description=self.description,
+        )
+        return render(request, self.template, context)
+
+    @property
+    def description(self):
+        taxon_id, accession, description = self.db.server.adaptor.execute_and_fetchall(
+            "SELECT taxon_id, accession, description from bioentry WHERE bioentry_id=?",
+            [self.bioentry_id],
+        )[0]
+        return (
+            f"Genomic island: "
+            f"{format_genome((taxon_id, description))} "
+            f"({accession}: {self.start_pos} - {self.end_pos})"
+        )

--- a/webapp/views/genomic_island.py
+++ b/webapp/views/genomic_island.py
@@ -13,7 +13,7 @@ class GenomicIsland(BaseViewMixin, View):
 
     def get(self, request, entry_id, *args, **kwargs):
         self.gis_id, self.bioentry_id, self.start_pos, self.end_pos = (
-            self.db.get_genomic_island(entry_id)
+            self.db.gi.get_genomic_island(entry_id)
         )
         all_infos, wd_start, wd_end, contig_size, contig_topology = (
             locusx_genomic_region(

--- a/webapp/views/genomic_island.py
+++ b/webapp/views/genomic_island.py
@@ -13,7 +13,7 @@ class GenomicIsland(BaseViewMixin, View):
 
     def get(self, request, entry_id, *args, **kwargs):
         self.gis_id, self.bioentry_id, self.start_pos, self.end_pos = (
-            self.db.gi.get_genomic_island(entry_id)
+            self.db.gi.get_hit_descriptions([entry_id], as_dataframe=False)[0]
         )
         all_infos, wd_start, wd_end, contig_size, contig_topology = (
             locusx_genomic_region(

--- a/webapp/views/locus.py
+++ b/webapp/views/locus.py
@@ -32,6 +32,7 @@ from views.object_type_metadata import my_locals
 from views.utils import DataTableConfig
 from views.utils import format_gene
 from views.utils import format_genome
+from views.utils import format_genomic_island
 from views.utils import format_locus
 from views.utils import format_orthogroup
 from views.utils import format_pfam
@@ -540,13 +541,18 @@ def tab_og_best_hits(db, orthogroup, locus=None):
 
 
 def get_genomic_island(db, seqid, gene_pos):
-    bioentry, _, _, _ = db.get_bioentry_list(seqid, search_on="seqid")
+    bioentry, accession, _, _ = db.get_bioentry_list(seqid, search_on="seqid")
     genomic_islands = []
     for start, stop, _ in gene_pos:
         genomic_islands.extend(
             db.get_containing_genomic_islands(bioentry, int(start), int(stop))
         )
-    return {"genomic_islands": genomic_islands}
+    return {
+        "genomic_islands": [
+            format_genomic_island(gis_id, accession, start, stop)
+            for gis_id, start, stop in genomic_islands
+        ]
+    }
 
 
 def get_sequence(db, seqid, flanking=0):

--- a/webapp/views/locus.py
+++ b/webapp/views/locus.py
@@ -545,7 +545,7 @@ def get_genomic_island(db, seqid, gene_pos):
     genomic_islands = []
     for start, stop, _ in gene_pos:
         genomic_islands.extend(
-            db.get_containing_genomic_islands(bioentry, int(start), int(stop))
+            db.gi.get_containing_genomic_islands(bioentry, int(start), int(stop))
         )
     return {
         "genomic_islands": [

--- a/webapp/views/locus.py
+++ b/webapp/views/locus.py
@@ -539,6 +539,16 @@ def tab_og_best_hits(db, orthogroup, locus=None):
     return {"best_hits_phylogeny": asset_path, "has_refseq_phylo": True}
 
 
+def get_genomic_island(db, seqid, gene_pos):
+    bioentry, _, _, _ = db.get_bioentry_list(seqid, search_on="seqid")
+    genomic_islands = []
+    for start, stop, _ in gene_pos:
+        genomic_islands.extend(
+            db.get_containing_genomic_islands(bioentry, int(start), int(stop))
+        )
+    return {"genomic_islands": genomic_islands}
+
+
 def get_sequence(db, seqid, flanking=0):
     loc = db.get_gene_loc([seqid], as_hash=False)
     bioentry, accession, length, seq = db.get_bioentry_list(seqid, search_on="seqid")
@@ -732,6 +742,9 @@ class LocusX(ViewBase):
 
         if optional2status.get("BLAST_database", False):
             context.update(tab_get_refseq_homologs(self.db, self.seqid))
+
+        if optional2status.get("genomic_islands", False):
+            context.update(get_genomic_island(self.db, self.seqid, context["gene_pos"]))
 
         context.update(
             {

--- a/webapp/views/locus.py
+++ b/webapp/views/locus.py
@@ -749,7 +749,7 @@ class LocusX(ViewBase):
         if optional2status.get("BLAST_database", False):
             context.update(tab_get_refseq_homologs(self.db, self.seqid))
 
-        if optional2status.get("genomic_islands", False):
+        if optional2status.get("gi", False):
             context.update(get_genomic_island(self.db, self.seqid, context["gene_pos"]))
 
         context.update(

--- a/webapp/views/mixins.py
+++ b/webapp/views/mixins.py
@@ -4,6 +4,7 @@ from lib.db_utils import DB
 from views.analysis_view_metadata import analysis_views_metadata
 from views.object_type_metadata import AmrMetadata
 from views.object_type_metadata import CogMetadata
+from views.object_type_metadata import GiMetadata
 from views.object_type_metadata import KoMetadata
 from views.object_type_metadata import OrthogroupMetadata
 from views.object_type_metadata import PfamMetadata
@@ -439,6 +440,26 @@ class VfViewMixin(BaseViewMixin, VfMetadata):
         ]
 
 
+class GiViewMixin(BaseViewMixin, GiMetadata):
+    object_column = "gis_id"
+
+    _base_colname_to_header_mapping = {
+        "gis_id": "ID",
+        "bioentry_id": "Bioentry",
+        "start_pos": "Start",
+        "end_pos": "End",
+    }
+
+    table_data_accessors = ["gis_id", "bioentry_id", "start_pos", "end_pos"]
+
+    def get_hit_descriptions(self, ids, transformed=True, **kwargs):
+        descriptions = self.db.gi.get_hit_descriptions(ids)
+        descriptions = descriptions.set_index("gis_id", drop=False)
+        if transformed:
+            descriptions = self.transform_data(descriptions)
+        return descriptions
+
+
 class ComparisonViewMixin:
     """This class is somewhat of a hack to get pseudo inheritance
     from the correct mixin for views that get the object_type as
@@ -452,6 +473,7 @@ class ComparisonViewMixin:
         "orthogroup": OrthogroupViewMixin,
         "amr": AmrViewMixin,
         "vf": VfViewMixin,
+        "gi": GiViewMixin,
     }
 
     mixin = None

--- a/webapp/views/object_type_metadata.py
+++ b/webapp/views/object_type_metadata.py
@@ -2,6 +2,7 @@ from urllib.parse import quote
 
 from views.utils import format_amr
 from views.utils import format_cog
+from views.utils import format_genomic_island
 from views.utils import format_ko
 from views.utils import format_orthogroup
 from views.utils import format_pfam
@@ -89,6 +90,15 @@ class VfMetadata(BaseObjectMetadata):
         return entry
 
 
+class GiMetadata(BaseObjectMetadata):
+    object_type = "gi"
+    object_name = "Genomic island"
+
+    @staticmethod
+    def format_entry(entry, to_url=False):
+        return format_genomic_island(entry, to_url=to_url)
+
+
 class ModuleMetadata(BaseObjectMetadata):
     object_type = "module"
     object_name = "KEGG Module"
@@ -141,11 +151,12 @@ class MetadataGetter:
         PfamMetadata,
         OrthogroupMetadata,
         VfMetadata,
+        GiMetadata,
         ModuleMetadata,
         PathwayMetadata,
     ]
 
-    _annotations = ["cog", "pfam", "ko", "amr", "vf"]
+    _annotations = ["cog", "pfam", "ko", "amr", "vf", "gi"]
     _orthology = ["orthogroup"]
 
     def __init__(self):

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -18,6 +18,7 @@ title2page = {
     "COG Ortholog": ["fam_cog"],
     "Comparisons: Antimicrobial Resistance": ["amr_comparison"],
     "Comparisons: Clusters of Orthologous groups (COGs)": ["cog_comparison"],
+    "Comparisons: Genomic Islands": ["gi_comparison"],
     "Comparisons: Kegg Orthologs (KO)": ["ko_comparison"],
     "Comparisons: PFAM domains": ["pfam_comparison"],
     "Comparisons: orthologous groups": ["orthogroup_comparison"],

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -63,7 +63,7 @@ with DB.load_db(settings.BIODB_DB_PATH, settings.BIODB_CONF) as db:
     optional2status["pathway"] = optional2status["KEGG"]
     optional2status["amr"] = optional2status["AMR"]
     optional2status["vf"] = optional2status["BLAST_vfdb"]
-    optional2status["genomic_islands"] = optional2status["GIS"]
+    optional2status["gi"] = optional2status["GIS"]
 
     missing_mandatory = [
         name
@@ -227,8 +227,16 @@ def format_genome(taxid_and_description):
     return f'<a href="/extract_contigs/{taxid}">{description}</a>'
 
 
-def format_genomic_island(gis_id, bioentry_accession, start, end):
-    return f'<a href="/genomic_island/{gis_id}">GI{gis_id} {bioentry_accession}: {start} - {end}</a>'
+def format_genomic_island(
+    gis_id, bioentry_accession=None, start=None, end=None, to_url=False
+):
+    if bioentry_accession is not None:
+        description = f"GI{gis_id} {bioentry_accession}: {start} - {end}"
+    else:
+        description = f"GI{gis_id}"
+    if to_url:
+        return f'<a href="/genomic_island/{gis_id}">{description}</a>'
+    return description
 
 
 class DataTableConfig:

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -62,6 +62,7 @@ with DB.load_db(settings.BIODB_DB_PATH, settings.BIODB_CONF) as db:
     optional2status["pathway"] = optional2status["KEGG"]
     optional2status["amr"] = optional2status["AMR"]
     optional2status["vf"] = optional2status["BLAST_vfdb"]
+    optional2status["genomic_islands"] = optional2status["GIS"]
 
     missing_mandatory = [
         name

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -227,6 +227,10 @@ def format_genome(taxid_and_description):
     return f'<a href="/extract_contigs/{taxid}">{description}</a>'
 
 
+def format_genomic_island(gis_id, bioentry_accession, start, end):
+    return f'<a href="/genomic_island/{gis_id}">GI{gis_id} {bioentry_accession}: {start} - {end}</a>'
+
+
 class DataTableConfig:
     def __init__(
         self,

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -159,6 +159,8 @@ def home(request):
         number_ko = db.get_number_of_ko_entries()
     if optional2status.get("pfam", False):
         number_pfam = db.get_number_of_pfam_entries()
+    if optional2status.get("gi", False):
+        number_gi = db.gi.get_number_of_entries()
     versions = db.get_versions_table()
     return render(request, "chlamdb/home.html", my_locals(locals()))
 


### PR DESCRIPTION
With this PR we:
- Integrate `island_path` into the annotation pipeline.
- Add information about containing genomic islands to the `locusx` view.
- Add a detail view for genomic islands.
- Add the entry list view for genomic islands

This is a rough first step, but there is much more work to be done in order to properly integrate genomic islands into zDB, notably:
- Cluster homologous genomic islands together
- Display clusters of genomic islands with similarity between them
- Show lists of genes in a given genomic island
- Presence/absence table of genomic islands in various genomes
- ...

## Checklist
- [x] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

