### PR TITLE
Pin biopython to version still containing the Bio.Application modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ to [Common Changelog](https://common-changelog.org)
 - Prevent crashes in the locus page for CDS in contigs without topology qualifier. ([#215](https://github.com/metagenlab/zDB/pull/215)) (Bastian Marquis)
 - Bump checkm-genome container to 1.2.3 to fix incompatibility with numpy 2. ([#224](https://github.com/metagenlab/zDB/pull/224)) (Niklaus Johner)
 - Fix loading of KO hits when there is an inconsistency between the KEGG REST API and the ko_list. ([#225](https://github.com/metagenlab/zDB/pull/225)) (Niklaus Johner)
+- Use biopython version still containing the Bio.Application modules in webapp environment. ([#226](https://github.com/metagenlab/zDB/pull/226)) (Niklaus Johner)
 
 ### Added
 

--- a/conda/webapp.yaml
+++ b/conda/webapp.yaml
@@ -9,7 +9,7 @@ dependencies:
     - pandas
     - seaborn
     - django>=4
-    - biopython>=1.80
+    - biopython>=1.80,<1.86
     - matplotlib
     - celery
     - django-crispy-forms=1.14.0


### PR DESCRIPTION
Bio.Application modules were removed in biopython 1.86.

## Checklist
- [x] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

