### PR TITLE
Fix annotation pipeline for input file with .genbank extensions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
+- Fix annotation pipeline for input file with .genbank extensions. ([#181](https://github.com/metagenlab/zDB/pull/181)) (Niklaus Johner)
+
 ### Changed
 
 - Color genes as AMR if they are annotated as both AMR and VF in GI genomic region.([#180](https://github.com/metagenlab/zDB/pull/180)) (Niklaus Johner)

--- a/annotation_pipeline.nf
+++ b/annotation_pipeline.nf
@@ -1153,9 +1153,7 @@ process cleanup {
     fi
 
     mkdir -p "${gbk_dir}"
-    for gbk in filtered/*.gb*; do
-    cp \$gbk ${gbk_dir}
-    done
+    cp $gbks/* ${gbk_dir}
 
     mv \$(readlink $index) ${results_dir}/search_index/index_${workflow.runName}
 


### PR DESCRIPTION
Cleanup basically only worked for .gbk and .gbff inputs. We now support any extension.

resolves #179 

## Checklist
- [x] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

