### PR TITLE
Filter out unmapped_name from labels in circos plot.

### DIFF
--- a/webapp/templates/chlamdb/circos.html
+++ b/webapp/templates/chlamdb/circos.html
@@ -163,7 +163,7 @@ $(document).ready(function() {
   cgv.highlighter.feature.popoverContents = function(e) {
     const feature = e.element;
     const fullLength = feature.length !== feature.fullLength ? `(${window.CGView.utils.commaNumber(feature.fullLength)} bp)` : '';
-    const filtered_meta = Object.fromEntries(Object.entries(feature.meta).filter(([key, value]) => !(['highlighted', 'url'].includes(key))))
+    const filtered_meta = Object.fromEntries(Object.entries(feature.meta).filter(([key, value]) => !(['highlighted', 'unmapped_name'].includes(key))))
     return (`
       <div style='margin: 0 5px; font-size: 14px'>
         <div>${feature.type}: ${feature.meta.unmapped_name || feature.name}<div>


### PR DESCRIPTION
This fixes filtering of the metadata displayed in the labels in the circos map, which was forgotten in https://github.com/metagenlab/zDB/pull/198.

No CL as this was forgotten in a PR from the same release.

## Checklist
- [ ] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

