### PR TITLE
Use up to date KEGG database as reference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
+- Use up to date KEGG database as reference. ([#157](https://github.com/metagenlab/zDB/pull/157)) (Niklaus Johner)
 - Fix SQL queries for libsqlite 3.49.1. ([#151](https://github.com/metagenlab/zDB/pull/151)) (Niklaus Johner)
 -  Fix accession in contig tab of locusx view. ([#153](https://github.com/metagenlab/zDB/pull/153)) (Niklaus Johner)
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ The following databases can be downloaded:
 
 Moreover, before your first run, you will need to prepare the database skeleton for zDB. This is done using the ```zdb setup``` command with the ``--setup_base_db`` flag.
 
+Note that the base database contains some information about the KEGGs, and as both the base database and reference database will use the latest KEGG version, they should be created together.
+
 The database setup can be run either in singularity containers (by default), in conda environment (if the ```--conda``` flag is set) or in docker (if the ```--docker``` flag is set).
 
 In addition, you can specify the directory where you want the databases to be installed with the ```--dir``` option: ```zdb setup --swissprot --dir=foobardir```.
@@ -275,6 +277,9 @@ Modify the 8000 to the same number you attributed to the port number of gunicorn
 
 Please run the webapp in docker containers, setting --allowed_host=0.0.0.0 or 127.0.0.1, for the webapp to correctly display in your browser.
 
+**Error in load_KO_into_db process**
+
+The base database and KEGG reference database might have different versions. Update both with `zdb setup --setup_base_db --ko`.
 
 ## Developping zDB
 

--- a/db_setup.nf
+++ b/db_setup.nf
@@ -118,15 +118,14 @@ process download_ko_profiles {
         path "version.txt"
 
     script:
-    version="2022-03-01"
     """
-    wget https://www.genome.jp/ftp/db/kofam/archives/$version/ko_list.gz
-    wget https://www.genome.jp/ftp/db/kofam/archives/$version/profiles.tar.gz
+    wget https://www.genome.jp/ftp/db/kofam/ko_list.gz
+    wget https://www.genome.jp/ftp/db/kofam/profiles.tar.gz
 
     gunzip < ko_list.gz > ko_list && rm -f ko_list.gz
     tar xvf profiles.tar.gz
     rm profiles.tar.gz
-    echo $version > version.txt
+    echo "\$(date +'%Y-%m-%d')" > version.txt
     """
 }
 


### PR DESCRIPTION
As zDB's base database is now created with "zdb setup", the KO definitions it contains will be up to date, so that we also need to have an up to date version of the KEGG database as reference. This means that the base database and reference databases should be created together to ensure compatibility between the two.

## Checklist
- [x] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

