### PR TITLE
Add possibility to display GIs, AMRs and VFs and to show/hide certain tracks on circos map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,12 @@ to [Common Changelog](https://common-changelog.org)
 
 - Update orthofinder to version 3.1 to speed-up annotation pipeline. ([#188](https://github.com/metagenlab/zDB/pull/188)) (Niklaus Johner)
 - Improve circos plots by making them interactive. ([#190](https://github.com/metagenlab/zDB/pull/190)) (Niklaus Johner)
+- Allow switching certain tracks on/off on the circos map. ([#191](https://github.com/metagenlab/zDB/pull/191)) (Niklaus Johner)
 
 ### Added
+
+- Add possibility to display GIs, AMRs and VFs on circos map. ([#191](https://github.com/metagenlab/zDB/pull/191)) (Niklaus Johner)
+
 
 ## 1.3.8 - 2025-07-15
 

--- a/testing/webapp/test_autocomplete_views.py
+++ b/testing/webapp/test_autocomplete_views.py
@@ -73,7 +73,7 @@ class TestAutocompleteTaxid(BaseAutocompleteTestCase):
         self.db.server.close()
 
     def test_handles_include_plasmids(self):
-        with self.add_plasmid_for_taxids([1, 2]):
+        with self.add_plasmid_for_taxids([1, 3]):
             resp = self.make_request()
             self.assertItemsEqual(self.taxons + self.groups, resp.json()["results"])
 

--- a/testing/webapp/test_utils.py
+++ b/testing/webapp/test_utils.py
@@ -50,7 +50,7 @@ class TestAccessionFieldHandler(SimpleTestCase):
     def test_get_choices_handles_plasmids(self):
         self.assertItemsEqual(self.taxons + self.groups, self.handler.get_choices())
 
-        self.add_plasmid_for_taxids([1, 3])
+        self.add_plasmid_for_taxids([1, 4])
         self.assertItemsEqual(
             self.taxons + self.groups + self.plasmids[::2], self.handler.get_choices()
         )
@@ -68,7 +68,7 @@ class TestAccessionFieldHandler(SimpleTestCase):
             [self.taxons[0]], self.handler.get_choices(exclude=exclude)
         )
 
-        self.add_plasmid_for_taxids([1, 2, 3])
+        self.add_plasmid_for_taxids([1, 3, 4])
         self.assertItemsEqual(
             self.taxons + self.groups + self.plasmids, self.handler.get_choices()
         )
@@ -85,7 +85,7 @@ class TestAccessionFieldHandler(SimpleTestCase):
         )
 
     def test_get_choices_handles_plasmid_exclusion(self):
-        self.add_plasmid_for_taxids([1, 2, 3])
+        self.add_plasmid_for_taxids([1, 3, 4])
 
         exclude = [self.plasmids[-1][0]]
         self.assertItemsEqual(

--- a/webapp/lib/queries.py
+++ b/webapp/lib/queries.py
@@ -156,8 +156,12 @@ class GIQueries(BaseQueries):
     )
 
     hit_cols = [
+        "gis_id",
         "bioentry.taxon_id",
+        "bioentry.bioentry_id",
         f"{hit_table}.{id_col}",
+        "start_pos",
+        "end_pos",
         "length",
     ]
 
@@ -189,6 +193,10 @@ class GIQueries(BaseQueries):
         return self.to_pandas_frame(
             self.server.adaptor.execute_and_fetchall(sql, gis_ids), columns
         )
+
+    def get_genomic_islands(self, cluster_id):
+        sql = f"SELECT {self.id_col}, bioentry_id, start_pos, end_pos FROM {self.hit_table} WHERE {self.id_col}=?"
+        return self.server.adaptor.execute_and_fetchall(sql, [cluster_id])
 
 
 class VFQueries(BaseQueries):

--- a/webapp/templates/chlamdb/circos.html
+++ b/webapp/templates/chlamdb/circos.html
@@ -85,22 +85,36 @@
                       <div class="cgv-btn" id="btn-download" title="Download Map PNG"></div>
                       <div class="cgv-btn" id="btn-toggle-labels" title="Toggle Labels"></div>
 
-                      <label for="ref_coloring">Ref. genome color map:</label>
+                      <div>
+                        <label for="ref_coloring" style="margin-left: 10px">Ref. genome color map:</label>
 
-                      <select name="ref_coloring" id="ref_colors">
-                        {% if with_highlighted_ogs %}
-                          <option selected value="extracted">Extracted</option>
-                          <option value="type">Locus type</option>
-                        {% else %}
-                          <option selected value="type">Locus type</option>
-                        {% endif %}
-                        {% if with_amr %}
-                          <option value="AMR">AMR</option>
-                        {% endif %}
-                        {% if with_vf %}
-                          <option value="VF">VF</option>
-                        {% endif %}
-                      </select> 
+                        <select name="ref_coloring" id="ref_colors">
+                          {% if with_highlighted_ogs %}
+                            <option selected value="extracted">Extracted</option>
+                            <option value="type">Locus type</option>
+                          {% else %}
+                            <option selected value="type">Locus type</option>
+                          {% endif %}
+                          {% if with_amr %}
+                            <option value="AMR">AMR</option>
+                          {% endif %}
+                          {% if with_vf %}
+                            <option value="VF">VF</option>
+                          {% endif %}
+                        </select> 
+                      </div>
+
+                      <div>
+                        <label for="visible_tracks" style="vertical-align:top; margin-left: 10px">visible tracks</label>
+                        <select name="visible_tracks" id="visible_tracks" multiple >
+                          <option selected value="prevalence">Prevalence</option>
+                          {% if with_gi %}
+                            <option selected value="Genomic island">Genomic island</option>
+                          {% endif %}
+                          <option selected value="GC Content">GC Content</option>
+                          <option selected value="GC Skew">GC Skew</option>
+                        </select> 
+                      </div>
                     </div>
                   </ul>
                 </div>
@@ -241,6 +255,45 @@ $(document).ready(function() {
     })
     cgv.draw();
   });
+
+  // Add event listener for visible tracks
+  document.getElementById('visible_tracks').addEventListener('change', function() {
+    const selected = Array.from(this.selectedOptions).map(opt => opt.value);
+    const optionValues = Array.from(this.options).map(opt => opt.value);
+
+    optionValues.forEach(function(trackName) {
+      // Set track visibility
+      const track = cgv.tracks(trackName);
+      visible = selected.includes(trackName)
+      track.visible = visible;
+      
+      // Set legendItem visibility
+      if (trackName === "GC Skew") {
+        legendItem = cgv.legend.findLegendItemByName(trackName + "+")
+        legendItem.visible = visible;
+        legendItem = cgv.legend.findLegendItemByName(trackName + "-")
+        legendItem.visible = visible;
+      }
+      else {
+        const legendItem = cgv.legend.findLegendItemByName(trackName)
+        legendItem.visible = visible;
+      }
+
+      // Set label visibility
+      gi_visible = selected.includes("Genomic island")
+      og_visible = selected.includes("prevalence")
+      cgv.annotation.labels().forEach(function(label){
+        type = label.feature.type
+        if (type === "genomic island") {
+          label.feature.visible = gi_visible
+        }
+        else if (type === "OG") {
+          label.feature.visible = og_visible
+        }
+      })
+    });
+  cgv.draw();
+});
 
   cgv.reset();
   cgv.draw();

--- a/webapp/templates/chlamdb/circos.html
+++ b/webapp/templates/chlamdb/circos.html
@@ -97,6 +97,9 @@
                         {% if with_amr %}
                           <option value="AMR">AMR</option>
                         {% endif %}
+                        {% if with_vf %}
+                          <option value="VF">VF</option>
+                        {% endif %}
                       </select> 
                     </div>
                   </ul>

--- a/webapp/templates/chlamdb/circos.html
+++ b/webapp/templates/chlamdb/circos.html
@@ -164,6 +164,9 @@ $(document).ready(function() {
       else if (event.slot.track.name === 'Prevalence') {
         window.open(`/orthogroup/${event.element.name}`)
       }
+      else if (event.slot.track.name === 'gi') {
+        window.open(`/genomic_island/${event.element.name.substring(2)}`)
+      }
     }
   });
 

--- a/webapp/templates/chlamdb/circos.html
+++ b/webapp/templates/chlamdb/circos.html
@@ -84,6 +84,20 @@
                       <div class="cgv-btn" id="btn-invert-colors" title="Invert Map Colors"></div>
                       <div class="cgv-btn" id="btn-download" title="Download Map PNG"></div>
                       <div class="cgv-btn" id="btn-toggle-labels" title="Toggle Labels"></div>
+
+                      <label for="ref_coloring">Ref. genome color map:</label>
+
+                      <select name="ref_coloring" id="ref_colors">
+                        {% if with_highlighted_ogs %}
+                          <option selected value="extracted">Extracted</option>
+                          <option value="type">Locus type</option>
+                        {% else %}
+                          <option selected value="type">Locus type</option>
+                        {% endif %}
+                        {% if with_amr %}
+                          <option value="AMR">AMR</option>
+                        {% endif %}
+                      </select> 
                     </div>
                   </ul>
                 </div>
@@ -194,7 +208,32 @@ $(document).ready(function() {
     cgv.annotation.update({visible: !cgv.annotation.visible});
     cgv.draw();
   });
-  
+
+  // Add event listener for reference coloring scheme select menu
+  document.getElementById('ref_colors').addEventListener('change', function() {
+    const selected = this.value;
+    const ref = cgv.tracks("reference");
+
+    if (selected === "type") {
+      get_legend = function(feature) {
+        return feature.type
+      };
+    }
+    else {
+      get_legend = function(feature) {
+        return `${selected} ${feature._meta[selected]}`
+      };
+    }
+
+    to_remove = new Set()
+    ref.features().forEach(function(feature) {
+      to_remove.add(feature.legend)
+      feature.update({"legendItem": get_legend(feature)})
+    });
+    cgv.legend.removeItems(Array.from(to_remove))
+    cgv.draw();
+  });
+
   cgv.reset();
   cgv.draw();
 });

--- a/webapp/templates/chlamdb/circos.html
+++ b/webapp/templates/chlamdb/circos.html
@@ -129,28 +129,22 @@ $(document).ready(function() {
   // Load data
   cgv.io.loadJSON({{circos_json| safe}});
   cgv.addTracks({
-    name: 'GC Skew',
+    name: 'GC Content',
     position: 'inside',
     dataType: 'feature',
     dataMethod: 'sequence',
-    // e.g. In this example, GC Skew plot will be extracted from the sequence.
-    dataKeys: 'gc-skew',
-    // By default, the step and window values are calculated based on the sequence length,
-    // but they can be overridden here.
+    dataKeys: 'gc-content',
     dataOptions: {
       step: 1,
       window: 100
     }
   });
   cgv.addTracks({
-    name: 'GC Content',
+    name: 'GC Skew',
     position: 'inside',
     dataType: 'feature',
     dataMethod: 'sequence',
-    // e.g. In this example, GC Content plot will be extracted from the sequence.
-    dataKeys: 'gc-content',
-    // By default, the step and window values are calculated based on the sequence length,
-    // but they can be overridden here.
+    dataKeys: 'gc-skew',
     dataOptions: {
       step: 1,
       window: 100
@@ -231,12 +225,20 @@ $(document).ready(function() {
       };
     }
 
-    to_remove = new Set()
+    to_hide = new Set()
+    to_show = new Set()
     ref.features().forEach(function(feature) {
-      to_remove.add(feature.legend)
-      feature.update({"legendItem": get_legend(feature)})
+      to_hide.add(feature.legend)
+      new_legend = get_legend(feature)
+      to_show.add(new_legend)
+      feature.update({"legendItem": new_legend})
     });
-    cgv.legend.removeItems(Array.from(to_remove))
+    to_hide.forEach(function(item) {
+      item.visible = false;
+    })
+    to_show.forEach(function(name) {
+      cgv.legend.findLegendItemByName(name).visible = true;
+    })
     cgv.draw();
   });
 

--- a/webapp/views/circos.py
+++ b/webapp/views/circos.py
@@ -445,6 +445,8 @@ class CircosView(BaseViewMixin, View):
             taxon_colors = {
                 el: tab20(i % 20) for i, el in enumerate(target_taxon_n_homologs.index)
             }
+
+        genome_descriptions = self.db.get_genomes_description(self.target_taxons)
         for target_taxon in target_taxon_n_homologs.index:
             df_combined = df_feature_location.join(
                 df_identity.loc[target_taxon]
@@ -470,7 +472,7 @@ class CircosView(BaseViewMixin, View):
             )
             self.data.add_heatmap_data(
                 df_combined,
-                f"target_{target_taxon}",
+                genome_descriptions.loc[target_taxon].description,
                 mpl.colors.rgb2hex(taxon_colors[target_taxon]),
             )
         self.data.add_heatmap_track()

--- a/webapp/views/circos.py
+++ b/webapp/views/circos.py
@@ -17,10 +17,13 @@ class CircosData:
     Prepare json for CGView
     """
 
-    def __init__(self, with_amr=False, with_vf=False, with_highlighted_ogs=False):
+    def __init__(
+        self, with_amr=False, with_vf=False, with_highlighted_ogs=False, with_gi=False
+    ):
         self.with_amr = with_amr
         self.with_vf = with_vf
         self.with_highlighted_ogs = with_highlighted_ogs
+        self.with_gi = with_gi
         self.features = []
         self.contigs = []
         self.plots = []
@@ -267,7 +270,7 @@ class CircosData:
         self.features.extend(loci)
         self.tracks.append(
             {
-                "name": "gi",
+                "name": "Genomic island",
                 "separateFeaturesBy": "none",
                 "position": "outside",
                 "dataKeys": "gi",
@@ -308,7 +311,6 @@ class CircosView(BaseViewMixin, View):
                 self.highlighted_ogs = self.form.data.getlist("highlighted_ogs")
                 form_display = None
 
-            self.with_gi = optional2status.get("gi", False)
             self.prepare_circos_data()
             context = self.get_context(
                 show_results=True,
@@ -317,6 +319,7 @@ class CircosView(BaseViewMixin, View):
                 with_highlighted_ogs=self.data.with_highlighted_ogs,
                 with_amr=self.data.with_amr,
                 with_vf=self.data.with_vf,
+                with_gi=self.data.with_gi,
             )
             return render(request, self.template, context)
         return render(request, self.template, self.get_context())
@@ -326,6 +329,7 @@ class CircosView(BaseViewMixin, View):
             with_highlighted_ogs=self.highlighted_ogs is not None,
             with_amr=optional2status.get("amr", False),
             with_vf=optional2status.get("vf", False),
+            with_gi=optional2status.get("gi", False),
         )
         # "bioentry_id", "accession" ,"length"
         df_bioentry = self.db.get_bioentry_list(
@@ -424,7 +428,7 @@ class CircosView(BaseViewMixin, View):
             columns={"locus_tag": "locus_ref"}
         )
 
-        if self.with_gi:
+        if self.data.with_gi:
             gis = self.db.gi.get_hits([self.reference_taxon])
             self.data.add_gi_track(gis)
 


### PR DESCRIPTION
With this pull request we further improve the circos view. Specifically we:

- Add a track for the genomic islands
- Allow displaying VFs and AMRs on the reference genome. This is done by allowing to switch between different color schemes for the reference genome.
- Allow hiding/showing certain tracks on the circos map.
- Overall improvement of the map by improving spacing, colors and legend order.

<img width="844" height="662" alt="circos" src="https://github.com/user-attachments/assets/be4e1767-e337-432e-ac61-e86c721f5226" />


## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

