### PR TITLE
Protect against crawlers indexing the web application.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ to [Common Changelog](https://common-changelog.org)
 
 ### Added
 
+- Protect against crawlers indexing the web application. ([#222](https://github.com/metagenlab/zDB/pull/222)) (Niklaus Johner)
+
 ## 1.3.11 - 2025-10-28
 
 ### Fixed

--- a/webapp/chlamdb/urls.py
+++ b/webapp/chlamdb/urls.py
@@ -18,7 +18,8 @@ from views import views
 favicon_view = RedirectView.as_view(url="/assets/favicon.ico", permanent=True)
 
 
-urlpatterns = [
+urlpatterns = [        
+    re_path('^robots.txt$', TemplateView.as_view(template_name='robots.txt', content_type='text/plain')),
     re_path(
         r"^vf_comparison",
         tabular_comparison.VfComparisonView.as_view(),

--- a/webapp/templates/chlamdb/header.html
+++ b/webapp/templates/chlamdb/header.html
@@ -1,5 +1,5 @@
 {% load static %}
-
+<meta name="robots" content="noindex,nofollow" />
 <meta name="description" content="zDB: comparative bacterial genomics made easy">
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>

--- a/webapp/templates/robots.txt
+++ b/webapp/templates/robots.txt
@@ -1,51 +1,7 @@
 
 User-agent: *
-Disallow: /*?
-Disallow: /query?kw=*
-Disallow: /locusx/*
-Disallow: /fam/*
-Disallow: /KEGG_mapp/*
-Disallow: /KEGG_module_map/*
-Disallow: /*.jpg$
-Disallow: /*.png$
-Disallow: /*.gif$
-Disallow: /*.svg$
-Disallow: /extract_orthogroup/*
-Disallow: /extract_cog/*
-Disallow: /extract_pfam/*
-Disallow: /extract_interpro/*
-Disallow: /extract_EC/*
-Disallow: /extract_ko/*
-Disallow: /pairwiseid/*
-Disallow: /pairwiseCDS_length/*
-Disallow: /transporters/*
-Disallow: /plot_region/*
-Disallow: /circos/*
-Disallow: /priam_kegg/*
-Disallow: /metabo_overview/*
-Disallow: /kegg_module/*
-Disallow: /blastnr_barchart/*
-Disallow: /interpro_taxonomy/*
-Disallow: /blastnr_euk/*
-Disallow: /interpro_taxonomy/*
-Disallow: /effector_pred/*
-Disallow: /locus_int/*
-Disallow: /add_locus_int/*
-Disallow: /effector_pred/*
-Disallow: /orthogroup_annotation/*
-Disallow: /extract_region/*
-Disallow: /KEGG_mapp_ko/*
-Disallow: /genome_annotation/*
-Disallow: /venn_orthogroup
-Disallow: /orthogroup_comparison
-Disallow: /hmm2circos
-Disallow: /blast_sets
-Disallow: /metabo_comparison_ko
-Disallow: /metabo_comparison_ko
 Disallow: /
 
 Allow: /about
 Allow: /home
-Allow: /$
 
-Sitemap : http://www.chlamdb.ch/sitemap


### PR DESCRIPTION
Last week there was at least one bot trying to index `zdb.metagenlab.ch` leading to issues for the server. We try to ban such indexing by returning the `robots.txt` file on the corresponding URL and also by adding the `robots` metatag on all pages. 

I pushed this change from our amazon server, on which it seems Trestan has setup git for his user, that's why the commit seems to come from him...

## Checklist
- [x] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

