### PR TITLE
Revert handling of GI spanning end of circular contig

### DIFF
--- a/bin/setup_chlamdb.py
+++ b/bin/setup_chlamdb.py
@@ -876,16 +876,9 @@ def gi_hits_to_fasta(gbk_files, gi_hits, output_file):
     records = []
     for i, gi in genomic_islands.iterrows():
         gid = str(i)
-        contig = contigs[gi.seqid]
-        start = int(gi.start)
-        end = int(gi.end)
-        if end < start and contig.annotations["topology"] == "circular":
-            seq = contig[start:].seq + contig[:end].seq
-        else:
-            seq = contig[start:end].seq
         records.append(
             SeqRecord.SeqRecord(
-                seq,
+                contigs[gi.seqid][int(gi.start) : int(gi.end)].seq,
                 id=gid,
                 name=gid,
                 description="",

--- a/bin/setup_chlamdb.py
+++ b/bin/setup_chlamdb.py
@@ -924,12 +924,9 @@ def extract_gis_hits(gff_files, hit_files, output_file):
             ["evalue", "seqid", "qcov"], ascending=[True, False, False], inplace=True
         )
         for i, row in hit_table.iterrows():
-            # We handle the case of circular contigs in the gff file (cannot happen in the hit table).
             n_overlapping = len(
                 genomic_islands.query(
-                    f"seqid=='{row.subject}' & ("
-                    f"((start<end) & ((start<{row.sstart} & end>{row.sstart}) | (start<{row.send} & end>{row.send}))) |"
-                    f"((start>end) & (end>{row.sstart} | start<{row.send})))"
+                    f"seqid=='{row.subject}' & ((start<{row.sstart} & end>{row.sstart}) | (start<{row.send} & end>{row.send}))"
                 )
             )
             if n_overlapping == 0:

--- a/bin/setup_chlamdb.py
+++ b/bin/setup_chlamdb.py
@@ -846,16 +846,9 @@ def gis_to_fasta(gbk_file, gff_file, output_file):
     records = []
     for gi in genomic_islands:
         gid = gi.attributes["ID"].strip()
-        contig = contigs[gi.seqid]
-        start = int(gi.start)
-        end = int(gi.end)
-        if end < start and contig.annotations["topology"] == "circular":
-            seq = contig[start:].seq + contig[:end].seq
-        else:
-            seq = contig[start:end].seq
         records.append(
             SeqRecord.SeqRecord(
-                seq,
+                contigs[gi.seqid][int(gi.start) : int(gi.end)].seq,
                 id=gid,
                 name=gid,
                 description="genomic island",

--- a/webapp/lib/db_utils.py
+++ b/webapp/lib/db_utils.py
@@ -2585,14 +2585,6 @@ class DB:
         ]
         self.server.adaptor.executemany(sql, data)
 
-    def get_gi_length(self, bioentry_id, start_pos, end_pos):
-        if start_pos > end_pos:
-            # GI spanning edge of circular contig
-            contig_length = self.get_bioentry_length(bioentry_id)
-            return contig_length - start_pos + end_pos
-        else:
-            return end_pos - start_pos
-
     def load_genomic_islands(self, gis, clusters):
         cluster_data = {
             gis_id: i for i, cluster in enumerate(clusters) for gis_id in cluster
@@ -2615,8 +2607,7 @@ class DB:
         # Now we prepare some descriptions of the GI clusters
         descriptions = defaultdict(list)
         for gis_id, cluster_id, bioentry_id, start_pos, end_pos in gis:
-            gi_length = self.get_gi_length(bioentry_id, start_pos, end_pos)
-            descriptions[cluster_id].append(gi_length)
+            descriptions[cluster_id].append(end_pos - start_pos)
 
         descriptions = [
             (key, int(sum(value) / len(value))) for key, value in descriptions.items()

--- a/webapp/lib/queries.py
+++ b/webapp/lib/queries.py
@@ -162,14 +162,8 @@ class GIQueries(BaseQueries):
     ]
 
     def get_containing_genomic_islands(self, bioentry_id, start, stop):
-        sql = (
-            f"SELECT gis_id, start_pos, end_pos FROM {self.hit_table} WHERE bioentry_id=? AND ("
-            "((start_pos < end_pos) AND (? BETWEEN start_pos AND end_pos OR ? BETWEEN start_pos AND end_pos)) | "
-            "((start_pos > end_pos) AND (? >= start_pos OR ? <= end_pos)) )"
-        )
-        return self.server.adaptor.execute_and_fetchall(
-            sql, [bioentry_id, start, stop, stop, start]
-        )
+        sql = f"SELECT {self.id_col}, start_pos, end_pos FROM {self.hit_table} WHERE bioentry_id=? AND (? BETWEEN start_pos AND end_pos OR ? BETWEEN start_pos AND end_pos)"
+        return self.server.adaptor.execute_and_fetchall(sql, [bioentry_id, start, stop])
 
     def get_gi_descriptions(self, gis_ids):
         plchd = self.gen_placeholder_string(gis_ids)

--- a/webapp/views/fam.py
+++ b/webapp/views/fam.py
@@ -378,19 +378,13 @@ class FamGiClusterView(FamBaseView, GiViewMixin):
 
         genomic_regions = []
         for gis_id, row in self.gics.iterrows():
-            start = int(row["start_pos"])
-            end = int(row["end_pos"])
-            bioentry_id = int(row["bioentry.bioentry_id"])
-            # We use the GI length to determine the end of the GI to handle
-            # GI spanning edge of circular contig
-            end = start + self.db.get_gi_length(bioentry_id, start, end)
             genomic_regions.append(
                 list(
                     locusx_genomic_region(
                         self.db,
-                        bioentry=bioentry_id,
-                        window_start=start,
-                        window_stop=end,
+                        bioentry=int(row["bioentry.bioentry_id"]),
+                        window_start=int(row["start_pos"]),
+                        window_stop=int(row["end_pos"]),
                     )
                 )
             )

--- a/webapp/views/genomic_island.py
+++ b/webapp/views/genomic_island.py
@@ -17,16 +17,12 @@ class GenomicIsland(GiViewMixin, View):
         cluster_descr = self.get_hit_descriptions([cluster_id]).iloc[0]
 
         self.data = self.transform_data(self.data).iloc[0]
-        gi_size = self.db.get_gi_length(
-            bioentry, self.data.start_pos, self.data.end_pos
-        )
-        end_pos = self.data.start_pos + gi_size
         all_infos, wd_start, wd_end, contig_size, contig_topology = (
             locusx_genomic_region(
                 self.db,
                 bioentry=bioentry,
                 window_start=self.data.start_pos,
-                window_stop=end_pos,
+                window_stop=self.data.end_pos,
             )
         )
         genomic_region = genomic_region_df_to_js(
@@ -41,7 +37,7 @@ class GenomicIsland(GiViewMixin, View):
             bioentry=self.data.bioentry,
             start_pos=self.data.start_pos,
             end_pos=self.data.end_pos,
-            island_size=gi_size,
+            island_size=self.data.end_pos - self.data.start_pos,
             description=self.data.gis_id,
             genomic_region=genomic_region,
             window_size=window_size,


### PR DESCRIPTION
We actually do not need this, as islandpath does not predict GIs spanning the end of a contig. This was a side-effect of using islandpath on genomes with several contigs, which is not supported by the software. To avoid this issue we will instead run islandpath on each contig in a future PR.

## Checklist
- [ ] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

