### PR TITLE
Pin nextflow to <26.04 to avoid strict syntax.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ to [Common Changelog](https://common-changelog.org)
 - Fix issue where contigs with multiple accessions due to revisions were not displayed in the plotregion. ([#217](https://github.com/metagenlab/zDB/pull/217)) (Bastian Marquis)
 - Prevent crashes in the locus page for CDS in contigs without topology qualifier. ([#215](https://github.com/metagenlab/zDB/pull/215)) (Bastian Marquis)
 - Bump checkm-genome container to 1.2.3 to fix incompatibility with numpy 2. ([#224](https://github.com/metagenlab/zDB/pull/224)) (Niklaus Johner)
-- Bump checkm-genome container to 1.2.5 to fix issues with setuptools. ([#225](https://github.com/metagenlab/zDB/pull/225)) (Niklaus Johner)
+- Bump checkm-genome container to 1.2.5 to fix issues with setuptools. ([#227](https://github.com/metagenlab/zDB/pull/227)) (Niklaus Johner)
 - Fix loading of KO hits when there is an inconsistency between the KEGG REST API and the ko_list. ([#225](https://github.com/metagenlab/zDB/pull/225)) (Niklaus Johner)
 - Use biopython version still containing the Bio.Application modules in webapp environment. ([#226](https://github.com/metagenlab/zDB/pull/226)) (Niklaus Johner)
+- Pin nextflow to <26.04 to avoid strict syntax. ([#226](https://github.com/metagenlab/zDB/pull/226)) (Niklaus Johner)
 
 ### Added
 

--- a/conda/main.yaml
+++ b/conda/main.yaml
@@ -3,5 +3,5 @@ channels:
     - conda-forge
     - bioconda
 dependencies:
-    - nextflow>=24.04
+    - nextflow>=24.04,<26.04
     - apptainer=1.4

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 requirements:
   run:
-    - nextflow >=24.04.0
+    - nextflow >=24.04.0,<26.04
 
 test:
   commands:


### PR DESCRIPTION
The pipeline is currently not ready for strict syntax.

## Checklist
- [x] Changelog entry
- [ ] Check that tests still pass
- [ ] Add tests for new features and regression tests for bugfixes whenever possible.

