### PR TITLE
Highlight AMR and VF genes in genomic island representations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Added
 
+- Highlight AMR and VF genes in genomic island representations. ([#174](https://github.com/metagenlab/zDB/pull/174)) (Niklaus Johner)
 
 ## 1.3.6 - 2025-05-02
 

--- a/webapp/assets/js/genomic_region.js
+++ b/webapp/assets/js/genomic_region.js
@@ -137,8 +137,8 @@ function createGenomicRegion(div, div_width, svg_id, regions, connections, highl
 		.style("stroke-width", 2)
 		.style("opacity", .9)
 		.style("fill", function(d) {
-			if(highlight!=null && highlight.find(el => el===d.locus_tag)!==undefined) {
-				return "red";
+			if(highlight!=null && d.locus_tag in highlight) {
+				return highlight[d.locus_tag];
 			} else if(d.type=="CDS") {
 				return "green";
 			} else if(d.type=="tmRNA" || d.type=="tRNA" || d.type=="rRNA") {

--- a/webapp/lib/db_utils.py
+++ b/webapp/lib/db_utils.py
@@ -2630,25 +2630,27 @@ class DB:
         self.server.adaptor.execute(sql)
         self.load_data_into_table("amr_hits", data)
 
-    def get_amr_hits_from_seqids(self, ids):
+    def get_amr_hits_from_seqids(self, ids, columns=None):
         """
         For now we limit that search to AMR type
         """
+        if columns is None:
+            columns = (
+                "gene",
+                "scope",
+                "type",
+                "class",
+                "subclass",
+                "coverage",
+                "identity",
+                "closest_seq",
+                "hmm_id",
+            )
 
-        columns = (
-            "gene",
-            "scope",
-            "type",
-            "class",
-            "subclass",
-            "coverage",
-            "identity",
-            "closest_seq",
-            "hmm_id",
-        )
-
+        col_sele = [f"hsh.{col}" if col == "seqid" else f"amr.{col}" for col in columns]
+        col_sele = ", ".join(col_sele)
         query = (
-            f"SELECT {', '.join(f'amr.{col}' for col in columns)} "
+            f"SELECT {col_sele} "
             "FROM amr_hits AS amr "
             "INNER JOIN sequence_hash_dictionnary AS hsh ON hsh.hsh = amr.hsh "
             f"WHERE hsh.seqid IN ({', '.join(str(el) for el in ids)});"

--- a/webapp/templates/chlamdb/genomic_island.html
+++ b/webapp/templates/chlamdb/genomic_island.html
@@ -86,7 +86,10 @@
                       <i class="glyphicon glyphicon-download"></i>
                     </button>
                   </div>
-                  <h3 class="panel-title">Genomic island</h3>
+                  <h3 class="panel-title">
+                    Genomic island
+                    <i class="fab fa-info-circle " style="size: 5em;" title="Genes in magenta are AMR genes, while purple correspond to VF genes."></i>
+                  </h3>
                 </div>
                 <div class="panel-body" style="height:100px; display:flex; justify-content:center; align-items:center; margin-bottom:30px" id="genomic_region_rect">
                   <div id="div_genomic_region"></div>

--- a/webapp/templates/chlamdb/genomic_island.html
+++ b/webapp/templates/chlamdb/genomic_island.html
@@ -110,7 +110,7 @@ var genomic_region_rect = document.querySelector("#genomic_region_rect")
 var genomic_width = genomic_region_rect.right-genomic_region_rect.left;
 
 createGenomicRegion(d3.select("#div_genomic_region"), genomic_width*.8, "genomic_region", [genomic_region],
-    0, ["{{locus_tag}}"], {{window_size}});
+    0, {}, {{window_size}});
 
 document.querySelector("#download_svg_button").onclick = function() {
   var svg_elem = document.querySelector("#genomic_region");

--- a/webapp/templates/chlamdb/genomic_island.html
+++ b/webapp/templates/chlamdb/genomic_island.html
@@ -105,12 +105,13 @@
 
 <script>
 var genomic_region = {{genomic_region|safe}};
+var to_highlight = {{to_highlight|safe}};
 var genomic_region_rect = document.querySelector("#genomic_region_rect")
     .getBoundingClientRect();
 var genomic_width = genomic_region_rect.right-genomic_region_rect.left;
 
 createGenomicRegion(d3.select("#div_genomic_region"), genomic_width*.8, "genomic_region", [genomic_region],
-    0, {}, {{window_size}});
+    0, to_highlight, {{window_size}});
 
 document.querySelector("#download_svg_button").onclick = function() {
   var svg_elem = document.querySelector("#genomic_region");

--- a/webapp/templates/chlamdb/locus.html
+++ b/webapp/templates/chlamdb/locus.html
@@ -540,7 +540,7 @@ var genomic_region_rect = document.querySelector("#genomic_region_rect")
 var genomic_width = genomic_region_rect.right-genomic_region_rect.left;
 
 createGenomicRegion(d3.select("#div_genomic_region"), genomic_width*.8, "genomic_region", [genomic_region],
-    0, ["{{locus_tag}}"], {{window_size}});
+    0, {"{{locus_tag}}":"red"}, {{window_size}});
 
 document.querySelector("#download_svg_button").onclick = function() {
   var svg_elem = document.querySelector("#genomic_region");

--- a/webapp/templates/chlamdb/region.html
+++ b/webapp/templates/chlamdb/region.html
@@ -37,7 +37,7 @@
 <script>
 
 var regions = {{results.genomic_regions|safe}};
-var to_highlight = {{results.to_highlight|safe}};
+var to_highlight = {{results.to_highlight|safe|default:"{}"}};
 var connections = {{results.connections | safe}};
 var ident_range = [{{results.min_ident}}, {{results.max_ident}}];
 var genomic_region_rect = document.querySelector("#div_alignment_bounding")

--- a/webapp/templates/chlamdb/region.html
+++ b/webapp/templates/chlamdb/region.html
@@ -9,7 +9,7 @@
   <div  class="col-md-12 col-lg-12" style="padding-left: 15px">
     <div class="alert alert-info fade in" style="width:90%; margin: 10px 10px 10px 10px">
       <a href="#" class="close" data-dismiss="alert">&times;</a>
-      {{results.description}}<br>
+      {{results.description|safe}}<br>
       Links are coloured wiht a scale of gray reflecting the sequence identity:
       dark gray for highly conserved, light grey for features with less identity. Click on the link to visualise the percentage of identity.
       Beginning and end of the regions are shown as dashed line if the region shows a complete circular contig, a double line if the start or end of the region matches the start or end of a linear contig and a single line otherwise.

--- a/webapp/views/fam.py
+++ b/webapp/views/fam.py
@@ -443,7 +443,10 @@ class FamGiClusterView(FamBaseView, GiViewMixin):
         if len(all_identities) > 0:
             tabs[0].max_ident = max(all_identities)
             tabs[0].min_ident = min(all_identities)
-        tabs[0].description = "This plot shows the genomic regions of the selected GIs."
+        tabs[0].description = (
+            "This plot shows the genomic regions of the selected GIs."
+            "<br>Genes in magenta are AMR genes, while purple correspond to VF genes."
+        )
 
     def add_orthogroup_table(self, tabs):
         og_mixin = OrthogroupViewMixin()

--- a/webapp/views/fam.py
+++ b/webapp/views/fam.py
@@ -416,6 +416,7 @@ class FamGiClusterView(FamBaseView, GiViewMixin):
         all_regions, connections, all_identities = prepare_genomic_regions(
             self.db, genomic_regions, allow_flips=True
         )
+        to_highlight = {}
         if optional2status.get("amr", False):
             amrs = self.db.get_amr_hits_from_seqids(self.seqids, columns=("seqid",))
             to_highlight = {
@@ -424,8 +425,17 @@ class FamGiClusterView(FamBaseView, GiViewMixin):
                     amrs.seqid.to_list(), to_return=["locus_tag"], as_df=True
                 ).locus_tag
             }
-        else:
-            to_highlight = {}
+        if optional2status.get("vf", False):
+            vfs = self.db.vf.get_hits_from_seqids(self.seqids, columns=("seqid",))
+            to_highlight.update(
+                {
+                    el: "purple"
+                    for el in self.db.get_proteins_info(
+                        vfs.seqid.to_list(), to_return=["locus_tag"], as_df=True
+                    ).locus_tag
+                }
+            )
+
         tabs[0].show_genomic_region = True
         tabs[0].genomic_regions = "[" + "\n,".join(all_regions) + "]"
         tabs[0].connections = "[" + ",".join(connections) + "]"

--- a/webapp/views/views.py
+++ b/webapp/views/views.py
@@ -1484,7 +1484,7 @@ def plot_region(request):
     region_size = form.get_region_size()
 
     locus_tags = db.get_proteins_info(seqids, to_return=["locus_tag"], as_df=True)
-    to_highlight = locus_tags["locus_tag"].tolist()
+    to_highlight = {el: "red" for el in locus_tags["locus_tag"]}
 
     genomic_regions = []
     for seqid in seqids:


### PR DESCRIPTION
With this PR we add coloring of AMR and VF genes in genomic representations of GIs and GI clusters.
To do so, we make the `to_highlight` parameter into a dictionary instead of a list, allowing to set the color for individual loci directly in python.

## Checklist
- [x] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

