### PR TITLE
Fix displaying genomic islands in locus view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 Versions are of the form MAJOR.MINOR.PATCH and this changelog tries to conform
 to [Common Changelog](https://common-changelog.org)
 
+## Unreleased
+
+### Fixed
+
+- Fix displaying genomic islands in locus view. ([#160](https://github.com/metagenlab/zDB/pull/160)) (Niklaus Johner)
+
+### Changed
+
+### Added
+
+
 ## 1.3.5 - 2025-03-26
 
 ### Fixed

--- a/webapp/templates/chlamdb/locus.html
+++ b/webapp/templates/chlamdb/locus.html
@@ -217,7 +217,7 @@
                               <td>{{nucl_length}} (nucleotides)</td>
                             {% endif %}
                           </tr>
-                          {% if optional2status|keyvalue:"genomic_islands" %}
+                          {% if optional2status|keyvalue:"gi" %}
                             <tr>
                               <th>In genomic island</th>
                               <td>


### PR DESCRIPTION
Seems I forgot to adapt the locus view when I renamed the option in `optional2status`...

## Checklist
- [x] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

