### PR TITLE
Allow errors in islandpath execution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ to [Common Changelog](https://common-changelog.org)
 ### Fixed
 
 - Re-add JS libraries accidentally removed and fix various small JS errors. ([#196](https://github.com/metagenlab/zDB/pull/196)) (Niklaus Johner)
--Fix broken links for genomic islands and features with a mapped label on circos map. ([#198](https://github.com/metagenlab/zDB/pull/198)) (Niklaus Johner)
+- Fix broken links for genomic islands and features with a mapped label on circos map. ([#198](https://github.com/metagenlab/zDB/pull/198)) (Niklaus Johner)
+- Fix genomic island prediction for short contigs ([#200](https://github.com/metagenlab/zDB/pull/200)) (Niklaus Johner)
 
 ### Changed
 

--- a/annotation_pipeline.nf
+++ b/annotation_pipeline.nf
@@ -546,7 +546,8 @@ process split_contigs {
 process execute_islandpath {
     conda "$baseDir/conda/islandpath.yaml"
     container "$params.islandpath_container"
-
+    errorStrategy 'ignore'
+    
     input:
     path(genome)
 


### PR DESCRIPTION
For very short contigs, with no predicted proteins islandpath sometimes fails. We simply skip these errors, as this is equivalent to no prediction.

## Checklist
- [x] Changelog entry
- [x] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

