### PR TITLE
Rename "N plasmid contigs" column to "Has plasmid(s)" in genome table.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Changed
 
+- Rename "N plasmid contigs" column to "Has plasmid(s)" in genome table. ([#184](https://github.com/metagenlab/zDB/pull/184)) (Niklaus Johner))
 - Color genes as AMR if they are annotated as both AMR and VF in GI genomic region.([#180](https://github.com/metagenlab/zDB/pull/180)) (Niklaus Johner)
 
 ### Added

--- a/webapp/views/mixins.py
+++ b/webapp/views/mixins.py
@@ -563,7 +563,7 @@ class GenomesTableMixin:
             "N contigs",
             "Size (Mbp)",
             "Coding %",
-            "N plasmid contigs",
+            "Has plasmid(s)",
             "faa seq",
             "fna seq",
             "ffn seq",


### PR DESCRIPTION
This column indeed displays whether the genome has at least one plasmid contig and not the number of plasmid contigs.

Fixes https://github.com/metagenlab/zDB/issues/182

## Checklist
- [x] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

