### PR TITLE
Make sure that all reference DB files get published and not a symlink.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Fixed
 
+- Make sure that all reference DB files get published and not a symlink. ([#209](https://github.com/metagenlab/zDB/pull/209)) (Niklaus Johner)
 - Re-add JS libraries accidentally removed and fix various small JS errors. ([#196](https://github.com/metagenlab/zDB/pull/196)) (Niklaus Johner)
 - Fix broken links for genomic islands and features with a mapped label on circos map. ([#198](https://github.com/metagenlab/zDB/pull/198)) (Niklaus Johner)
 - Fix genomic island prediction for short contigs ([#200](https://github.com/metagenlab/zDB/pull/200)) (Niklaus Johner)

--- a/db_setup.nf
+++ b/db_setup.nf
@@ -20,6 +20,8 @@ process setup_base_db {
 process download_cog_cdd {
     label 'process_single'
 
+    publishDir "$params.cog_db", mode: "copy", pattern: 'cdd.info'
+
     output:
         tuple path("COG*.smp"), path("Cog.pn"), path("cdd.info")
 
@@ -46,7 +48,6 @@ process setup_cog_cdd {
     output:
         file "cog_db*"
         file "cdd_to_cog"
-        path("${info}", includeInputs: true)
 
     script:
     """
@@ -124,6 +125,8 @@ process diamond_refseq {
 process download_pfam_db {
     label 'process_single'
 
+    publishDir "$params.pfam_db", mode: "copy"
+
     output:
         tuple path("Pfam-A.hmm"), path("Pfam-A.hmm.dat"), path("Pfam.version")
 
@@ -152,9 +155,6 @@ process prepare_hmm {
 
     output:
         path "${pfam_hmm}.h3*"
-        path("${pfam_hmm}", includeInputs: true)
-        path("${pfam_defs}", includeInputs: true)
-        path("${pfam_version}", includeInputs: true)
 
     script:
     """
@@ -190,6 +190,8 @@ process download_ko_profiles {
 process download_swissprot {
     label 'process_single'
 
+    publishDir "$params.swissprot_db", mode: "copy"
+
     output:
         tuple path("swissprot.fasta"), path("relnotes.txt")
 
@@ -215,7 +217,7 @@ process prepare_swissprot {
         tuple path(swissprot_fasta), path(relnotes)
 
     output:
-        path("*", includeInputs: true)
+        path("*")
 
     script:
     """
@@ -225,6 +227,8 @@ process prepare_swissprot {
 
 process download_vfdb {
     label 'process_single'
+
+    publishDir "$params.vf_db", mode: "copy"
 
     output:
         tuple path("vfdb.fasta"), path("VFs.xls")
@@ -252,7 +256,7 @@ process prepare_vfdb {
         tuple path(vfdb_fasta), path(vf_descr)
 
     output:
-        path("*", includeInputs: true)
+        path("*")
 
     script:
     """


### PR DESCRIPTION
When using the "move" mode of publishDir on files that were passed as input to a process, its symlink will be moved instead of the object itself. This is not desirable, as deleting the work directory will lead to missing file in the reference database folder.

## Checklist
- [x] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

