### PR TITLE
Add genomic island cluster visualisations and comparison views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ to [Common Changelog](https://common-changelog.org)
 ### Added
 
 - Add genomic island prediction consistency and clustering to analysis pipeline. ([#162](https://github.com/metagenlab/zDB/pull/162)) (Niklaus Johner)
+- Add genomic island visualizations. ([#165](https://github.com/metagenlab/zDB/pull/165)) (Niklaus Johner)
 
 ## 1.3.5 - 2025-03-26
 

--- a/testing/pipelines/test_annotation_pipeline.py
+++ b/testing/pipelines/test_annotation_pipeline.py
@@ -202,10 +202,11 @@ class TestAnnotationPipeline(BasePipelineTestCase):
 
         # Let's check that tables were correctly created and filled
         self.assertItemsEqual(
-            base_tables + ["genomic_islands"], self.metadata_obj.tables.keys()
+            base_tables + ["genomic_islands", "genomic_island_descriptions"],
+            self.metadata_obj.tables.keys(),
         )
         self.assert_db_base_table_row_counts()
-        self.assertEqual(1, self.query("genomic_islands").count())
+        self.assertEqual(2, self.query("genomic_islands").count())
 
     def test_full_pipeline(self):
         self.nf_params["pfam"] = "true"
@@ -235,6 +236,7 @@ class TestAnnotationPipeline(BasePipelineTestCase):
             "vf_defs",
             "vf_hits",
             "genomic_islands",
+            "genomic_island_descriptions",
         ]
         self.assertItemsEqual(
             base_tables + added_tables, self.metadata_obj.tables.keys()
@@ -250,7 +252,7 @@ class TestAnnotationPipeline(BasePipelineTestCase):
         self.assertEqual(2, self.query("amr_hits").count())
         self.assertEqual(36, self.query("vf_hits").count())
         self.assertEqual(35, self.query("vf_defs").count())
-        self.assertEqual(1, self.query("genomic_islands").count())
+        self.assertEqual(2, self.query("genomic_islands").count())
 
         self.assertItemsEqual(
             [

--- a/testing/webapp/test_views.py
+++ b/testing/webapp/test_views.py
@@ -41,19 +41,21 @@ urls = [
     "/custom_plots/",
     "/entry_list_amr",
     "/entry_list_cog",
-    "/entry_list_gi",
+    "/entry_list_gic",
     "/entry_list_ko",
     "/entry_list_pfam",
     "/entry_list_vf",
     "/extract_amr/",
     "/extract_cog/",
     "/extract_contigs/1",
+    "/extract_gic/",
     "/extract_ko/",
     "/extract_orthogroup/",
     "/extract_pfam/",
     "/extract_vf/",
     "/fam_amr/ybtP",
     "/fam_cog/COG0775",
+    "/fam_gic/GIC0",
     "/fam_ko/K01241",
     "/fam_pfam/PF10423",
     "/fam_vf/VFG048797",
@@ -61,6 +63,7 @@ urls = [
     "/genomes",
     "/genomic_island/1",
     "/get_cog/3/L?h=1&h=2&h=3",
+    "/gic_comparison/",
     "/groups/",
     "/groups/add/",
     "/groups/positive",
@@ -73,7 +76,7 @@ urls = [
     "/help",
     "/home/",
     "/index_comp/cog",
-    "/index_comp/gi",
+    "/index_comp/gic",
     "/index_comp/ko",
     "/index_comp/orthogroup",
     "/index_comp/pfam",
@@ -99,6 +102,7 @@ urls = [
     "/orthogroup_comparison",
     "/pan_genome/amr",
     "/pan_genome/cog",
+    "/pan_genome/gic",
     "/pan_genome/ko",
     "/pan_genome/orthogroup",
     "/pan_genome/pfam",
@@ -106,6 +110,7 @@ urls = [
     "/pfam_comparison",
     "/phylogeny",
     "/plot_heatmap/cog",
+    "/plot_heatmap/gic",
     "/plot_heatmap/ko",
     "/plot_heatmap/orthogroup",
     "/plot_heatmap/pfam",
@@ -113,6 +118,7 @@ urls = [
     "/plot_heatmap/vf",
     "/venn_amr/",
     "/venn_cog/",
+    "/venn_gic/",
     "/venn_ko/",
     "/venn_orthogroup/",
     "/venn_pfam/",
@@ -269,7 +275,7 @@ class TestViewsContent(ViewTestCase):
         )
         self.assertContains(
             resp,
-            '<a class="link_boxes" href="/index_comp/gi"><span class="link"></span>Genomic islands</a>',
+            '<a class="link_boxes" href="/index_comp/gic"><span class="link"></span>Genomic island clusters</a>',
             html=True,
         )
         self.assertContains(
@@ -667,20 +673,12 @@ class TestOrthogroupViews(ViewTestCase, ComparisonViewsTestMixin):
 
 
 class TestGIViews(ViewTestCase, ComparisonViewsTestMixin):
-    view_type = "gi"
+    view_type = "gic"
     page_title = "Comparisons: Genomic Islands"
 
-    def test_tabular_comparison_view(self):
-        pass
-
-    def test_venn_view(self):
-        pass
-
+    @skip("Heatmap plot fails because the test data does not provide enough hits")
     def test_plot_heatmap_view(self):
-        pass
-
-    def test_pan_genome_view(self):
-        pass
+        super(TestGIViews, self).test_plot_heatmap_view()
 
     def test_gwas_view(self):
         pass

--- a/webapp/chlamdb/urls.py
+++ b/webapp/chlamdb/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
         r"^venn_orthogroup/$", venn.VennOrthogroupView.as_view(), name="venn_orthogroup"
     ),  # noqa
     re_path(r"^venn_ko/$", venn.VennKoView.as_view(), name="venn_ko"),
+    re_path(r"^venn_gi/$", venn.VennGiView.as_view(), name="venn_gi"),
     re_path(r"^venn_cog/$", venn.VennCogView.as_view(), name="venn_cog"),
     re_path(r"^venn_amr/$", venn.VennAmrView.as_view(), name="venn_amr"),
     re_path(r"^search_suggest/.*$", views.search_suggest, name="search_suggest"),  # noqa

--- a/webapp/chlamdb/urls.py
+++ b/webapp/chlamdb/urls.py
@@ -182,6 +182,9 @@ urlpatterns = [
         r"^extract_ko/$", hits_extraction.ExtractKoView.as_view(), name="extract_ko"
     ),  # noqa
     re_path(
+        r"^extract_gi/$", hits_extraction.ExtractGiView.as_view(), name="extract_gi"
+    ),  # noqa
+    re_path(
         r"^extract_contigs/([0-9]+)",
         views.ExtractContigs.as_view(),
         name="extract_contigs",

--- a/webapp/chlamdb/urls.py
+++ b/webapp/chlamdb/urls.py
@@ -147,6 +147,11 @@ urlpatterns = [
         name=groups.GroupsOverview.view_name,
     ),  # noqa
     re_path(
+        r"^gi_comparison",
+        tabular_comparison.GiComparisonView.as_view(),
+        name="gi_comparison",
+    ),  # noqa
+    re_path(
         r"^get_cog/([a-zA-Z0-9_\.]+)/([a-zA-Z0-9_\.\%]+)$",
         views.get_cog,
         name="get_cog",

--- a/webapp/chlamdb/urls.py
+++ b/webapp/chlamdb/urls.py
@@ -167,6 +167,7 @@ urlpatterns = [
     re_path(r"^fam_vf/(VFG[0-9]+)$", fam.FamVfView.as_view(), name="fam_vf"),
     re_path(r"^fam_pfam/(PF[0-9]+)$", fam.FamPfamView.as_view(), name="fam_pfam"),
     re_path(r"^fam_ko/(K[0-9]+)$", fam.FamKoView.as_view(), name="fam_ko"),
+    re_path(r"^fam_gic/(GIC[0-9]+)$", fam.FamGiClusterView.as_view(), name="fam_gic"),
     re_path(r"^fam_cog/(COG[0-9]+)$", fam.FamCogView.as_view(), name="fam_cog"),  # noqa
     re_path(
         r"^fam_amr/([a-zA-Z0-9_\.\(\)\-\']+)$", fam.FamAmrView.as_view(), name="fam_amr"

--- a/webapp/chlamdb/urls.py
+++ b/webapp/chlamdb/urls.py
@@ -29,7 +29,7 @@ urlpatterns = [
         r"^venn_orthogroup/$", venn.VennOrthogroupView.as_view(), name="venn_orthogroup"
     ),  # noqa
     re_path(r"^venn_ko/$", venn.VennKoView.as_view(), name="venn_ko"),
-    re_path(r"^venn_gi/$", venn.VennGiView.as_view(), name="venn_gi"),
+    re_path(r"^venn_gic/$", venn.VennGiView.as_view(), name="venn_gic"),
     re_path(r"^venn_cog/$", venn.VennCogView.as_view(), name="venn_cog"),
     re_path(r"^venn_amr/$", venn.VennAmrView.as_view(), name="venn_amr"),
     re_path(r"^search_suggest/.*$", views.search_suggest, name="search_suggest"),  # noqa
@@ -147,9 +147,9 @@ urlpatterns = [
         name=groups.GroupsOverview.view_name,
     ),  # noqa
     re_path(
-        r"^gi_comparison",
+        r"^gic_comparison",
         tabular_comparison.GiComparisonView.as_view(),
-        name="gi_comparison",
+        name="gic_comparison",
     ),  # noqa
     re_path(
         r"^get_cog/([a-zA-Z0-9_\.]+)/([a-zA-Z0-9_\.\%]+)$",
@@ -189,7 +189,7 @@ urlpatterns = [
         r"^extract_ko/$", hits_extraction.ExtractKoView.as_view(), name="extract_ko"
     ),  # noqa
     re_path(
-        r"^extract_gi/$", hits_extraction.ExtractGiView.as_view(), name="extract_gi"
+        r"^extract_gic/$", hits_extraction.ExtractGiView.as_view(), name="extract_gic"
     ),  # noqa
     re_path(
         r"^extract_contigs/([0-9]+)",
@@ -214,7 +214,9 @@ urlpatterns = [
         r"^entry_list_ko$", entry_lists.KoEntryListView.as_view(), name="entry_list_ko"
     ),  # noqa
     re_path(
-        r"^entry_list_gi$", entry_lists.GiEntryListView.as_view(), name="entry_list_gi"
+        r"^entry_list_gic$",
+        entry_lists.GiEntryListView.as_view(),
+        name="entry_list_gic",
     ),  # noqa
     re_path(
         r"^entry_list_cog$",

--- a/webapp/lib/queries.py
+++ b/webapp/lib/queries.py
@@ -162,7 +162,7 @@ class GIQueries(BaseQueries):
     ]
 
     def get_containing_genomic_islands(self, bioentry_id, start, stop):
-        sql = f"SELECT {self.id_col}, start_pos, end_pos FROM {self.description_table} WHERE bioentry_id=? AND (? BETWEEN start_pos AND end_pos OR ? BETWEEN start_pos AND end_pos)"
+        sql = f"SELECT {self.id_col}, start_pos, end_pos FROM {self.hit_table} WHERE bioentry_id=? AND (? BETWEEN start_pos AND end_pos OR ? BETWEEN start_pos AND end_pos)"
         return self.server.adaptor.execute_and_fetchall(sql, [bioentry_id, start, stop])
 
     def get_gi_descriptions(self, gis_ids):

--- a/webapp/lib/queries.py
+++ b/webapp/lib/queries.py
@@ -152,9 +152,14 @@ class BaseQueries:
 
 
 class GIQueries(BaseQueries):
-    description_table = "genomic_islands"
-    id_col = "gis_id"
-    default_columns = [id_col, "bioentry_id", "start_pos", "end_pos"]
+    id_col = "cluster_id"
+    hit_table = "genomic_islands"
+    description_table = "genomic_island_descriptions"
+    default_columns = [id_col, "length"]
+
+    join_bioentry = (
+        f"INNER JOIN bioentry ON {hit_table}.bioentry_id = bioentry.bioentry_id "
+    )
 
     def get_containing_genomic_islands(self, bioentry_id, start, stop):
         sql = f"SELECT {self.id_col}, start_pos, end_pos FROM {self.description_table} WHERE bioentry_id=? AND (? BETWEEN start_pos AND end_pos OR ? BETWEEN start_pos AND end_pos)"

--- a/webapp/templates/chlamdb/fam.html
+++ b/webapp/templates/chlamdb/fam.html
@@ -51,7 +51,7 @@
             <p style="margin: 10px 10px 10px 10px; line-height: 180%">Three outputs have been generated:
               <br> <b>General</b>:  this result contains the description and frequency of the selected {{ object_name }} {{ fam }}, of which KO pathways and KO modules it is part. Additionally, its occurence in the database is reported.
               <br> <b>Proteins list</b>: list of occurences of the {{ object_name }}
-              within the database. {{ n_entries }} occurences are identified.
+              within the database. {{ table_size }} occurences are identified.
               The table reports the orthogroup, the organism in which each occurrence has been found, and the locus tag enriched by start and stop position, strand, gene name and product.
               <br>Clicking on the Ortohgroup name or locus you will be redirected to further info.
               <br><b> Profiles</b>: Phylogenetic tree annotated with
@@ -177,11 +177,11 @@
 
                     <table class="table table-striped" style="width: 100%">
                       <tr>
-                        <td>{{ fam }} is associated with <strong>{{ n_entries }} different proteins</strong> (see tab "<a href="#tab2" data-toggle="tab">Protein list</a>" and "<a href="#tab3" data-toggle="tab">Profile</a>")</td>
+                        <td>{{ fam }} is associated with <strong>{{ table_size }} different proteins</strong> (see tab "<a href="#tab2" data-toggle="tab">Protein list</a>" and "<a href="#tab3" data-toggle="tab">Profile</a>")</td>
                       </tr>
                       <tr>
                         <td>
-                          The {{ n_entries }} proteins are classified into <strong>{{ group_count|length }} different orthogroup(s)</strong>
+                          The {{ table_size }} proteins are classified into <strong>{{ group_count|length }} different orthogroup(s)</strong>
                           <div style="padding-left:20px">
                             <ul style="list-style-type:disc; width:100%;">
                               {% for group in group_count %}

--- a/webapp/templates/chlamdb/fam.html
+++ b/webapp/templates/chlamdb/fam.html
@@ -154,10 +154,6 @@
 
             </div>
 
-            <div class="tab-pane" id="tab66" style="height:100%">
-              <iframe name="orthoIDframe2" id="orthoIDframe2" scrolling="no" width="100%" height="2800px"></iframe>
-            </div>
-
             <div class="tab-pane" id="tab3">
               <div class="row">
                 <a download="profile_{{fam}}.svg" class="btn" href="{% static asset_path %}"> <i class="fa fa-download"></i> Download SVG

--- a/webapp/templates/chlamdb/fam.html
+++ b/webapp/templates/chlamdb/fam.html
@@ -46,122 +46,8 @@
             </p>
           </div>
 
-          <ul id="tabs" class="nav nav-tabs" data-tabs="tabs">
-              <li class="active"><a href="#tab1" data-toggle="tab">General</a></li>
-              <li><a href="#tab2" data-toggle="tab">Protein list</a></li>
-              <li><a href="#tab3" data-toggle="tab">Profile</a></li>
-          </ul>
+          {% include "chlamdb/result_tabs.html" %}
 
-          <div id="my-tab-content" class="tab-content" style="margin-top: 1em;">
-            <div class="tab-pane active" id="tab1">
-              <div class="col-md-12 col-lg-10" style="padding-right:30px;">
-                <div class="row">
-                  <div class="panel panel-default">
-                    <div class="panel-heading">
-                      <h3 class="panel-title">Description</h3>
-                    </div>
-                    <table class="table table-striped" style="width: 100%">
-
-                      {% for key, value in info.items %}
-                        <tr>
-                          <th>{{key}}</th>
-                          <td>{{value|safe}}</td>
-                        </tr>
-                      {% endfor %}
-
-                    </table>
-                  </div>
-                </div>
-
-                {% if object_type == 'ko'%}
-                  <div class="row">
-                    <div class="panel panel-default">
-                      <div class="panel-heading">
-                        <h3 class="panel-title">KO part of <strong>{{pathway_data|length }} pathways</strong></h3>
-                      </div>
-
-                      {% if pathway_data|length > 0 %}
-                        <table class="table table-striped" style="width: 100%">
-                          <tbody>
-
-                            {% for path in pathway_data %}
-                              <tr>
-                                <td>{{path|safe}}</td>
-                              </tr>
-                            {% endfor %}
-
-                          </tbody>
-                        </table>
-                      {% endif %}
-
-                      <div class="panel-heading">
-                        <h3 class="panel-title">KO part of <strong>{{module_data|length }} modules </strong></h3>
-                      </div>
-
-                      {% if module_data|length > 0 %}
-                        <table class="table table-striped" style="width: 100%">
-                          <tbody>
-
-                            {% for path in module_data %}
-                              <tr>
-                                <td>{{path.0|safe}}</td>
-                                <td>{{path.1}}</td>
-                                <td>{{path.2}}</td>
-                              </tr>
-                            {% endfor %}
-
-                          </tbody>
-                        </table>
-                      {% endif %}
-
-                    </div>
-                  </div>
-                {% endif %}
-
-                <div class="row">
-                  <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h3 class="panel-title">Occurence in the database</h3>
-                    </div>
-
-                    <table class="table table-striped" style="width: 100%">
-                      <tr>
-                        <td>{{ fam }} is associated with <strong>{{ table_size }} different proteins</strong> (see tab "<a href="#tab2" data-toggle="tab">Protein list</a>" and "<a href="#tab3" data-toggle="tab">Profile</a>")</td>
-                      </tr>
-                      <tr>
-                        <td>
-                          The {{ table_size }} proteins are classified into <strong>{{ group_count|length }} different orthogroup(s)</strong>
-                          <div style="padding-left:20px">
-                            <ul style="list-style-type:disc; width:100%;">
-                              {% for group in group_count %}
-                                <li style="float:left;margin-right:10px;width:120px;">{{group|safe}}</li>
-                              {% endfor %}
-                            </ul>
-                          </div>
-                        </td>
-                      </tr>
-                    </table>
-
-                  </div>
-                </div>
-
-              </div>
-            </div>
-
-            <div class="tab-pane" id="tab2">
-
-              {% include "chlamdb/result_table.html" with results=table %}
-
-            </div>
-
-            <div class="tab-pane" id="tab3">
-              <div class="row">
-                <a download="profile_{{fam}}.svg" class="btn" href="{% static asset_path %}"> <i class="fa fa-download"></i> Download SVG
-                </a>
-                <object type="image/svg+xml" data="{% static asset_path %}" id="cog_tree"></object>
-              </div>
-            </div>
-          </div> <!--tabs-->
         {% endif %}
       </div>
     </div>
@@ -192,23 +78,6 @@ $(document).ready(function() {
         $('.nav-tabs a[href="#' + url.split('#')[1] + '"]').tab('show');
     } 
 
-    $('#fam_table').DataTable( {
-            dom: 'Bfrtip',
-            "pageLength": 15,
-            "paging":   true,
-            "ordering": true,
-            "info":     false,
-            buttons: [
-            {
-                extend: 'excel',
-                title: '{{ fam }}'
-            },
-            {
-                extend: 'csv',
-                title: '{{ fam }}'
-            }
-            ],
-        } );
 } );
 
 </script>

--- a/webapp/templates/chlamdb/fam.html
+++ b/webapp/templates/chlamdb/fam.html
@@ -61,25 +61,6 @@
                       <h3 class="panel-title">Description</h3>
                     </div>
                     <table class="table table-striped" style="width: 100%">
-                      {% if object_type == 'pfam' %}
-                        <tr>
-                          <th>External link</th>
-                          <td><a href="https://www.ebi.ac.uk/interpro/entry/pfam/{{ fam }}" target="_blank"> {{ fam }} <i class="fas fa-external-link-alt"></i></a></td>
-                        </tr>
-
-                      {% elif object_type == 'ko' %}
-                        <tr>
-                          <th>External link</th>
-                          <td><a href="http://www.genome.jp/dbget-bin/www_bget?{{ fam }}" target="_blank"> {{ fam }} <i class="fas fa-external-link-alt"></i></a></td>
-                        </tr>
-
-                      {% elif object_type == 'amr' %}
-                        <tr>
-                          <th>Gene</th>
-                          <td><a href="https://www.ncbi.nlm.nih.gov/pathogens/refgene/#gene_family:{{ fam }}" target="_blank">  {{ fam }} <i class="fas fa-external-link-alt"></i></a></td>
-                        </tr>
-
-                      {% endif %}
 
                       {% for key, value in info.items %}
                         <tr>

--- a/webapp/templates/chlamdb/fam.html
+++ b/webapp/templates/chlamdb/fam.html
@@ -48,21 +48,8 @@
             <div class="panel-heading" style="width:100%">
             <h3 class="panel-title">Help to interpret the results</h3>
             </div>
-            <p style="margin: 10px 10px 10px 10px; line-height: 180%">Three outputs have been generated:
-              <br> <b>General</b>:  this result contains the description and frequency of the selected {{ object_name }} {{ fam }}, of which KO pathways and KO modules it is part. Additionally, its occurence in the database is reported.
-              <br> <b>Proteins list</b>: list of occurences of the {{ object_name }}
-              within the database. {{ table_size }} occurences are identified.
-              The table reports the orthogroup, the organism in which each occurrence has been found, and the locus tag enriched by start and stop position, strand, gene name and product.
-              <br>Clicking on the Ortohgroup name or locus you will be redirected to further info.
-              <br><b> Profiles</b>: Phylogenetic tree annotated with
-              <br>- the presence of the {{ object_name_singular_or_plural }} of interest within all the genomes of the database (first column)
-
-              <br>- the size of the orthogroup(s) in which the reported {{ object_name }} has been clustered.
-
-              <br>In red the <font size="2" color="red">{{object_name}} with positive hit(s)</font> in the corresponding genome.
-              <br>In green <font size="2" color="green">the discrepencies between orthogroup clustering and {{object_name}} prediction</font>.
-              Green homologs (same orthogroup) <strong>are not</strong> positive hit(s) for the considered {{object_name}}.
-              <br><br>Variations within orthogroups may be due to the clustering of multi domain proteins or because of erroneous homolog clustering or {{object_name}} prediction.
+            <p style="margin: 10px 10px 10px 10px; line-height: 180%">
+              {{ help_text | safe}}
             </p>
           </div>
 

--- a/webapp/templates/chlamdb/fam.html
+++ b/webapp/templates/chlamdb/fam.html
@@ -67,22 +67,10 @@
                           <td><a href="https://www.ebi.ac.uk/interpro/entry/pfam/{{ fam }}" target="_blank"> {{ fam }} <i class="fas fa-external-link-alt"></i></a></td>
                         </tr>
 
-                      {% elif object_type == 'interpro' %}
-                        <tr>
-                          <th>External link</th>
-                          <td><a href="http://www.ebi.ac.uk/interpro/entry/{{ fam }}" target="_blank"> {{ fam }} <i class="fas fa-external-link-alt"></i></a></td>
-                        </tr>
-
                       {% elif object_type == 'ko' %}
                         <tr>
                           <th>External link</th>
                           <td><a href="http://www.genome.jp/dbget-bin/www_bget?{{ fam }}" target="_blank"> {{ fam }} <i class="fas fa-external-link-alt"></i></a></td>
-                        </tr>
-
-                      {% elif object_type == 'EC' %}
-                        <tr>
-                          <th>External link</th>
-                          <td><a href="{{ external_link }}" target="_blank">  {{ fam }} <i class="fas fa-external-link-alt"></i></a></td>
                         </tr>
 
                       {% elif object_type == 'amr' %}

--- a/webapp/templates/chlamdb/fam.html
+++ b/webapp/templates/chlamdb/fam.html
@@ -51,7 +51,7 @@
             <p style="margin: 10px 10px 10px 10px; line-height: 180%">Three outputs have been generated:
               <br> <b>General</b>:  this result contains the description and frequency of the selected {{ object_name }} {{ fam }}, of which KO pathways and KO modules it is part. Additionally, its occurence in the database is reported.
               <br> <b>Proteins list</b>: list of occurences of the {{ object_name }}
-              within the database. {{ all_locus_data|length }} occurences are identified.
+              within the database. {{ n_entries }} occurences are identified.
               The table reports the orthogroup, the organism in which each occurrence has been found, and the locus tag enriched by start and stop position, strand, gene name and product.
               <br>Clicking on the Ortohgroup name or locus you will be redirected to further info.
               <br><b> Profiles</b>: Phylogenetic tree annotated with
@@ -177,11 +177,11 @@
 
                     <table class="table table-striped" style="width: 100%">
                       <tr>
-                        <td>{{ fam }} is associated with <strong>{{ all_locus_data|length }} different proteins</strong> (see tab "<a href="#tab2" data-toggle="tab">Protein list</a>" and "<a href="#tab3" data-toggle="tab">Profile</a>")</td>
+                        <td>{{ fam }} is associated with <strong>{{ n_entries }} different proteins</strong> (see tab "<a href="#tab2" data-toggle="tab">Protein list</a>" and "<a href="#tab3" data-toggle="tab">Profile</a>")</td>
                       </tr>
                       <tr>
                         <td>
-                          The {{ all_locus_data|length }} proteins are classified into <strong>{{ group_count|length }} different orthogroup(s)</strong>
+                          The {{ n_entries }} proteins are classified into <strong>{{ group_count|length }} different orthogroup(s)</strong>
                           <div style="padding-left:20px">
                             <ul style="list-style-type:disc; width:100%;">
                               {% for group in group_count %}
@@ -200,36 +200,9 @@
             </div>
 
             <div class="tab-pane" id="tab2">
-              <table id="fam_table">
-                <thead>
-                  <tr>
-                    <th>#</th>
-                    <th>Orthogroup</th>
-                    <th>Locus</th>
-                    <th>Start</th>
-                    <th>Stop</th>
-                    <th>S.</th>
-                    <th>Gene</th>
-                    <th>Product</th>
-                    <th>Organism</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {% for values in all_locus_data %}
-                    <tr>
-                      <td>{{values.0}}</td>
-                      <td>{{values.1|safe}}</td>
-                      <td><a href='{% url "locusx" values.2 True %}' target="_top">{{values.2}}</a></td>
-                      <td>{{values.4}}</td>
-                      <td>{{values.5}}</td>
-                      <td>{{values.6}}</td>
-                      <td>{{values.7}}</td>
-                      <td>{{values.8}}</td>
-                      <td>{{values.9}}</td>
-                    </tr>
-                  {% endfor %}
-                </tbody>
-              </table>
+
+              {% include "chlamdb/result_table.html" with results=table %}
+
             </div>
 
             <div class="tab-pane" id="tab66" style="height:100%">

--- a/webapp/templates/chlamdb/fam.html
+++ b/webapp/templates/chlamdb/fam.html
@@ -26,16 +26,9 @@
         </div>
         <p class="page-title"><b>
           {{ fam }}
-
-          {% if object_type == 'pfam' %}
-
-            <a href="https://zdb.readthedocs.io/en/latest/tutorial/website.html#cog-pfam-annotation-summary" id="show-option" target="_blank" title="help with the overview page"><i class="fab fa-info-circle " style="size: 5em;" ></i></a>
-
-          {% elif object_type == 'ko' %}
-
-            <a href="https://zdb.readthedocs.io/en/latest/tutorial/website.html#kegg-module-overview-page" id="show-option" target="_blank" title="help with the overview page"><i class="fab fa-info-circle " style="size: 5em;" ></i></a>
-
-          {% endif %}
+          <a href="https://zdb.readthedocs.io/en/latest/website.html#ko-cog-pfam-annotation-summary" id="show-option" target="_blank" title="help with the overview page">
+            <i class="fab fa-info-circle " style="size: 5em;" ></i>
+          </a>
 
         </b></p>
 

--- a/webapp/templates/chlamdb/fam_general_tab.html
+++ b/webapp/templates/chlamdb/fam_general_tab.html
@@ -29,8 +29,7 @@
             <tbody>
 
               {% for path in pathway_data %}
-                <tr></div>
-
+                <tr>
                   <td>{{path|safe}}</td>
                 </tr>
               {% endfor %}

--- a/webapp/templates/chlamdb/fam_general_tab.html
+++ b/webapp/templates/chlamdb/fam_general_tab.html
@@ -89,4 +89,8 @@
 
     </div>
   </div>
+
+  {% if results.show_genomic_region %}
+    {% include "chlamdb/region.html" %} 
+  {% endif %}
 </div>

--- a/webapp/templates/chlamdb/fam_general_tab.html
+++ b/webapp/templates/chlamdb/fam_general_tab.html
@@ -71,12 +71,20 @@
 
       <table class="table table-striped" style="width: 100%">
         <tr>
-          <td>{{ fam }} is associated with <strong>{{ table_size }} different proteins</strong> (see tab "<a href="#tab2" data-toggle="tab">Protein list</a>" and "<a href="#tab3" data-toggle="tab">Profile</a>")</td>
+          <td>{{ fam }} is associated with <strong>{{ table_size }} different 
+            {% if object_type == 'gic' %}
+              genomic islands
+            {% else %}
+              proteins
+            {% endif %}
+          </strong> </td>
         </tr>
         <tr>
           <td>
-            The {{ table_size }} proteins are classified into <strong>{{ group_count|length }} different orthogroup(s)</strong>
-            <div style="padding-left:20px">
+            {% if object_type != 'gic' %}
+              The {{ table_size }} proteins are classified into <strong>{{ group_count|length }} different orthogroup(s)</strong>
+            {% endif %}
+              <div style="padding-left:20px">
               <ul style="list-style-type:disc; width:100%;">
                 {% for group in group_count %}
                   <li style="float:left;margin-right:10px;width:120px;">{{group|safe}}</li>

--- a/webapp/templates/chlamdb/fam_general_tab.html
+++ b/webapp/templates/chlamdb/fam_general_tab.html
@@ -1,0 +1,92 @@
+<div class="col-md-12 col-lg-10" style="padding-right:30px;">
+  <div class="row">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">Description</h3>
+      </div>
+      <table class="table table-striped" style="width: 100%">
+
+        {% for key, value in info.items %}
+          <tr>
+            <th>{{key}}</th>
+            <td>{{value|safe}}</td>
+          </tr>
+        {% endfor %}
+
+      </table>
+    </div>
+  </div>
+
+  {% if object_type == 'ko'%}
+    <div class="row">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">KO part of <strong>{{pathway_data|length }} pathways</strong></h3>
+        </div>
+
+        {% if pathway_data|length > 0 %}
+          <table class="table table-striped" style="width: 100%">
+            <tbody>
+
+              {% for path in pathway_data %}
+                <tr></div>
+
+                  <td>{{path|safe}}</td>
+                </tr>
+              {% endfor %}
+
+            </tbody>
+          </table>
+        {% endif %}
+
+        <div class="panel-heading">
+          <h3 class="panel-title">KO part of <strong>{{module_data|length }} modules </strong></h3>
+        </div>
+
+        {% if module_data|length > 0 %}
+          <table class="table table-striped" style="width: 100%">
+            <tbody>
+
+              {% for path in module_data %}
+                <tr>
+                  <td>{{path.0|safe}}</td>
+                  <td>{{path.1}}</td>
+                  <td>{{path.2}}</td>
+                </tr>
+              {% endfor %}
+
+            </tbody>
+          </table>
+        {% endif %}
+
+      </div>
+    </div>
+  {% endif %}
+
+  <div class="row">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+          <h3 class="panel-title">Occurence in the database</h3>
+      </div>
+
+      <table class="table table-striped" style="width: 100%">
+        <tr>
+          <td>{{ fam }} is associated with <strong>{{ table_size }} different proteins</strong> (see tab "<a href="#tab2" data-toggle="tab">Protein list</a>" and "<a href="#tab3" data-toggle="tab">Profile</a>")</td>
+        </tr>
+        <tr>
+          <td>
+            The {{ table_size }} proteins are classified into <strong>{{ group_count|length }} different orthogroup(s)</strong>
+            <div style="padding-left:20px">
+              <ul style="list-style-type:disc; width:100%;">
+                {% for group in group_count %}
+                  <li style="float:left;margin-right:10px;width:120px;">{{group|safe}}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          </td>
+        </tr>
+      </table>
+
+    </div>
+  </div>
+</div>

--- a/webapp/templates/chlamdb/genomic_island.html
+++ b/webapp/templates/chlamdb/genomic_island.html
@@ -27,18 +27,70 @@
 
           </div>
 
-          <div class=row>
-            <div class="panel panel-default">
-              <div class="panel-heading clearfix">
-                <div class="pull-right">
-                  <button id="download_svg_button" class="btn-link btn-xs" style="background-color: transparent;">
-                    <i class="glyphicon glyphicon-download"></i>
-                  </button>
+          <div class="row">
+            <div class="col-md-12 col-lg-6">
+              <div class="panel panel-default">
+                <div class="panel-heading">
+                  <h3 class="panel-title">General</h3>
                 </div>
-                <h3 class="panel-title">Genomic island</h3>
+                <table id="panel_table" class="table table-striped" style="width: 100%">
+                  <tr>
+                      <th>Source</th>
+                      <td>{{organism|safe}}</td>
+                  </tr>
+                  <tr>
+                      <th>Genomic Island ID</th>
+                      <td>{{gis_id|safe}}</td>
+                  </tr>
+                  <tr>
+                    <th> Contig </th>
+                    <td> {{bioentry}} </td>
+                  </tr>
+                  <tr>
+                    <th>Location</th>
+                    <td>{{start_pos}} - {{end_pos}}</td>
+                  </tr>
+                  <tr>
+                    <th>Island size</th>
+                    <td>{{island_size}}</td>
+                  </tr>
+                </table>
               </div>
-              <div class="panel-body" style="height:100px; display:flex; justify-content:center; align-items:center; margin-bottom:30px" id="genomic_region_rect">
-                <div id="div_genomic_region"></div>
+            </div>
+            <div class="col-md-12 col-lg-6">
+              <div class="panel panel-default">
+                <div class="panel-heading">
+                  <h3 class="panel-title">GI Cluster</h3>
+                </div>
+                <table id="panel_table" class="table table-striped" style="width: 100%">
+                  <tr>
+                    <th>Cluster</th>
+                    <td>{{cluster_id|safe}}</td>
+                  </tr>
+                  <tr>
+                      <th>Average island size</th>
+                      <td>{{cluster_average_size}}</td>
+                  </tr>
+                </table>
+              </div>
+            </div>
+          </div>
+
+
+          <div class=row>
+            <div class="col-md-12 col-lg-12">
+              <div class="panel panel-default">
+                <div class="panel-heading clearfix">
+                  <div class="pull-right">
+                    <button id="download_svg_button" class="btn-link btn-xs" style="background-color: transparent;">
+                      <i class="glyphicon glyphicon-download"></i>
+                    </button>
+                  </div>
+                  <h3 class="panel-title">Genomic island</h3>
+                </div>
+                <div class="panel-body" style="height:100px; display:flex; justify-content:center; align-items:center; margin-bottom:30px" id="genomic_region_rect">
+                  <div id="div_genomic_region"></div>
+                </div>
               </div>
             </div>
           </div>

--- a/webapp/templates/chlamdb/home.html
+++ b/webapp/templates/chlamdb/home.html
@@ -87,7 +87,7 @@
                           {% endif %}
                           {% if optional2status|keyvalue:"gi" == 1 %}
                             <li class="summary_data">
-                              <a href="{% url 'index_comp' 'gi' %}" >
+                              <a href="{% url 'index_comp' 'gic' %}" >
                                 <b>{{number_gi}}  </b>
                               </a>Genomic islands
                             </li>

--- a/webapp/templates/chlamdb/plot_region.html
+++ b/webapp/templates/chlamdb/plot_region.html
@@ -6,13 +6,6 @@
 {% load static %}
 {% load crispy_forms_tags %}
 
-
-<script type="text/javascript" src={% static 'js/genomic_region.js' %}>
-</script>
-
-<script type="text/javascript" src="{% static 'js/svg-export.min.js' %}">
-</script>
-
 {% include "chlamdb/header.html" %}
 
 </head>
@@ -65,33 +58,7 @@
               {% endif %}
 
               {% if envoi %}
-                <div class="row">
-                  <div  class="col-md-12 col-lg-12" style="padding-left: 15px">
-                    <div class="alert alert-info fade in" style="width:90%; margin: 10px 10px 10px 10px">
-                      <a href="#" class="close" data-dismiss="alert">&times;</a>
-                      The generated plot shows a genomic feature in the neighborhood of a target locus along the selected genomes. Links are coloured wiht a scale of gray reflecting the sequence identity:
-                      dark gray for highly conserved, light grey for features with less identity. Click on the link to visualise the percentage of identity.
-                      Beginning and end of the regions are shown as dashed line if the region shows a complete circular contig, a double line if the start or end of the region matches the start or end of a linear contig and a single line otherwise.
-                    </div>
-                  </div>
-                </div>
-                <div class="row">
-                  <div  class="col-md-12 col-lg-12" style="padding-left: 15px">
-                    <div class="panel panel-success" style="width:90%; margin: 10px 10px 10px 10px">
-                      <div class="panel-heading clearfix">
-                        <div class="pull-right">
-                          <button id="download_svg_button" class="btn-link btn-xs" style="background-color: transparent;">
-                            <i class="glyphicon glyphicon-download"></i>
-                          </button>
-                        </div>
-                        <h5 class="panel-title">Genomic regions</h5>
-                      </div>
-                      <div class="panel-body" id="div_alignment_bounding">
-                        <div id="div_alignment"></div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
+                {% include "chlamdb/region.html" %}
               {% endif %}
             </div>
           </div>
@@ -100,28 +67,5 @@
     </div>
   </div>
 </body>
-
-
-<script>
-
-  {% if envoi %}
-    var regions = {{genomic_regions|safe}};
-    var to_highlight = {{to_highlight|safe}};
-    var connections = {{connections | safe}};
-    var ident_range = [{{min_ident}}, {{max_ident}}];
-    var genomic_region_rect = document.querySelector("#div_alignment_bounding")
-        .getBoundingClientRect();
-    var genomic_width = genomic_region_rect.right-genomic_region_rect.left;
-
-    createGenomicRegion(d3.select("#div_alignment"), genomic_width*0.95, "genomic_region",
-        regions, connections, to_highlight, ident_range);
-
-    document.querySelector("#download_svg_button").onclick = function() {
-      var svg_elem = document.querySelector("#genomic_region");
-      svgExport.downloadSvg(svg_elem, "Genomic region");
-    };
-  {% endif %}
-
-</script>
 
 </html>

--- a/webapp/templates/chlamdb/region.html
+++ b/webapp/templates/chlamdb/region.html
@@ -1,0 +1,55 @@
+{% load static %}
+<script type="text/javascript" src="{% static 'js/genomic_region.js' %}">
+</script>
+
+<script type="text/javascript" src="{% static 'js/svg-export.min.js' %}">
+</script>
+
+<div class="row">
+  <div  class="col-md-12 col-lg-12" style="padding-left: 15px">
+    <div class="alert alert-info fade in" style="width:90%; margin: 10px 10px 10px 10px">
+      <a href="#" class="close" data-dismiss="alert">&times;</a>
+      {{results.description}}<br>
+      Links are coloured wiht a scale of gray reflecting the sequence identity:
+      dark gray for highly conserved, light grey for features with less identity. Click on the link to visualise the percentage of identity.
+      Beginning and end of the regions are shown as dashed line if the region shows a complete circular contig, a double line if the start or end of the region matches the start or end of a linear contig and a single line otherwise.
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div  class="col-md-12 col-lg-12" style="padding-left: 15px">
+    <div class="panel panel-success" style="width:90%; margin: 10px 10px 10px 10px">
+      <div class="panel-heading clearfix">
+        <div class="pull-right">
+          <button id="download_svg_button" class="btn-link btn-xs" style="background-color: transparent;">
+            <i class="glyphicon glyphicon-download"></i>
+          </button>
+        </div>
+        <h5 class="panel-title">Genomic regions</h5>
+      </div>
+      <div class="panel-body" id="div_alignment_bounding">
+        <div id="div_alignment"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+
+var regions = {{results.genomic_regions|safe}};
+var to_highlight = {{results.to_highlight|safe}};
+var connections = {{results.connections | safe}};
+var ident_range = [{{results.min_ident}}, {{results.max_ident}}];
+var genomic_region_rect = document.querySelector("#div_alignment_bounding")
+    .getBoundingClientRect();
+var genomic_width = genomic_region_rect.right-genomic_region_rect.left;
+
+createGenomicRegion(d3.select("#div_alignment"), genomic_width*0.95, "genomic_region",
+    regions, connections, to_highlight, ident_range);
+
+document.querySelector("#download_svg_button").onclick = function() {
+  var svg_elem = document.querySelector("#genomic_region");
+  svgExport.downloadSvg(svg_elem, "Genomic region");
+};
+
+</script>

--- a/webapp/views/analysis_view_metadata.py
+++ b/webapp/views/analysis_view_metadata.py
@@ -1,5 +1,5 @@
 class AnalysisViewMetadata:
-    _types_available_for = ["amr", "cog", "ko", "pfam", "orthogroup", "vf"]
+    _types_available_for = ["amr", "cog", "ko", "pfam", "orthogroup", "vf", "gi"]
     static_icon = True
 
     def __init__(self, object_type, object_name_plural):

--- a/webapp/views/analysis_view_metadata.py
+++ b/webapp/views/analysis_view_metadata.py
@@ -1,5 +1,5 @@
 class AnalysisViewMetadata:
-    _types_available_for = ["amr", "cog", "ko", "pfam", "orthogroup", "vf", "gi"]
+    _types_available_for = ["amr", "cog", "ko", "pfam", "orthogroup", "vf", "gic"]
     static_icon = True
 
     def __init__(self, object_type, object_name_plural):
@@ -21,7 +21,7 @@ class AnalysisViewMetadata:
 
 class EntryListMetadata(AnalysisViewMetadata):
     name = "index"
-    _types_available_for = ["amr", "cog", "ko", "pfam", "vf", "gi"]
+    _types_available_for = ["amr", "cog", "ko", "pfam", "vf", "gic"]
     title = "Index"
     _description = "Index of all {} identified in all genomes"
     _url = "/entry_list_{}"

--- a/webapp/views/fam.py
+++ b/webapp/views/fam.py
@@ -50,6 +50,33 @@ class FamBaseView(View):
     hit_count_indexing = "seqid"
 
     @property
+    def help_text(self):
+        return (
+            f"Three outputs have been generated:"
+            f"<br> <b>General</b>:  this result contains the description and frequency of the selected "
+            f"{self.object_name} {self.fam}, of which KO pathways and KO modules it is part. "
+            f"Additionally, its occurence in the database is reported."
+            f"<br> <b>Proteins list</b>: list of occurences of the {self.object_name}"
+            f"within the database. {self.table_size} occurences are identified."
+            f"The table reports the orthogroup, the organism in which each occurrence has been found, "
+            f"and the locus tag enriched by start and stop position, strand, gene name and product."
+            f"<br>Clicking on the Ortohgroup name or locus you will be redirected to further info."
+            f"<br><b> Profiles</b>: Phylogenetic tree annotated with"
+            f"<br>- the presence of the {self.object_name_singular_or_plural} of interest within all "
+            f"the genomes of the database (first column)"
+            f"<br>- the size of the orthogroup(s) in which the reported {self.object_name} has been "
+            f"clustered."
+            f'<br>In red the <font size="2" color="red">{self.object_name} with positive hit(s)</font> '
+            f"in the corresponding genome."
+            f'<br>In green <font size="2" color="green">the discrepencies between orthogroup clustering '
+            f"and {self.object_name} prediction</font>."
+            f"Green homologs (same orthogroup) <strong>are not</strong> positive hit(s) for the considered"
+            f" {self.object_name}."
+            f"<br><br>Variations within orthogroups may be due to the clustering of multi domain proteins"
+            f" or because of erroneous homolog clustering or {self.object_name} prediction."
+        )
+
+    @property
     def view_name(self):
         return f"fam_{self.object_type}"
 
@@ -163,7 +190,7 @@ class FamBaseView(View):
         infos = infos.iloc[0]
 
         hit_counts = hit_counts.groupby(["taxid"]).count()
-        fam = self.format_entry(entry_id)
+        self.fam = self.format_entry(entry_id)
         e_tree = self.get_profile_tree(
             getattr(hit_counts, self.object_column),
             self.format_entry(entry_id),
@@ -181,7 +208,7 @@ class FamBaseView(View):
         }
 
         table_data, table_headers, table_accessors = self.get_table(seqids)
-
+        self.table_size = len(table_data)
         table = {
             "table_data": table_data,
             "table_headers": table_headers,
@@ -190,13 +217,14 @@ class FamBaseView(View):
         }
 
         context = self.get_context(
-            fam=fam,
+            fam=self.fam,
             info=info,
             table=table,
-            table_size=len(table_data),
+            table_size=self.table_size,
             group_count=self.get_associated_entries(table_data),
             asset_path=asset_path,
             object_name_singular_or_plural=self.object_name_singular_or_plural,
+            help_text=self.help_text,
         )
         return context
 

--- a/webapp/views/fam.py
+++ b/webapp/views/fam.py
@@ -389,7 +389,7 @@ class FamGiClusterView(FamBaseView, GiViewMixin):
                 )
             )
         all_regions, connections, all_identities = prepare_genomic_regions(
-            self.db, genomic_regions
+            self.db, genomic_regions, allow_flips=True
         )
         tabs[0].show_genomic_region = True
         tabs[0].genomic_regions = "[" + "\n,".join(all_regions) + "]"

--- a/webapp/views/fam.py
+++ b/webapp/views/fam.py
@@ -36,7 +36,6 @@ class FamBaseView(View):
     template = "chlamdb/fam.html"
 
     table_headers = [
-        "#",
         "Orthogroup",
         "Locus",
         "Start",
@@ -137,7 +136,7 @@ class FamBaseView(View):
         hsh_organisms = self.db.get_organism(seqids)
         all_locus_data = []
 
-        for index, seqid in enumerate(seqids):
+        for seqid in seqids:
             # NOTE: all seqids are attributed an orthogroup, the case where
             # seqid is not in orthogroups should therefore not arise.
             og = self.orthogroups.loc[seqid].orthogroup
@@ -148,7 +147,6 @@ class FamBaseView(View):
             if gene is None:
                 gene = ""
             data = (
-                index,
                 fmt_orthogroup,
                 locus,
                 start,
@@ -243,6 +241,7 @@ class FamBaseView(View):
                 table_headers=table_headers,
                 table_data=table_data,
                 table_data_accessors=table_accessors,
+                selectable=True,
             ),
             ResultTab(
                 "profile",

--- a/webapp/views/fam.py
+++ b/webapp/views/fam.py
@@ -40,7 +40,7 @@ class FamBaseView(View):
     def get_orthogroups(self, seqids):
         return self.db.get_og_count(seqids, search_on="seqid", keep_taxid=True)
 
-    def get_profile_tree(self, main_series, header, intersect):
+    def get_profile_tree(self, main_series, header):
         """
         Generate the tree from the profiles tab in the pfam/ko/cog pages:
         -ref_tree: the phylogenetic tree
@@ -60,10 +60,12 @@ class FamBaseView(View):
         e_tree.rename_leaves(ref_names)
 
         e_tree.add_column(SimpleColorColumn.fromSeries(main_series, header=header))
-        self.add_additional_columns(e_tree, intersect)
         return e_tree
 
     def add_additional_columns(self, e_tree, intersect):
+        """
+        - intersect: a dataframe containing the seqid, taxid and orthogroups of the pfam/cog/ko hits
+        """
         # the (group, taxid) in this dataframe are those that should be colored in red
         # in the profile (correspondance between a cog entry and an orthogroup)
         unique_og = intersect.orthogroup.unique().tolist()
@@ -143,8 +145,8 @@ class FamBaseView(View):
         e_tree = self.get_profile_tree(
             getattr(hit_counts, self.object_column),
             self.format_entry(entry_id),
-            orthogroups,
         )
+        self.add_additional_columns(e_tree, orthogroups)
         asset_path = f"/temp/fam_tree_{entry_id}.svg"
         path = settings.ASSET_ROOT + asset_path
         e_tree.render(path, dpi=500)

--- a/webapp/views/fam.py
+++ b/webapp/views/fam.py
@@ -37,6 +37,9 @@ class FamBaseView(View):
         context = self.prepare_context(request, entry_id, *args, **kwargs)
         return render(request, self.template, context)
 
+    def get_orthogroups(self, seqids):
+        return self.db.get_og_count(seqids, search_on="seqid", keep_taxid=True)
+
     def get_profile_tree(self, main_series, header, intersect):
         """
         Generate the tree from the profiles tab in the pfam/ko/cog pages:
@@ -127,7 +130,7 @@ class FamBaseView(View):
             # Pfam hits are not indexed with seqid...
             seqids = hit_counts.seqid.unique().tolist()
 
-        orthogroups = self.db.get_og_count(seqids, search_on="seqid", keep_taxid=True)
+        orthogroups = self.get_orthogroups(seqids)
         infos = self.get_hit_descriptions(
             [entry_id], columns=self.accessors, extended_data=False
         )

--- a/webapp/views/fam.py
+++ b/webapp/views/fam.py
@@ -47,7 +47,7 @@ class FamBaseView(View):
     ]
 
     table_accessors = table_headers
-
+    tabular_result_tab_header = "Protein list"
     hit_count_indexing = "seqid"
 
     external_link_tag = (
@@ -55,18 +55,9 @@ class FamBaseView(View):
     )
 
     @property
-    def help_text(self):
+    def profile_tab_help_text(self):
         return (
-            f"Three outputs have been generated:"
-            f"<br> <b>General</b>:  this result contains the description and frequency of the selected "
-            f"{self.object_name} {self.fam}, of which KO pathways and KO modules it is part. "
-            f"Additionally, its occurence in the database is reported."
-            f"<br> <b>Proteins list</b>: list of occurences of the {self.object_name}"
-            f"within the database. {self.table_size} occurences are identified."
-            f"The table reports the orthogroup, the organism in which each occurrence has been found, "
-            f"and the locus tag enriched by start and stop position, strand, gene name and product."
-            f"<br>Clicking on the Ortohgroup name or locus you will be redirected to further info."
-            f"<br><b> Profiles</b>: Phylogenetic tree annotated with"
+            f"<b> Profiles</b>: Phylogenetic tree annotated with"
             f"<br>- the presence of the {self.object_name_singular_or_plural} of interest within all "
             f"the genomes of the database (first column)"
             f"<br>- the size of the orthogroup(s) in which the reported {self.object_name} has been "
@@ -79,6 +70,17 @@ class FamBaseView(View):
             f" {self.object_name}."
             f"<br><br>Variations within orthogroups may be due to the clustering of multi domain proteins"
             f" or because of erroneous homolog clustering or {self.object_name} prediction."
+        )
+
+    @property
+    def help_text(self):
+        return (
+            f"Three outputs have been generated:"
+            f"<br> <b>General</b>:  this tab contains the description, occurence in the database "
+            f"and other information related to the selected {self.object_name} {self.fam}"
+            f"<br> <b>{self.tabular_result_tab_header}</b>: lists the {self.table_size} occurences of "
+            f"the {self.object_name} within the database. The table reports information on each occurence."
+            f"<br>{self.profile_tab_help_text}"
         )
 
     @property
@@ -237,7 +239,7 @@ class FamBaseView(View):
             ResultTab("general", "General", "chlamdb/fam_general_tab.html"),
             TabularResultTab(
                 "distribution",
-                "Protein list",
+                self.tabular_result_tab_header,
                 table_headers=table_headers,
                 table_data=table_data,
                 table_data_accessors=table_accessors,
@@ -334,6 +336,15 @@ class FamPfamView(FamBaseView, PfamViewMixin):
 class FamGiClusterView(FamBaseView, GiViewMixin):
     accessors = ["cluster_id", "length"]
     hit_count_indexing = "gi"
+    tabular_result_tab_header = "GIs list"
+
+    @property
+    def profile_tab_help_text(self):
+        return (
+            f"<b> Profiles</b>: Phylogenetic tree annotated with"
+            f"<br>- the presence of the {self.object_name_singular_or_plural} of interest within all "
+            f"the genomes of the database"
+        )
 
     def get(self, request, entry_id, *args, **kwargs):
         entry_id = int(entry_id[3:])

--- a/webapp/views/genomic_island.py
+++ b/webapp/views/genomic_island.py
@@ -30,14 +30,13 @@ class GenomicIsland(GiViewMixin, View):
         genomic_region = genomic_region_df_to_js(
             all_infos, wd_start, wd_end, contig_size, contig_topology
         )
-
         window_size = wd_end - wd_start
         context = self.get_context(
             organism=self.data.taxon_id,
             gis_id=self.data.gis_id,
             cluster_id=self.data.cluster_id,
             cluster_average_size=cluster_descr.length,
-            bioentry=bioentry,
+            bioentry=self.data.bioentry,
             start_pos=self.data.start_pos,
             end_pos=self.data.end_pos,
             island_size=self.data.end_pos - self.data.start_pos,

--- a/webapp/views/genomic_island.py
+++ b/webapp/views/genomic_island.py
@@ -1,8 +1,6 @@
 from django.shortcuts import render
 from django.views import View
 from views.mixins import GiViewMixin
-from views.utils import format_genome
-from views.utils import format_genomic_island
 from views.utils import genomic_region_df_to_js
 from views.utils import locusx_genomic_region
 

--- a/webapp/views/hits_extraction.py
+++ b/webapp/views/hits_extraction.py
@@ -6,6 +6,7 @@ from views.analysis_view_metadata import ExtractionMetadata
 from views.errors import errors
 from views.mixins import AmrViewMixin
 from views.mixins import CogViewMixin
+from views.mixins import GiViewMixin
 from views.mixins import KoViewMixin
 from views.mixins import OrthogroupViewMixin
 from views.mixins import PfamViewMixin
@@ -362,6 +363,10 @@ class ExtractAmrView(ExtractHitsBaseView, AmrViewMixin):
 
 
 class ExtractVfView(ExtractHitsBaseView, VfViewMixin):
+    pass
+
+
+class ExtractGiView(ExtractHitsBaseView, GiViewMixin):
     pass
 
 

--- a/webapp/views/locus.py
+++ b/webapp/views/locus.py
@@ -549,8 +549,7 @@ def get_genomic_island(db, seqid, gene_pos):
         )
     return {
         "genomic_islands": [
-            format_genomic_island(gis_id, accession, start, stop)
-            for gis_id, start, stop in genomic_islands
+            format_genomic_island(gis_id) for gis_id, start, stop in genomic_islands
         ]
     }
 

--- a/webapp/views/mixins.py
+++ b/webapp/views/mixins.py
@@ -500,7 +500,7 @@ class ComparisonViewMixin:
         "orthogroup": OrthogroupViewMixin,
         "amr": AmrViewMixin,
         "vf": VfViewMixin,
-        "gi": GiViewMixin,
+        "gic": GiViewMixin,
     }
 
     mixin = None

--- a/webapp/views/mixins.py
+++ b/webapp/views/mixins.py
@@ -441,23 +441,28 @@ class VfViewMixin(BaseViewMixin, VfMetadata):
 
 
 class GiViewMixin(BaseViewMixin, GiMetadata):
-    object_column = "gis_id"
+    object_column = "cluster_id"
 
     _base_colname_to_header_mapping = {
+        "cluster_id": "Cluster ID",
         "gis_id": "ID",
         "bioentry_id": "Bioentry",
         "start_pos": "Start",
         "end_pos": "End",
     }
 
-    table_data_accessors = ["gis_id", "bioentry_id", "start_pos", "end_pos"]
+    table_data_accessors = ["cluster_id", "length"]
 
     def get_hit_descriptions(self, ids, transformed=True, **kwargs):
         descriptions = self.db.gi.get_hit_descriptions(ids)
-        descriptions = descriptions.set_index("gis_id", drop=False)
+        descriptions = descriptions.set_index("cluster_id", drop=False)
         if transformed:
             descriptions = self.transform_data(descriptions)
         return descriptions
+
+    @property
+    def get_hit_counts(self):
+        return self.db.gi.get_hit_counts
 
 
 class ComparisonViewMixin:

--- a/webapp/views/mixins.py
+++ b/webapp/views/mixins.py
@@ -12,6 +12,7 @@ from views.object_type_metadata import VfMetadata
 from views.object_type_metadata import my_locals
 from views.utils import DataTableConfig
 from views.utils import format_genome
+from views.utils import format_genomic_island
 from views.utils import format_hmm_url
 from views.utils import format_ko_module
 from views.utils import format_lst_to_html
@@ -467,6 +468,23 @@ class GiViewMixin(BaseViewMixin, GiMetadata):
     @property
     def get_hits(self):
         return self.db.gi.get_hits
+
+    def get_gi_descriptions(self, ids, transformed=True, **kwargs):
+        descriptions = self.db.gi.get_gi_descriptions(ids)
+        descriptions = descriptions.set_index("gis_id", drop=False)
+        if transformed:
+            descriptions = self.transform_data(descriptions)
+            descriptions["organism"] = descriptions["taxon_id"]
+            descriptions.drop(columns=["taxon_id"], inplace=True)
+        return descriptions
+
+    @property
+    def transforms(self):
+        return [
+            Transform(self.object_column, self.format_entry, {"to_url": True}),
+            TransformWithAccessoryColumn("taxon_id", "organism", format_genome),
+            Transform("gis_id", format_genomic_island),
+        ]
 
 
 class ComparisonViewMixin:

--- a/webapp/views/mixins.py
+++ b/webapp/views/mixins.py
@@ -464,6 +464,10 @@ class GiViewMixin(BaseViewMixin, GiMetadata):
     def get_hit_counts(self):
         return self.db.gi.get_hit_counts
 
+    @property
+    def get_hits(self):
+        return self.db.gi.get_hits
+
 
 class ComparisonViewMixin:
     """This class is somewhat of a hack to get pseudo inheritance

--- a/webapp/views/object_type_metadata.py
+++ b/webapp/views/object_type_metadata.py
@@ -94,6 +94,11 @@ class GiMetadata(BaseObjectMetadata):
     object_type = "gic"
     object_name = "Genomic island cluster"
 
+    @property
+    @staticmethod
+    def is_enabled(self):
+        return optional2status.get("gi", False)
+
     @staticmethod
     def format_entry(entry, to_url=False):
         return format_genomic_island_cluster(entry, to_url=to_url)

--- a/webapp/views/object_type_metadata.py
+++ b/webapp/views/object_type_metadata.py
@@ -2,7 +2,7 @@ from urllib.parse import quote
 
 from views.utils import format_amr
 from views.utils import format_cog
-from views.utils import format_genomic_island
+from views.utils import format_genomic_island_cluster
 from views.utils import format_ko
 from views.utils import format_orthogroup
 from views.utils import format_pfam
@@ -91,12 +91,12 @@ class VfMetadata(BaseObjectMetadata):
 
 
 class GiMetadata(BaseObjectMetadata):
-    object_type = "gi"
-    object_name = "Genomic island"
+    object_type = "gic"
+    object_name = "Genomic island cluster"
 
     @staticmethod
     def format_entry(entry, to_url=False):
-        return format_genomic_island(entry, to_url=to_url)
+        return format_genomic_island_cluster(entry, to_url=to_url)
 
 
 class ModuleMetadata(BaseObjectMetadata):
@@ -156,7 +156,7 @@ class MetadataGetter:
         PathwayMetadata,
     ]
 
-    _annotations = ["cog", "pfam", "ko", "amr", "vf", "gi"]
+    _annotations = ["cog", "pfam", "ko", "amr", "vf", "gic"]
     _orthology = ["orthogroup"]
 
     def __init__(self):

--- a/webapp/views/tabular_comparison.py
+++ b/webapp/views/tabular_comparison.py
@@ -6,6 +6,7 @@ from django.views import View
 from views.analysis_view_metadata import TabularComparisonMetadata
 from views.mixins import AmrViewMixin
 from views.mixins import CogViewMixin
+from views.mixins import GiViewMixin
 from views.mixins import KoViewMixin
 from views.mixins import OrthogroupViewMixin
 from views.mixins import PfamViewMixin
@@ -425,3 +426,22 @@ class VfComparisonView(TabularComparisonViewBase, VfViewMixin):
     @property
     def hist_colour_index_shift(self):
         return len(self.targets)
+
+
+class GiComparisonView(TabularComparisonViewBase, GiViewMixin):
+    table_help = """
+    The ouput table contains the number of times a given GI cluster appears
+    in the selected genomes, color coded according to that number.<br>
+    <br> Counts can be reordrered by clicking on column headers.<br>
+    """
+
+    base_info_accessors = ["", "cluster_id"]
+
+    def get_table_rows(self):
+        hits = self.get_hit_counts(self.targets)
+        hits["cluster_id"] = hits.index
+        hits = self.transform_data(hits)
+        return [
+            (i, *row[self.base_info_accessors[1:] + self.targets])
+            for i, row in hits.iterrows()
+        ]

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -228,13 +228,8 @@ def format_genome(taxid_and_description):
     return f'<a href="/extract_contigs/{taxid}">{description}</a>'
 
 
-def format_genomic_island(
-    gis_id, bioentry_accession=None, start=None, end=None, to_url=True
-):
-    if bioentry_accession is not None:
-        description = f"GI{gis_id} {bioentry_accession}: {start} - {end}"
-    else:
-        description = f"GI{gis_id}"
+def format_genomic_island(gis_id, to_url=True):
+    description = f"GI{gis_id}"
     if to_url:
         return f'<a href="/genomic_island/{gis_id}">{description}</a>'
     return description

--- a/webapp/views/utils.py
+++ b/webapp/views/utils.py
@@ -18,7 +18,7 @@ title2page = {
     "COG Ortholog": ["fam_cog"],
     "Comparisons: Antimicrobial Resistance": ["amr_comparison"],
     "Comparisons: Clusters of Orthologous groups (COGs)": ["cog_comparison"],
-    "Comparisons: Genomic Islands": ["gi_comparison"],
+    "Comparisons: Genomic Islands": ["gic_comparison"],
     "Comparisons: Kegg Orthologs (KO)": ["ko_comparison"],
     "Comparisons: PFAM domains": ["pfam_comparison"],
     "Comparisons: orthologous groups": ["orthogroup_comparison"],
@@ -229,7 +229,7 @@ def format_genome(taxid_and_description):
 
 
 def format_genomic_island(
-    gis_id, bioentry_accession=None, start=None, end=None, to_url=False
+    gis_id, bioentry_accession=None, start=None, end=None, to_url=True
 ):
     if bioentry_accession is not None:
         description = f"GI{gis_id} {bioentry_accession}: {start} - {end}"
@@ -237,6 +237,13 @@ def format_genomic_island(
         description = f"GI{gis_id}"
     if to_url:
         return f'<a href="/genomic_island/{gis_id}">{description}</a>'
+    return description
+
+
+def format_genomic_island_cluster(gic_id, to_url=False):
+    description = f"GIC{gic_id}"
+    if to_url:
+        return f'<a href="/fam_gic/GIC{gic_id}">{description}</a>'
     return description
 
 

--- a/webapp/views/venn.py
+++ b/webapp/views/venn.py
@@ -5,6 +5,7 @@ from views.analysis_view_metadata import VennMetadata
 from views.errors import errors
 from views.mixins import AmrViewMixin
 from views.mixins import CogViewMixin
+from views.mixins import GiViewMixin
 from views.mixins import KoViewMixin
 from views.mixins import OrthogroupViewMixin
 from views.mixins import PfamViewMixin
@@ -166,4 +167,8 @@ class VennAmrView(VennBaseView, AmrViewMixin):
 
 
 class VennVfView(VennBaseView, VfViewMixin):
+    pass
+
+
+class VennGiView(VennBaseView, GiViewMixin):
     pass

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -1310,8 +1310,7 @@ def optimal_region_order(regions):
     return best_path
 
 
-def prepare_genomic_regions(db, filtered_regions, organisms, ref_strand):
-    hsh_description = db.get_genomes_description().description.to_dict()
+def prepare_genomic_regions(db, filtered_regions, ref_strand):
     all_regions = []
     connections = []
     prev_infos = None
@@ -1369,14 +1368,12 @@ def prepare_genomic_regions(db, filtered_regions, organisms, ref_strand):
             )
             connections.append("{" + ",".join(related) + "}")
 
-        taxid = organisms.loc[seqid].taxid
-        genome_name = hsh_description[taxid]
-        contig_name = (
-            db.get_bioentry_qualifiers(int(region["bioentry_id"][0]))
-            .set_index("term")
-            .loc["accessions"]
-            .value
-        )
+        bioentry_qualifiers = db.get_bioentry_qualifiers(
+            int(region["bioentry_id"][0])
+        ).set_index("term")
+        contig_name = bioentry_qualifiers.loc["accessions"].value
+        genome_name = bioentry_qualifiers.loc["organism"].value
+
         region_name = f"{genome_name} - {contig_name} - {int(start)}:{int(end)}"
         js_val = genomic_region_df_to_js(
             region, start, end, contig_size, contig_topology, region_name
@@ -1466,7 +1463,7 @@ def plot_region(request):
     filtered_regions = genomic_regions  # coalesce_regions(genomic_regions, seqids)
 
     all_regions, connections, all_identities = prepare_genomic_regions(
-        db, filtered_regions, organisms, ref_strand
+        db, filtered_regions, ref_strand
     )
 
     ctx = {

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -1522,13 +1522,13 @@ def get_circos_data(reference_taxon, target_taxons, highlight_og=False):
     ).set_index(["seqfeature_id"])
     # df of target genomes
     df_targets = db.get_proteins_info(
-            ids=target_taxons,
-            search_on="taxid",
-            as_df=True,
-            to_return=["locus_tag"],
-            inc_non_CDS=False,
-            inc_pseudo=False,
-        )
+        ids=target_taxons,
+        search_on="taxid",
+        as_df=True,
+        to_return=["locus_tag"],
+        inc_non_CDS=False,
+        inc_pseudo=False,
+    )
 
     # retrieve n_orthologs of list of seqids
     seq_og = db.get_og_count(df_feature_location.index.to_list(), search_on="seqid")
@@ -1550,7 +1550,6 @@ def get_circos_data(reference_taxon, target_taxons, highlight_og=False):
     df_identity = db.get_identity_closest_homolog(
         reference_taxon, target_taxons
     ).set_index(["target_taxid"])
-
 
     c = circosjs.CircosJs()
 
@@ -1576,8 +1575,12 @@ def get_circos_data(reference_taxon, target_taxons, highlight_og=False):
     ].fillna("-")
 
     df_feature_location["color"] = "grey"
-    df_feature_location.loc[df_feature_location["term_name"] == "tRNA", "color"] = "magenta"
-    df_feature_location.loc[df_feature_location["term_name"] == "rRNA", "color"] = "magenta"
+    df_feature_location.loc[df_feature_location["term_name"] == "tRNA", "color"] = (
+        "magenta"
+    )
+    df_feature_location.loc[df_feature_location["term_name"] == "rRNA", "color"] = (
+        "magenta"
+    )
 
     df_feature_location = df_feature_location.rename(columns={"locus_tag": "locus_ref"})
 
@@ -1607,9 +1610,13 @@ def get_circos_data(reference_taxon, target_taxons, highlight_og=False):
             .sort_index()
         )
 
-        df_combined = df_combined.join(df_targets, on="seqfeature_id_2", how="left").reset_index()
-        df_combined["locus_tag"] = df_combined["locus_tag"].fillna(np.nan).replace([np.nan], [None])
-        
+        df_combined = df_combined.join(
+            df_targets, on="seqfeature_id_2", how="left"
+        ).reset_index()
+        df_combined["locus_tag"] = (
+            df_combined["locus_tag"].fillna(np.nan).replace([np.nan], [None])
+        )
+
         # comp is a custom scale with missing orthologs coloured in light blue
         if n == 0:
             sep = 0.03

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -1274,14 +1274,13 @@ def optimal_region_order(regions):
     #  Make sure the genes are sorted, as we use the og order for the score:
     for region, start, end, _, _ in regions:
         region.sort_values("start_pos", inplace=True)
-
     for i, (region1, start1, end1, _, _) in enumerate(regions):
-        ogs1 = region1["orthogroup"].unique()
+        ogs1 = region1["orthogroup"]
         neighboring_ogs1 = {(ogs1[i], ogs1[i + 1]) for i in range(len(ogs1) - 1)}
         for j, (region2, start2, end2, _, _) in enumerate(regions):
             if j <= i:
                 continue
-            ogs2 = region2["orthogroup"].unique()
+            ogs2 = region2["orthogroup"]
             neighboring_ogs2 = {(ogs2[i], ogs2[i + 1]) for i in range(len(ogs2) - 1)}
             score = len(set(ogs1).intersection(ogs2)) + len(
                 neighboring_ogs1.intersection(neighboring_ogs2)

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -1356,32 +1356,35 @@ def prepare_genomic_regions(db, filtered_regions, allow_flips=False):
                 prev_infos, on="orthogroup"
             )[["locus_tag_x", "locus_tag_y", "seqid_x", "seqid_y", "orthogroup"]]
             if len(common_og) == 0:
-                continue
-            related = []
-            ogs = common_og.orthogroup.astype(int).tolist()
-            p1 = common_og.seqid_x.tolist()
-            p2 = common_og.seqid_y.tolist()
+                connections.append("{}")
+            else:
+                related = []
+                ogs = common_og.orthogroup.astype(int).tolist()
+                p1 = common_og.seqid_x.tolist()
+                p2 = common_og.seqid_y.tolist()
 
-            identities = db.get_og_identity(og=ogs, pairs=zip(p1, p2))
-            identities = identities.set_index(["seqid_x", "seqid_y"]).identity.to_dict()
-            hsh_agg = {}
-            for i, v in common_og.iterrows():
-                if v.seqid_x == v.seqid_y:
-                    ident = 100
-                elif (v.seqid_x, v.seqid_y) in identities:
-                    ident = identities[(v.seqid_x, v.seqid_y)]
-                else:
-                    ident = identities[(v.seqid_y, v.seqid_x)]
-                all_identities.append(ident)
-                og_val = to_s(int(v.orthogroup))
-                arr = hsh_agg.get(v.locus_tag_x, [])
-                arr.append(f"[{to_s(v.locus_tag_y)}, {og_val}, {ident: .2f}]")
-                hsh_agg[v.locus_tag_x] = arr
-            related = (
-                f"{to_s(loc)}: [" + ",".join(values) + "]"
-                for loc, values in hsh_agg.items()
-            )
-            connections.append("{" + ",".join(related) + "}")
+                identities = db.get_og_identity(og=ogs, pairs=zip(p1, p2))
+                identities = identities.set_index(
+                    ["seqid_x", "seqid_y"]
+                ).identity.to_dict()
+                hsh_agg = {}
+                for i, v in common_og.iterrows():
+                    if v.seqid_x == v.seqid_y:
+                        ident = 100
+                    elif (v.seqid_x, v.seqid_y) in identities:
+                        ident = identities[(v.seqid_x, v.seqid_y)]
+                    else:
+                        ident = identities[(v.seqid_y, v.seqid_x)]
+                    all_identities.append(ident)
+                    og_val = to_s(int(v.orthogroup))
+                    arr = hsh_agg.get(v.locus_tag_x, [])
+                    arr.append(f"[{to_s(v.locus_tag_y)}, {og_val}, {ident: .2f}]")
+                    hsh_agg[v.locus_tag_x] = arr
+                related = (
+                    f"{to_s(loc)}: [" + ",".join(values) + "]"
+                    for loc, values in hsh_agg.items()
+                )
+                connections.append("{" + ",".join(related) + "}")
 
         bioentry_qualifiers = db.get_bioentry_qualifiers(
             int(region["bioentry_id"][0])


### PR DESCRIPTION
With this PR we add the visualizations of genomic island clusters. Notably:
- The comparison views for genomic island clusters (index, extraction form, venn, presence/absence table, heatmap, accumulation/rarefaction)
- A details view for genomic islands
- A details view for genomic island clusters

For the genomic island cluster details view we use the fam view, so that we display 3 tabs. A tab with general information, a tab with the list of GIs in that cluster and a tab with the phylogenetic distribution of the cluster.
In the general tab we also show the genomic regions of all the GIs in the cluster.

We still have an issue with genomic islands in circular contigs spanning the "end" of the contig. Will fix that in a separate PR.

## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [x] Add tests for new features and regression tests for bugfixes whenever possible.

