### PR TITLE
Improve labels and popovers and fix broken links in circos map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ to [Common Changelog](https://common-changelog.org)
 ### Fixed
 
 - Fix circos view for contigs shorter than 1000bp. ([#194](https://github.com/metagenlab/zDB/pull/194)) (Niklaus Johner)
+-Fix broken links for feature with a mapped label on circos map. ([#198](https://github.com/metagenlab/zDB/pull/198)) (Niklaus Johner)
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ to [Common Changelog](https://common-changelog.org)
 ### Fixed
 
 - Fix circos view for contigs shorter than 1000bp. ([#194](https://github.com/metagenlab/zDB/pull/194)) (Niklaus Johner)
--Fix broken links for feature with a mapped label on circos map. ([#198](https://github.com/metagenlab/zDB/pull/198)) (Niklaus Johner)
+-Fix broken links for genomic islands and features with a mapped label on circos map. ([#198](https://github.com/metagenlab/zDB/pull/198)) (Niklaus Johner)
 
 
 ### Changed

--- a/webapp/templates/chlamdb/circos.html
+++ b/webapp/templates/chlamdb/circos.html
@@ -187,14 +187,15 @@ $(document).ready(function() {
   });
   cgv.on('click', (event) => {
     if (event.elementType === 'feature') {
+      const name = event.element.meta.unmapped_name || event.element.name
       if (['targets', 'reference'].includes(event.slot.track.name)) {
-        window.open(`/locusx/${event.element.name}`)
+        window.open(`/locusx/${name}`)
       }
       else if (event.slot.track.name === 'Prevalence') {
-        window.open(`/orthogroup/${event.element.name}`)
+        window.open(`/orthogroup/${name}`)
       }
       else if (event.slot.track.name === 'gi') {
-        window.open(`/genomic_island/${event.element.name.substring(2)}`)
+        window.open(`/genomic_island/${name.substring(2)}`)
       }
     }
   });

--- a/webapp/templates/chlamdb/circos.html
+++ b/webapp/templates/chlamdb/circos.html
@@ -194,7 +194,7 @@ $(document).ready(function() {
       else if (event.slot.track.name === 'Prevalence') {
         window.open(`/orthogroup/${name}`)
       }
-      else if (event.slot.track.name === 'gi') {
+      else if (event.slot.track.name === 'Genomic island') {
         window.open(`/genomic_island/${name.substring(2)}`)
       }
     }

--- a/webapp/templates/chlamdb/circos.html
+++ b/webapp/templates/chlamdb/circos.html
@@ -147,6 +147,22 @@ $(document).ready(function() {
   });
   // Load data
   cgv.io.loadJSON({{circos_json| safe}});
+  // Custom highlighter to hide certain metadata fields and display the unmapped name
+  // when it was mapped for the label.
+  cgv.highlighter.feature.popoverContents = function(e) {
+    const feature = e.element;
+    const fullLength = feature.length !== feature.fullLength ? `(${window.CGView.utils.commaNumber(feature.fullLength)} bp)` : '';
+    const filtered_meta = Object.fromEntries(Object.entries(feature.meta).filter(([key, value]) => !(['highlighted', 'url'].includes(key))))
+    return (`
+      <div style='margin: 0 5px; font-size: 14px'>
+        <div>${feature.type}: ${feature.meta.unmapped_name || feature.name}<div>
+        <div class='track-data'>Length: ${window.CGView.utils.commaNumber(feature.length)} bp ${fullLength}</div>
+        ${window.CGView.Highlighter.getMetaDivs(feature.qualifiers)}
+        ${window.CGView.Highlighter.getMetaDivs(filtered_meta)}
+        ${window.CGView.Highlighter.getTrackDiv(e)}
+      </div>
+    `);
+  };
   cgv.addTracks({
     name: 'GC Content',
     position: 'inside',

--- a/webapp/views/circos.py
+++ b/webapp/views/circos.py
@@ -294,6 +294,7 @@ class CircosData:
         if label_mapping:
             for el in self.features:
                 if el["name"] in label_mapping:
+                    el["meta"]["unmapped_name"] = el["name"]
                     el["name"] = label_mapping[el["name"]]
                     el["favorite"] = True
         else:


### PR DESCRIPTION
When using custom labels, the links to go to the locus views were broken. Moreover there was some unnecessary information in the popovers and the links for the genomic islands were broken. We fix all of this with this PR. For this we had to add a custom highlighter for features, to display the information we want, as the feature name is always what is used for the label.

## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

