### PR TITLE
Display correct GI ID in locus view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
+- Display correct GI ID in locus view. ([#175](https://github.com/metagenlab/zDB/pull/175)) (Niklaus Johner)
+
 ### Changed
 
 ### Added

--- a/webapp/lib/queries.py
+++ b/webapp/lib/queries.py
@@ -162,7 +162,7 @@ class GIQueries(BaseQueries):
     ]
 
     def get_containing_genomic_islands(self, bioentry_id, start, stop):
-        sql = f"SELECT {self.id_col}, start_pos, end_pos FROM {self.hit_table} WHERE bioentry_id=? AND (? BETWEEN start_pos AND end_pos OR ? BETWEEN start_pos AND end_pos)"
+        sql = f"SELECT gis_id, start_pos, end_pos FROM {self.hit_table} WHERE bioentry_id=? AND (? BETWEEN start_pos AND end_pos OR ? BETWEEN start_pos AND end_pos)"
         return self.server.adaptor.execute_and_fetchall(sql, [bioentry_id, start, stop])
 
     def get_gi_descriptions(self, gis_ids):


### PR DESCRIPTION
We were displaying the GI cluster ID in the locus view, but linking it as if it were a GI. We now correctly display the link to the GI.

## Checklist
- [x] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

