### PR TITLE
Improve display of genomic islands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Common Changelog](https://common-changelog.org)
 
 - Fix displaying genomic islands in locus view. ([#160](https://github.com/metagenlab/zDB/pull/160)) (Niklaus Johner)
 - Make sure to add run to list of completed run upon import. ([#163](https://github.com/metagenlab/zDB/pull/163)) (Niklaus Johner)
+- Fix bug in genomic_region.js for very small regions. ([#171](https://github.com/metagenlab/zDB/pull/171)) (Niklaus Johner)
 
 ### Changed
 

--- a/webapp/assets/js/genomic_region.js
+++ b/webapp/assets/js/genomic_region.js
@@ -247,18 +247,18 @@ function createGenomicRegion(div, div_width, svg_id, regions, connections, highl
 			.style("stroke", "black")
 			.style("stroke-width", base_line_width)
 			.style("stroke-dasharray", complete && circular ? "3,3" : null)
-			.attr("x1", x_scale(start))
+			.attr("x1", x_scale(start) - 0.5*base_line_width)
 			.attr("y1", y_scale(0))
-			.attr("x2", x_scale(start))
+			.attr("x2", x_scale(start) - 0.5*base_line_width)
 			.attr("y2", y_scale(2*arrow_height+base_line_width));
 
 		if(contig_start == start && !circular) {
 			svg.append("line")
 				.style("stroke", "black")
 				.style("stroke-width", 2*base_line_width)
-				.attr("x1", x_scale(start) - 2*base_line_width)
+				.attr("x1", x_scale(start) - 2.5*base_line_width)
 				.attr("y1", y_scale(0))
-				.attr("x2", x_scale(start) - 2*base_line_width)
+				.attr("x2", x_scale(start) - 2.5*base_line_width)
 				.attr("y2", y_scale(2*arrow_height+base_line_width));
 		}
 
@@ -267,18 +267,18 @@ function createGenomicRegion(div, div_width, svg_id, regions, connections, highl
 			.style("stroke", "black")
 			.style("stroke-width", base_line_width)
 			.style("stroke-dasharray", complete && circular ? "3,3" : null)
-			.attr("x1", x_scale(end))
+			.attr("x1", x_scale(end) + 0.5*base_line_width)
 			.attr("y1", y_scale(0))
-			.attr("x2", x_scale(end))
+			.attr("x2", x_scale(end) + 0.5*base_line_width)
 			.attr("y2", y_scale(2*arrow_height+base_line_width));
 
 		if(contig_end == end && !circular) {
 			svg.append("line")
 				.style("stroke", "black")
 				.style("stroke-width", 2*base_line_width)
-				.attr("x1", x_scale(end) + 2*base_line_width)
+				.attr("x1", x_scale(end) + 2.5*base_line_width)
 				.attr("y1", y_scale(0))
-				.attr("x2", x_scale(end) + 2*base_line_width)
+				.attr("x2", x_scale(end) + 2.5*base_line_width)
 				.attr("y2", y_scale(2*arrow_height+base_line_width));
 		}
 
@@ -366,8 +366,7 @@ function createGenomicRegion(div, div_width, svg_id, regions, connections, highl
 		let current_region = regions[i];
 		let region_size = current_region.end-current_region.start;
 		let y_base_pos = region_height*i + i*regions_vertical_interval;
-		let this_region_width = (region_size/max_region_size)*default_width;
-		this_region_width -= 6*base_line_width;
+		let this_region_width = (region_size/max_region_size)*(default_width - 7*base_line_width);
 		let horiz_padding = default_width-this_region_width;
 		let x_scale = d3.scale.linear().
 			domain([current_region.start, current_region.end]).

--- a/webapp/assets/js/genomic_region.js
+++ b/webapp/assets/js/genomic_region.js
@@ -317,6 +317,9 @@ function createGenomicRegion(div, div_width, svg_id, regions, connections, highl
 			text = text.slice(0, -1);
 			obj.text(text + "...");
 			textLength = obj.node().getComputedTextLength();
+			if (text.length <= 5) {
+				break;
+			}
 		}
 	}
 

--- a/webapp/views/mixins.py
+++ b/webapp/views/mixins.py
@@ -471,6 +471,7 @@ class GiViewMixin(BaseViewMixin, GiMetadata):
 
     def get_gi_descriptions(self, ids, transformed=True, **kwargs):
         descriptions = self.db.gi.get_gi_descriptions(ids)
+        descriptions["length"] = descriptions["end_pos"] - descriptions["start_pos"]
         descriptions = descriptions.set_index("gis_id", drop=False)
         if transformed:
             descriptions = self.transform_data(descriptions)

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -1309,6 +1309,7 @@ def optimal_region_order(regions, allow_flips=False):
             next_choice = region_indices[remaining_choices][max_index]
             path.append(next_choice)
             path_flips.append(flips[current, next_choice])
+            current = next_choice
         score = sum(similarities[path[i], path[i + 1]] for i in range(n_regions - 1))
         if score > max_score:
             max_score = score

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -1299,7 +1299,7 @@ def optimal_region_order(regions, allow_flips=False):
     max_score = -1
     for start in region_indices:
         path = [start]
-        path_flips = [False]
+        path_flips = [0]
         current = start
         while len(path) < n_regions:
             remaining_choices = [
@@ -1354,11 +1354,16 @@ def prepare_genomic_regions(db, filtered_regions, allow_flips=False):
         filtered_regions, allow_flips=allow_flips
     )
     filtered_regions = [filtered_regions[i] for i in best_path]
+
     # Flip the regions if necessary
     if allow_flips:
+        prev_flip = 0
         for i, (region, start, end, _, _) in enumerate(filtered_regions):
-            if best_path_flips[i]:
+            if best_path_flips[i] != prev_flip:
                 flip_region(region, start, end)
+                prev_flip = 1
+            else:
+                prev_flip = 0
 
     for region, start, end, contig_size, contig_topology in filtered_regions:
         if prev_infos is not None:

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -1293,7 +1293,7 @@ def optimal_region_order(regions, allow_flips=False):
                     ns = ns2
                     flips[i, j] = flips[j, i] = 1
             score = len(set(ogs1).intersection(ogs2)) + ns
-            similarities[i, j] = similarities[j, i] = score
+            similarities[i, j] = similarities[j, i] = score / len(set(ogs1).union(ogs2))
 
     region_indices = np.arange(n_regions)
     max_score = -1


### PR DESCRIPTION
In this PR we fix a few bugs for the display of the genomic islands notably for the plot of the genomic regions:
- Fix optimization of orientation of genomic regions.
- Fix choosing the optimal order of genomic regions.
- Improve score for optimal ordering of genomic regions.
- Add length to genomic island table.
- Fix relative sizes of plotted regions.
- Fix bug in `genomic_region.js` for very small regions.

## Checklist
- [x] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

